### PR TITLE
Port zondscan to QRL Testnet V2 protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ backendAPI/backendAPI.log
 backendAPI/backendAPI
 Zond2mongoDB/syncer
 Zond2mongoDB/backendAPI
+backendAPI/handler/main
+ExplorerFrontend/tsconfig.tsbuildinfo

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ backendAPI/backendAPI.log
 *.cert
 *.key
 
+backendAPI/backendAPI
+Zond2mongoDB/syncer
+Zond2mongoDB/backendAPI

--- a/ExplorerFrontend/app/address/[query]/address-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-view.tsx
@@ -61,15 +61,15 @@ export default function AddressView({ addressData, addressSegment }: AddressView
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
             </svg>
         );
-    } else if (addressSegment.slice(0, 3) === "0x2") {
+    } else if (addressSegment.startsWith("Q2")) {
         addressType = "Dilithium Address";
         addressIcon = (
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 md:h-6 md:w-6 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
             </svg>
         );
-    } else if (addressSegment.startsWith("Z")) {
-        addressType = "Zond Address";
+    } else if (addressSegment.startsWith("Q")) {
+        addressType = "QRL Address";
         addressIcon = (
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 md:h-6 md:w-6 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />

--- a/ExplorerFrontend/app/address/[query]/page.tsx
+++ b/ExplorerFrontend/app/address/[query]/page.tsx
@@ -85,9 +85,9 @@ async function fetchAddressData(address: string): Promise<AddressData | null> {
 
 export default async function Page({ params }: PageProps): Promise<JSX.Element> {
     const resolvedParams = await params;
-    // Normalize lowercase z prefix to uppercase Z
-    const address = resolvedParams.query.startsWith('z') && !resolvedParams.query.startsWith('0x')
-        ? 'Z' + resolvedParams.query.slice(1)
+    // Normalize lowercase q prefix to uppercase Q
+    const address = resolvedParams.query.startsWith('q') && !resolvedParams.query.startsWith('0x')
+        ? 'Q' + resolvedParams.query.slice(1)
         : resolvedParams.query;
     const addressData = await fetchAddressData(address);
     const handlerUrl = process.env.NEXT_PUBLIC_HANDLER_URL || process.env.HANDLER_URL || 'http://127.0.0.1:8080';

--- a/ExplorerFrontend/app/block/[query]/block-detail-client.tsx
+++ b/ExplorerFrontend/app/block/[query]/block-detail-client.tsx
@@ -47,16 +47,11 @@ type Block = {
     value: string;
   }>;
   transactionsRoot: string;
-  difficulty: string;
   extraData: string;
   logsBloom: string;
   miner: string;
-  mixHash: string;
-  nonce: string;
-  sha3Uncles: string;
   size: string;
-  totalDifficulty: string;
-  uncles: string[];
+  prevRandao: string;
   withdrawals: any[];
   withdrawalsRoot: string;
 };
@@ -123,16 +118,11 @@ export default function BlockDetailClient({ blockNumber }: BlockDetailClientProp
           timestamp: block.timestamp || '0x0',
           transactions: block.transactions || [],
           transactionsRoot: block.transactionsRoot || '',
-          difficulty: block.difficulty || '0x0',
           extraData: block.extraData || '',
           logsBloom: block.logsBloom || '',
           miner: block.miner || '',
-          mixHash: block.mixHash || '',
-          nonce: block.nonce || '',
-          sha3Uncles: block.sha3Uncles || '',
           size: block.size || '0x0',
-          totalDifficulty: block.totalDifficulty || '0x0',
-          uncles: block.uncles || [],
+          prevRandao: block.prevRandao || '',
           withdrawals: block.withdrawals || [],
           withdrawalsRoot: block.withdrawalsRoot || ''
         };

--- a/ExplorerFrontend/app/components/Charts.tsx
+++ b/ExplorerFrontend/app/components/Charts.tsx
@@ -7,7 +7,7 @@ export default function Charts(): JSX.Element {
     <div className="w-full mb-4">
       <div className="bg-[#1e1e1e] border border-[#2a2a2a] rounded-xl overflow-hidden">
         <div className="px-4 py-3 border-b border-[#2a2a2a]">
-          <h2 className="text-sm font-semibold text-white">
+          <h2 className="text-[15px] font-semibold text-[#ffa729]">
             QRL/USDT Chart
           </h2>
         </div>

--- a/ExplorerFrontend/app/components/Charts.tsx
+++ b/ExplorerFrontend/app/components/Charts.tsx
@@ -5,11 +5,13 @@ import TradingViewWidget from './TradingViewWidget';
 export default function Charts(): JSX.Element {
   return (
     <div className="w-full mb-4">
-      <div className="bg-[#1f1f1f] border border-[#3d3d3d] rounded-2xl hover:border-[#ffa729] transition-colors duration-300">
+      <div className="bg-[#1e1e1e] border border-[#2a2a2a] rounded-xl overflow-hidden">
+        <div className="px-4 py-3 border-b border-[#2a2a2a]">
+          <h2 className="text-sm font-semibold text-white">
+            QRL/USDT Chart
+          </h2>
+        </div>
         <div className="p-4">
-          <p className="text-[#ffa729] text-sm sm:text-xl font-bold mb-0">
-            MEXC QRL/USDT Chart
-          </p>
           <div className="h-[400px] mt-2">
             <TradingViewWidget />
           </div>

--- a/ExplorerFrontend/app/components/SearchBar.tsx
+++ b/ExplorerFrontend/app/components/SearchBar.tsx
@@ -8,12 +8,12 @@ function onlyNumbers(str: string): boolean {
   return /^[0-9]+$/.test(str);
 }
 
-// Validates if the input is a valid address (either 0x or Z prefixed)
+// Validates if the input is a valid address (either 0x or Q prefixed)
 function isValidAddress(address: string): boolean {
-  // Check for Z-prefixed address (Z or z + 40 hex chars)
-  if ((address.startsWith('Z') || address.startsWith('z')) && address.length === 41) {
+  // Check for Q-prefixed address (Q or q + 40 hex chars)
+  if ((address.startsWith('Q') || address.startsWith('q')) && address.length === 41) {
     // Check if the rest of the string is valid hex
-    return /^[Zz][0-9a-fA-F]{40}$/.test(address);
+    return /^[Qq][0-9a-fA-F]{40}$/.test(address);
   }
   
   // Check for 0x-prefixed address (0x + 40 hex chars)
@@ -42,7 +42,7 @@ export default function SearchBar(): JSX.Element {
     } else if (searchValue.length === 66) {
       newPath = "/tx/" + searchValue;
     } else if (isValidAddress(searchValue)) {
-      const normalized = searchValue.startsWith('z') ? 'Z' + searchValue.slice(1) : searchValue;
+      const normalized = searchValue.startsWith('q') ? 'Q' + searchValue.slice(1) : searchValue;
       newPath = "/address/" + normalized;
     } else {
       setError('Invalid input!');
@@ -78,7 +78,7 @@ export default function SearchBar(): JSX.Element {
             ref={inputRef}
             type="text"
             aria-label="Search by address, transaction hash, or block number"
-            placeholder="Search by Address (Zxx) / Txn Hash / Block.."
+            placeholder="Search by Address (Qxx) / Txn Hash / Block.."
             className="flex-1 py-3 sm:py-4 px-4 sm:px-6 text-sm sm:text-base text-gray-300
                      bg-background rounded-xl
                      border border-border

--- a/ExplorerFrontend/app/components/Sidebar.tsx
+++ b/ExplorerFrontend/app/components/Sidebar.tsx
@@ -33,6 +33,7 @@ const navGroups: NavGroup[] = [
       { name: 'Latest Transactions', description: 'View all Transactions', href: '/transactions/1', imgSrc: PartnerHandshakeIcon },
       { name: 'Pending Transactions', description: 'View pending transactions', href: '/pending/1', imgSrc: PartnerHandshakeIcon },
       { name: 'Latest Blocks', description: 'View all Blocks', href: '/blocks/1', imgSrc: BlockchainIcon },
+      { name: 'Epochs', description: 'View all Epochs', href: '/epochs/1', imgSrc: BlockchainIcon },
       { name: 'Validators', description: 'Network Validators', href: '/validators', imgSrc: ContractIcon },
     ],
   },
@@ -63,6 +64,7 @@ function isActive(pathname: string, href: string): boolean {
   if (basePath !== href && pathname.startsWith(basePath + '/')) return true
   // Match parent paths for detail pages (e.g., /block/123 matches /blocks/1)
   if (href.startsWith('/blocks') && pathname.startsWith('/block/')) return true
+  if (href.startsWith('/epochs') && pathname.startsWith('/epochs/')) return true
   if (href.startsWith('/transactions') && pathname.startsWith('/tx/')) return true
   if (href === '/contracts' && pathname.startsWith('/contracts')) return true
   return false

--- a/ExplorerFrontend/app/components/StatusBadge.tsx
+++ b/ExplorerFrontend/app/components/StatusBadge.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+const styles: Record<string, string> = {
+  finalized: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+  justified: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
+  pending: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/20',
+  proposed: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+  missed: 'bg-red-500/15 text-red-400 border-red-500/20',
+};
+
+export default function StatusBadge({ status }: { status: string }) {
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium border ${styles[status] || styles.pending}`}>
+      {status.charAt(0).toUpperCase() + status.slice(1)}
+    </span>
+  );
+}

--- a/ExplorerFrontend/app/epoch/[id]/epoch-detail-client.tsx
+++ b/ExplorerFrontend/app/epoch/[id]/epoch-detail-client.tsx
@@ -4,8 +4,9 @@ import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import axios from 'axios';
 import config from '../../../config';
-import { formatNumberWithCommas, truncateHash, formatAddress, formatTimestamp } from '../../lib/helpers';
+import { formatNumberWithCommas, truncateHash, formatAddress, formatTimestamp, timeAgo, formatStaked } from '../../lib/helpers';
 import SearchBar from '../../components/SearchBar';
+import StatusBadge from '../../components/StatusBadge';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -47,49 +48,9 @@ function parseHex(hex: string): number {
   return parseInt(hex, 10) || 0;
 }
 
-function timeAgo(unixSeconds: number): string {
-  const now = Math.floor(Date.now() / 1000);
-  const diff = now - unixSeconds;
-  if (diff < 0) return 'just now';
-  if (diff < 60) return `${diff}s ago`;
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-  return `${Math.floor(diff / 86400)}d ago`;
-}
-
-function formatStaked(gwei: string): string {
-  try {
-    const val = BigInt(gwei || '0');
-    const qrlBase = val / BigInt(1_000_000_000);
-    const remainder = val % BigInt(1_000_000_000);
-    const decimalStr = remainder.toString().padStart(9, '0').replace(/0+$/, '');
-    const result = formatNumberWithCommas(qrlBase.toString());
-    return decimalStr.length > 0 ? `${result}.${decimalStr} QRL` : `${result} QRL`;
-  } catch {
-    return '0 QRL';
-  }
-}
-
 function formatGasUsed(hex: string): string {
   const val = parseHex(hex);
   return formatNumberWithCommas(val.toString());
-}
-
-// ── Status Badge ─────────────────────────────────────────────────────────────
-
-function StatusBadge({ status }: { status: string }) {
-  const styles: Record<string, string> = {
-    finalized: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
-    justified: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
-    pending: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/20',
-    proposed: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
-    missed: 'bg-red-500/15 text-red-400 border-red-500/20',
-  };
-  return (
-    <span className={`inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium border ${styles[status] || styles.pending}`}>
-      {status.charAt(0).toUpperCase() + status.slice(1)}
-    </span>
-  );
 }
 
 // ── Summary Row ──────────────────────────────────────────────────────────────

--- a/ExplorerFrontend/app/epoch/[id]/epoch-detail-client.tsx
+++ b/ExplorerFrontend/app/epoch/[id]/epoch-detail-client.tsx
@@ -1,0 +1,287 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
+import axios from 'axios';
+import config from '../../../config';
+import { formatNumberWithCommas, truncateHash, formatAddress, formatTimestamp } from '../../lib/helpers';
+import SearchBar from '../../components/SearchBar';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface EpochSlot {
+  slot: number;
+  status: string;
+  timestamp?: string;
+  proposer?: string;
+  transactions: number;
+  gasUsed?: string;
+  blockHash?: string;
+}
+
+interface EpochDetail {
+  epoch: string;
+  timestamp: number;
+  status: string;
+  validatorsCount: number;
+  activeCount: number;
+  pendingCount: number;
+  exitedCount: number;
+  slashedCount: number;
+  totalStaked: string;
+  startSlot: number;
+  endSlot: number;
+  blocks: EpochSlot[];
+  finalizedEpoch: string;
+  justifiedEpoch: string;
+  headEpoch: string;
+  proposedCount: number;
+  missedCount: number;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function parseHex(hex: string): number {
+  if (!hex) return 0;
+  if (hex.startsWith('0x')) return parseInt(hex, 16);
+  return parseInt(hex, 10) || 0;
+}
+
+function timeAgo(unixSeconds: number): string {
+  const now = Math.floor(Date.now() / 1000);
+  const diff = now - unixSeconds;
+  if (diff < 0) return 'just now';
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+function formatStaked(gwei: string): string {
+  try {
+    const val = BigInt(gwei || '0');
+    const qrl = val / BigInt(1_000_000_000);
+    return formatNumberWithCommas(qrl.toString()) + ' QRL';
+  } catch {
+    return '0 QRL';
+  }
+}
+
+function formatGasUsed(hex: string): string {
+  const val = parseHex(hex);
+  return formatNumberWithCommas(val.toString());
+}
+
+// ── Status Badge ─────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    finalized: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+    justified: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
+    pending: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/20',
+    proposed: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+    missed: 'bg-red-500/15 text-red-400 border-red-500/20',
+  };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium border ${styles[status] || styles.pending}`}>
+      {status.charAt(0).toUpperCase() + status.slice(1)}
+    </span>
+  );
+}
+
+// ── Summary Row ──────────────────────────────────────────────────────────────
+
+function SummaryRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center py-2.5 border-b border-[#2a2a2a] last:border-b-0">
+      <span className="text-gray-500 text-sm w-40 flex-shrink-0 mb-0.5 sm:mb-0">{label}:</span>
+      <span className="text-gray-200 text-sm">{children}</span>
+    </div>
+  );
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export default function EpochDetailClient({ epochId }: { epochId: string }): JSX.Element {
+  const [data, setData] = useState<EpochDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const epochNum = parseInt(epochId);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        setLoading(true);
+        setError(null);
+        const res = await axios.get(`${config.handlerUrl}/epoch/${epochId}`);
+        setData(res.data);
+      } catch (err: any) {
+        setError(err.response?.data?.error || 'Failed to load epoch data');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, [epochId]);
+
+  const headEpoch = data ? parseInt(data.headEpoch) : 0;
+
+  return (
+    <div className="p-4 sm:p-8 max-w-6xl mx-auto">
+      {/* Header with navigation */}
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="flex items-center gap-2 text-xl sm:text-2xl font-bold text-[#ffa729]">
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 sm:h-6 sm:w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          Epoch {formatNumberWithCommas(epochId)}
+        </h1>
+        <div className="flex items-center gap-2">
+          {epochNum > 0 ? (
+            <Link
+              href={`/epoch/${epochNum - 1}`}
+              className="px-3 py-1.5 rounded-lg bg-[#1e1e1e] border border-[#2a2a2a] text-gray-300 text-sm hover:border-[#ffa729] transition-colors"
+            >
+              &larr; Prev
+            </Link>
+          ) : (
+            <span className="px-3 py-1.5 rounded-lg bg-[#1e1e1e] border border-[#2a2a2a] text-gray-600 text-sm cursor-not-allowed">
+              &larr; Prev
+            </span>
+          )}
+          {!loading && epochNum < headEpoch ? (
+            <Link
+              href={`/epoch/${epochNum + 1}`}
+              className="px-3 py-1.5 rounded-lg bg-[#1e1e1e] border border-[#2a2a2a] text-gray-300 text-sm hover:border-[#ffa729] transition-colors"
+            >
+              Next &rarr;
+            </Link>
+          ) : (
+            <span className="px-3 py-1.5 rounded-lg bg-[#1e1e1e] border border-[#2a2a2a] text-gray-600 text-sm cursor-not-allowed">
+              Next &rarr;
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="mb-6">
+        <SearchBar />
+      </div>
+
+      {/* Loading */}
+      {loading && (
+        <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] p-8 text-center">
+          <div className="animate-pulse text-gray-500">Loading epoch data...</div>
+        </div>
+      )}
+
+      {/* Error */}
+      {error && !loading && (
+        <div className="rounded-xl bg-red-900/20 border border-red-800 p-6 text-center">
+          <p className="text-red-400 font-semibold mb-1">Epoch not found</p>
+          <p className="text-gray-400 text-sm">{error}</p>
+        </div>
+      )}
+
+      {/* Content */}
+      {data && !loading && (
+        <>
+          {/* Summary Panel */}
+          <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden mb-6">
+            <div className="px-4 py-3 border-b border-[#2a2a2a]">
+              <h2 className="text-[15px] font-semibold text-[#ffa729]">Epoch Details</h2>
+            </div>
+            <div className="px-4 py-2">
+              <SummaryRow label="Epoch">{formatNumberWithCommas(data.epoch)}</SummaryRow>
+              <SummaryRow label="Status"><StatusBadge status={data.status} /></SummaryRow>
+              <SummaryRow label="Time">
+                {data.timestamp > 0 ? (
+                  <span>
+                    {timeAgo(data.timestamp)}
+                    <span className="text-gray-500 ml-2">({formatTimestamp(data.timestamp)})</span>
+                  </span>
+                ) : '—'}
+              </SummaryRow>
+              <SummaryRow label="Validators">{formatNumberWithCommas(data.validatorsCount.toString())}</SummaryRow>
+              <SummaryRow label="Active">{formatNumberWithCommas(data.activeCount.toString())}</SummaryRow>
+              {data.pendingCount > 0 && <SummaryRow label="Pending">{data.pendingCount}</SummaryRow>}
+              {data.exitedCount > 0 && <SummaryRow label="Exited">{data.exitedCount}</SummaryRow>}
+              {data.slashedCount > 0 && <SummaryRow label="Slashed">{data.slashedCount}</SummaryRow>}
+              <SummaryRow label="Total Staked">{formatStaked(data.totalStaked)}</SummaryRow>
+              <SummaryRow label="Slots">
+                {data.proposedCount + data.missedCount} ({data.proposedCount} Proposed{data.missedCount > 0 ? `, ${data.missedCount} Missed` : ''})
+              </SummaryRow>
+            </div>
+          </div>
+
+          {/* Slots Table */}
+          <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden">
+            <div className="px-4 py-3 border-b border-[#2a2a2a]">
+              <h2 className="text-[15px] font-semibold text-[#ffa729]">Slots</h2>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-[#2a2a2a]">
+                    <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Slot</th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Status</th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Time</th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden sm:table-cell">Proposer</th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Txns</th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden md:table-cell">Gas Used</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.blocks.map((slot) => {
+                    const isProposed = slot.status === 'proposed';
+                    const timestamp = isProposed ? parseHex(slot.timestamp || '0') : 0;
+                    const proposer = isProposed ? formatAddress(slot.proposer || '') : '';
+
+                    return (
+                      <tr
+                        key={slot.slot}
+                        className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
+                      >
+                        <td className="px-4 py-2 tabular-nums">
+                          {isProposed ? (
+                            <Link href={`/block/${slot.slot}`} className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium">
+                              {formatNumberWithCommas(slot.slot.toString())}
+                            </Link>
+                          ) : (
+                            <span className="text-gray-600">{formatNumberWithCommas(slot.slot.toString())}</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-2">
+                          <StatusBadge status={slot.status} />
+                        </td>
+                        <td className="px-4 py-2 text-gray-400 tabular-nums">
+                          {isProposed ? timeAgo(timestamp) : '—'}
+                        </td>
+                        <td className="px-4 py-2 hidden sm:table-cell">
+                          {isProposed && proposer ? (
+                            <Link href={`/address/${proposer}`} className="text-gray-400 hover:text-[#ffa729] hover:underline font-mono text-xs transition-colors">
+                              {truncateHash(proposer, 8, 6)}
+                            </Link>
+                          ) : (
+                            <span className="text-gray-600">—</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-2 text-gray-300 tabular-nums">
+                          {isProposed ? slot.transactions : '—'}
+                        </td>
+                        <td className="px-4 py-2 text-gray-400 tabular-nums hidden md:table-cell">
+                          {isProposed && slot.gasUsed ? formatGasUsed(slot.gasUsed) : '—'}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ExplorerFrontend/app/epoch/[id]/epoch-detail-client.tsx
+++ b/ExplorerFrontend/app/epoch/[id]/epoch-detail-client.tsx
@@ -60,8 +60,11 @@ function timeAgo(unixSeconds: number): string {
 function formatStaked(gwei: string): string {
   try {
     const val = BigInt(gwei || '0');
-    const qrl = val / BigInt(1_000_000_000);
-    return formatNumberWithCommas(qrl.toString()) + ' QRL';
+    const qrlBase = val / BigInt(1_000_000_000);
+    const remainder = val % BigInt(1_000_000_000);
+    const decimalStr = remainder.toString().padStart(9, '0').replace(/0+$/, '');
+    const result = formatNumberWithCommas(qrlBase.toString());
+    return decimalStr.length > 0 ? `${result}.${decimalStr} QRL` : `${result} QRL`;
   } catch {
     return '0 QRL';
   }

--- a/ExplorerFrontend/app/epoch/[id]/page.tsx
+++ b/ExplorerFrontend/app/epoch/[id]/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from 'next';
+import EpochDetailClient from './epoch-detail-client';
+import { sharedMetadata } from '../../lib/seo/metaData';
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
+  const resolvedParams = await params;
+  const epochId = resolvedParams.id;
+
+  return {
+    ...sharedMetadata,
+    title: `Epoch ${epochId} | ZondScan`,
+    description: `View detailed information for epoch ${epochId} on the QRL Zond beacon chain.`,
+    alternates: {
+      ...sharedMetadata.alternates,
+      canonical: `https://zondscan.com/epoch/${epochId}`,
+    },
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title: `Epoch ${epochId} | ZondScan`,
+      description: `View detailed information for epoch ${epochId} on the QRL Zond beacon chain.`,
+      url: `https://zondscan.com/epoch/${epochId}`,
+      siteName: 'ZondScan',
+      type: 'website',
+    },
+  };
+}
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function Page({ params }: PageProps): Promise<JSX.Element> {
+  const resolvedParams = await params;
+  return <EpochDetailClient epochId={resolvedParams.id} />;
+}

--- a/ExplorerFrontend/app/epochs/[query]/epochs-client.tsx
+++ b/ExplorerFrontend/app/epochs/[query]/epochs-client.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import axios from 'axios';
+import config from '../../../config';
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { formatNumberWithCommas } from '../../lib/helpers';
+import SearchBar from '../../components/SearchBar';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface EpochItem {
+  epoch: string;
+  timestamp: number;
+  status: string;
+  validatorsCount: number;
+  activeCount: number;
+  totalStaked: string;
+}
+
+interface EpochsData {
+  epochs: EpochItem[];
+  total: number;
+  finalizedEpoch: string;
+  justifiedEpoch: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const ITEMS_PER_PAGE = 15;
+
+function timeAgo(unixSeconds: number): string {
+  const now = Math.floor(Date.now() / 1000);
+  const diff = now - unixSeconds;
+  if (diff < 0) return 'just now';
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+function formatStaked(gwei: string): string {
+  try {
+    const val = BigInt(gwei);
+    const qrl = val / BigInt(1_000_000_000);
+    return formatNumberWithCommas(qrl.toString()) + ' QRL';
+  } catch {
+    return '0 QRL';
+  }
+}
+
+// ── Status Badge ─────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    finalized: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+    justified: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
+    pending: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/20',
+  };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium border ${styles[status] || styles.pending}`}>
+      {status.charAt(0).toUpperCase() + status.slice(1)}
+    </span>
+  );
+}
+
+// ── Data Fetching ────────────────────────────────────────────────────────────
+
+const fetchEpochs = async (page: string): Promise<EpochsData> => {
+  const response = await axios.get<EpochsData>(`${config.handlerUrl}/epochs?page=${page}&limit=${ITEMS_PER_PAGE}`);
+  return response.data;
+};
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+interface EpochsClientProps {
+  initialData: EpochsData;
+  initialPage: string;
+}
+
+export default function EpochsClient({ initialData, initialPage }: EpochsClientProps): JSX.Element {
+  const router = useRouter();
+  const currentPage = parseInt(initialPage);
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['epochs', initialPage],
+    queryFn: () => fetchEpochs(initialPage),
+    staleTime: 60000,
+    gcTime: 5 * 60 * 1000,
+    retry: 2,
+    initialData,
+  });
+
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / ITEMS_PER_PAGE)) : 1;
+
+  const goToNextPage = (): void => {
+    router.push(`/epochs/${Math.min(currentPage + 1, totalPages)}`);
+  };
+
+  const goToPreviousPage = (): void => {
+    router.push(`/epochs/${Math.max(currentPage - 1, 1)}`);
+  };
+
+  if (isError) {
+    return (
+      <div className="p-4 sm:p-8 max-w-6xl mx-auto">
+        <h1 className="text-xl sm:text-2xl font-bold mb-4 text-[#ffa729]">Epochs</h1>
+        <div className="bg-red-900/50 border border-red-500 text-red-200 px-4 py-3 rounded-xl">
+          <p className="font-bold">Error:</p>
+          <p className="text-sm">{error instanceof Error ? error.message : 'Failed to load epochs'}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 sm:p-8 max-w-6xl mx-auto">
+      <h1 className="flex items-center gap-2 text-xl sm:text-2xl font-bold mb-4 text-[#ffa729]">
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 sm:h-6 sm:w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        Epochs
+      </h1>
+
+      <div className="mb-6">
+        <SearchBar />
+      </div>
+
+      {/* Epochs Table */}
+      <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden mb-6">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[#2a2a2a]">
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Epoch</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Time</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Status</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden sm:table-cell">Validators</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden sm:table-cell">Active</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden md:table-cell">Total Staked</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading ? (
+                Array.from({ length: ITEMS_PER_PAGE }).map((_, i) => (
+                  <tr key={i} className="border-b border-[#2a2a2a] last:border-b-0">
+                    <td className="px-4 py-3"><div className="h-4 w-12 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                    <td className="px-4 py-3"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                    <td className="px-4 py-3"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                    <td className="px-4 py-3 hidden sm:table-cell"><div className="h-4 w-10 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                    <td className="px-4 py-3 hidden sm:table-cell"><div className="h-4 w-10 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                    <td className="px-4 py-3 hidden md:table-cell"><div className="h-4 w-24 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  </tr>
+                ))
+              ) : !data?.epochs?.length ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-12 text-center text-gray-500">
+                    No epoch data available yet. The explorer is still syncing.
+                  </td>
+                </tr>
+              ) : (
+                data.epochs.map((epoch) => (
+                  <tr
+                    key={epoch.epoch}
+                    className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
+                  >
+                    <td className="px-4 py-3">
+                      <Link href="/validators" className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
+                        {formatNumberWithCommas(epoch.epoch)}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3 text-gray-400 tabular-nums">{timeAgo(epoch.timestamp)}</td>
+                    <td className="px-4 py-3">
+                      <StatusBadge status={epoch.status} />
+                    </td>
+                    <td className="px-4 py-3 text-gray-300 tabular-nums hidden sm:table-cell">
+                      {formatNumberWithCommas(epoch.validatorsCount.toString())}
+                    </td>
+                    <td className="px-4 py-3 text-gray-300 tabular-nums hidden sm:table-cell">
+                      {formatNumberWithCommas(epoch.activeCount.toString())}
+                    </td>
+                    <td className="px-4 py-3 text-gray-400 tabular-nums hidden md:table-cell">
+                      {formatStaked(epoch.totalStaked)}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Pagination */}
+      <div className="flex justify-center items-center gap-3 text-sm text-gray-300">
+        <button
+          onClick={goToPreviousPage}
+          disabled={currentPage === 1}
+          className="px-4 py-2 rounded-lg bg-[#1e1e1e] text-gray-300 border border-[#2a2a2a]
+                     hover:border-[#ffa729] disabled:opacity-50 disabled:hover:border-[#2a2a2a]
+                     transition-colors"
+        >
+          Previous
+        </button>
+        <span className="tabular-nums">Page {currentPage} of {totalPages}</span>
+        <button
+          onClick={goToNextPage}
+          disabled={currentPage >= totalPages}
+          className="px-4 py-2 rounded-lg bg-[#1e1e1e] text-gray-300 border border-[#2a2a2a]
+                     hover:border-[#ffa729] disabled:opacity-50 disabled:hover:border-[#2a2a2a]
+                     transition-colors"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ExplorerFrontend/app/epochs/[query]/epochs-client.tsx
+++ b/ExplorerFrontend/app/epochs/[query]/epochs-client.tsx
@@ -43,9 +43,12 @@ function timeAgo(unixSeconds: number): string {
 
 function formatStaked(gwei: string): string {
   try {
-    const val = BigInt(gwei);
-    const qrl = val / BigInt(1_000_000_000);
-    return formatNumberWithCommas(qrl.toString()) + ' QRL';
+    const val = BigInt(gwei || '0');
+    const qrlBase = val / BigInt(1_000_000_000);
+    const remainder = val % BigInt(1_000_000_000);
+    const decimalStr = remainder.toString().padStart(9, '0').replace(/0+$/, '');
+    const result = formatNumberWithCommas(qrlBase.toString());
+    return decimalStr.length > 0 ? `${result}.${decimalStr} QRL` : `${result} QRL`;
   } catch {
     return '0 QRL';
   }

--- a/ExplorerFrontend/app/epochs/[query]/epochs-client.tsx
+++ b/ExplorerFrontend/app/epochs/[query]/epochs-client.tsx
@@ -167,7 +167,7 @@ export default function EpochsClient({ initialData, initialPage }: EpochsClientP
                     className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
                   >
                     <td className="px-4 py-3">
-                      <Link href="/validators" className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
+                      <Link href={`/epoch/${epoch.epoch}`} className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
                         {formatNumberWithCommas(epoch.epoch)}
                       </Link>
                     </td>

--- a/ExplorerFrontend/app/epochs/[query]/epochs-client.tsx
+++ b/ExplorerFrontend/app/epochs/[query]/epochs-client.tsx
@@ -6,8 +6,9 @@ import axios from 'axios';
 import config from '../../../config';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { formatNumberWithCommas } from '../../lib/helpers';
+import { formatNumberWithCommas, timeAgo, formatStaked } from '../../lib/helpers';
 import SearchBar from '../../components/SearchBar';
+import StatusBadge from '../../components/StatusBadge';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -30,44 +31,6 @@ interface EpochsData {
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 const ITEMS_PER_PAGE = 15;
-
-function timeAgo(unixSeconds: number): string {
-  const now = Math.floor(Date.now() / 1000);
-  const diff = now - unixSeconds;
-  if (diff < 0) return 'just now';
-  if (diff < 60) return `${diff}s ago`;
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-  return `${Math.floor(diff / 86400)}d ago`;
-}
-
-function formatStaked(gwei: string): string {
-  try {
-    const val = BigInt(gwei || '0');
-    const qrlBase = val / BigInt(1_000_000_000);
-    const remainder = val % BigInt(1_000_000_000);
-    const decimalStr = remainder.toString().padStart(9, '0').replace(/0+$/, '');
-    const result = formatNumberWithCommas(qrlBase.toString());
-    return decimalStr.length > 0 ? `${result}.${decimalStr} QRL` : `${result} QRL`;
-  } catch {
-    return '0 QRL';
-  }
-}
-
-// ── Status Badge ─────────────────────────────────────────────────────────────
-
-function StatusBadge({ status }: { status: string }) {
-  const styles: Record<string, string> = {
-    finalized: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
-    justified: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
-    pending: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/20',
-  };
-  return (
-    <span className={`inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium border ${styles[status] || styles.pending}`}>
-      {status.charAt(0).toUpperCase() + status.slice(1)}
-    </span>
-  );
-}
 
 // ── Data Fetching ────────────────────────────────────────────────────────────
 

--- a/ExplorerFrontend/app/epochs/[query]/page.tsx
+++ b/ExplorerFrontend/app/epochs/[query]/page.tsx
@@ -1,0 +1,77 @@
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import EpochsClient from './epochs-client';
+import config from '../../../config';
+import { sharedMetadata } from '../../lib/seo/metaData';
+
+export const dynamic = 'force-dynamic';
+
+interface EpochsData {
+  epochs: any[];
+  total: number;
+  finalizedEpoch: string;
+  justifiedEpoch: string;
+}
+
+async function getEpochs(page: string): Promise<EpochsData> {
+  try {
+    const response = await fetch(`${config.handlerUrl}/epochs?page=${page}&limit=15`, {
+      method: 'GET',
+      headers: { 'Accept': 'application/json' },
+    });
+
+    if (!response.ok) {
+      if (response.status === 404) notFound();
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    return response.json();
+  } catch (error) {
+    console.error('Error fetching epochs:', error);
+    throw error;
+  }
+}
+
+interface PageProps {
+  params: Promise<{ query: string }>;
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ query: string }> }): Promise<Metadata> {
+  const resolvedParams = await params;
+  const pageNumber = resolvedParams.query || '1';
+
+  return {
+    ...sharedMetadata,
+    title: `Epochs - Page ${pageNumber} | ZondScan`,
+    description: `View epochs on the QRL Zond beacon chain. Page ${pageNumber} of the epochs list.`,
+    alternates: {
+      ...sharedMetadata.alternates,
+      canonical: 'https://zondscan.com/epochs',
+    },
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title: `Epochs - Page ${pageNumber} | ZondScan`,
+      description: `View epochs on the QRL Zond beacon chain. Page ${pageNumber} of the epochs list.`,
+      url: `https://zondscan.com/epochs/${pageNumber}`,
+      siteName: 'ZondScan',
+      type: 'website',
+    },
+    twitter: {
+      ...sharedMetadata.twitter,
+      title: `Epochs - Page ${pageNumber} | ZondScan`,
+      description: `View epochs on the QRL Zond beacon chain. Page ${pageNumber} of the epochs list.`,
+    },
+  };
+}
+
+export default async function EpochsPage({ params }: PageProps): Promise<JSX.Element> {
+  const resolvedParams = await params;
+  const pageNumber = resolvedParams.query || '1';
+  const data = await getEpochs(pageNumber);
+
+  return (
+    <main>
+      <EpochsClient initialData={data} initialPage={pageNumber} />
+    </main>
+  );
+}

--- a/ExplorerFrontend/app/home-client.tsx
+++ b/ExplorerFrontend/app/home-client.tsx
@@ -46,6 +46,7 @@ interface HomeData {
   epochInfo: EpochInfo | null;
   blocks: BlockResult[];
   totalStaked: string;
+  marketCap: number;
   loading: boolean;
   error: boolean;
   dataInitialized: boolean;
@@ -70,6 +71,16 @@ function parseHex(hex: string): number {
   if (!hex) return 0;
   if (hex.startsWith('0x')) return parseInt(hex, 16);
   return parseInt(hex, 10) || 0;
+}
+
+function formatStaked(gwei: string): string {
+  try {
+    const val = BigInt(gwei || '0');
+    const qrlBase = val / BigInt(1_000_000_000);
+    return formatNumberWithCommas(qrlBase.toString()) + ' QRL';
+  } catch {
+    return '0 QRL';
+  }
 }
 
 /** Derive recent epoch rows from epoch info */
@@ -134,6 +145,16 @@ const icons = {
       <path strokeLinecap="round" strokeLinejoin="round" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
     </svg>
   ),
+  staked: (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  ),
+  marketCap: (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+    </svg>
+  ),
 };
 
 // ── Stat Bar ─────────────────────────────────────────────────────────────────
@@ -144,12 +165,14 @@ function StatBar({ data }: { data: HomeData }) {
     { label: 'Slot', value: data.epochInfo ? formatNumberWithCommas(data.epochInfo.headSlot) : '—', icon: icons.slot },
     { label: 'Block Height', value: formatNumberWithCommas(data.blockHeight.toString()), icon: icons.block },
     { label: 'Validators', value: formatNumberWithCommas(data.validatorCount.toString()), icon: icons.validators },
+    { label: 'Staked QRL', value: data.totalStaked !== '0' ? formatStaked(data.totalStaked) : '—', icon: icons.staked },
     { label: 'Transactions', value: formatNumberWithCommas(data.totalTransactions.toString()), icon: icons.transactions },
+    { label: 'Market Cap', value: data.marketCap > 0 ? '$' + formatNumberWithCommas(data.marketCap.toString()) : '—', icon: icons.marketCap },
   ];
 
   return (
     <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden">
-      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5">
+      <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7">
         {stats.map((stat, i) => (
           <div
             key={stat.label}
@@ -366,6 +389,7 @@ export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.El
     epochInfo: null,
     blocks: [],
     totalStaked: '0',
+    marketCap: 0,
     loading: true,
     error: false,
     dataInitialized: false,
@@ -375,12 +399,13 @@ export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.El
     try {
       if (!config.handlerUrl) return;
 
-      const [overviewRes, latestBlockRes, txsRes, epochRes, blocksRes] = await Promise.allSettled([
+      const [overviewRes, latestBlockRes, txsRes, epochRes, blocksRes, epochsRes] = await Promise.allSettled([
         axios.get(config.handlerUrl + '/overview'),
         axios.get(config.handlerUrl + '/latestblock'),
         axios.get(config.handlerUrl + '/txs?page=1'),
         axios.get(config.handlerUrl + '/epoch'),
         axios.get(config.handlerUrl + '/blocks?page=1&limit=10'),
+        axios.get(config.handlerUrl + '/epochs?page=1&limit=1'),
       ]);
 
       setData((prev) => {
@@ -389,6 +414,7 @@ export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.El
         if (overviewRes.status === 'fulfilled') {
           next.validatorCount = overviewRes.value.data.validatorCount || 0;
           next.dataInitialized = overviewRes.value.data.status?.dataInitialized ?? false;
+          next.marketCap = overviewRes.value.data.marketcap || 0;
         }
         if (latestBlockRes.status === 'fulfilled') {
           next.blockHeight = latestBlockRes.value.data.blockNumber || 0;
@@ -401,6 +427,12 @@ export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.El
         }
         if (blocksRes.status === 'fulfilled') {
           next.blocks = blocksRes.value.data.blocks || [];
+        }
+        if (epochsRes.status === 'fulfilled') {
+          const latestEpoch = epochsRes.value.data.epochs?.[0];
+          if (latestEpoch?.totalStaked) {
+            next.totalStaked = latestEpoch.totalStaked;
+          }
         }
 
         return next;

--- a/ExplorerFrontend/app/home-client.tsx
+++ b/ExplorerFrontend/app/home-client.tsx
@@ -2,370 +2,449 @@
 
 import * as React from 'react';
 import dynamic from 'next/dynamic';
-import axios from "axios";
-import { formatNumberWithCommas, toFixed } from "./lib/helpers";
-import config from "../config.js"
-import SearchBar from "./components/SearchBar"
-import SeoTextSection from "./components/SeoTextSection";
+import Link from 'next/link';
+import axios from 'axios';
+import { formatNumberWithCommas, truncateHash, formatAddress } from './lib/helpers';
+import config from '../config.js';
+import SearchBar from './components/SearchBar';
 
-// Lazy load Charts component since it's below the fold and includes heavy TradingView widget
-const Charts = dynamic(() => import("./components/Charts"), {
+const Charts = dynamic(() => import('./components/Charts'), {
   loading: () => (
-    <div className="h-[400px] bg-[#1f1f1f] rounded-2xl border border-[#3d3d3d] animate-pulse flex items-center justify-center">
+    <div className="h-[400px] bg-[#1e1e1e] rounded-xl border border-[#2a2a2a] animate-pulse flex items-center justify-center">
       <span className="text-gray-500">Loading chart...</span>
     </div>
   ),
-  ssr: false // TradingView requires browser APIs
+  ssr: false,
 });
 
-interface StatsData {
-  value: string;
-  isLoading: boolean;
-  error: boolean;
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface EpochInfo {
+  headEpoch: string;
+  headSlot: string;
+  finalizedEpoch: string;
+  justifiedEpoch: string;
+  slotsPerEpoch: number;
+  secondsPerSlot: number;
+  slotInEpoch: number;
+  timeToNextEpoch: number;
+  updatedAt: number;
 }
 
-interface StatItem {
-  data: string;
-  title: string;
+interface BlockResult {
+  number: string;
+  timestamp: string;
+  hash: string;
+  miner: string;
+  transactions: any[];
+}
+
+interface HomeData {
+  blockHeight: number;
+  totalTransactions: number;
+  validatorCount: number;
+  epochInfo: EpochInfo | null;
+  blocks: BlockResult[];
+  totalStaked: string;
   loading: boolean;
   error: boolean;
-  icon: React.ReactNode;
-}
-
-const StatCard = ({ item }: { item: StatItem }): JSX.Element => (
-  <div className={`relative overflow-hidden rounded-2xl
-                 bg-gradient-to-br from-[#2d2d2d]/80 to-[#1f1f1f]/80
-                 border border-[#3d3d3d] shadow-xl
-                 hover:border-[#ffa729] transition-all duration-300
-                 group`}>
-    <div className="relative p-2 sm:p-6 text-center min-h-[90px] sm:min-h-[160px] flex flex-col justify-center">
-      {item.loading ? (
-        <div className="flex flex-col items-center justify-center space-y-2">
-          <div className="w-16 sm:w-32 h-4 sm:h-8 bg-gray-700/50 rounded animate-pulse"></div>
-          <div className="w-12 sm:w-24 h-2 sm:h-4 bg-gray-700/50 rounded animate-pulse"></div>
-        </div>
-      ) : item.error ? (
-        <div className="flex flex-col items-center justify-center text-red-400">
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 sm:h-8 w-4 sm:w-8 mb-1 sm:mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-          <span className="text-xs">Failed to load data</span>
-        </div>
-      ) : (
-        <>
-          <div className="flex justify-center items-center mb-1 sm:mb-2">
-            <div className="h-4 w-4 sm:h-6 sm:w-6 text-[#ffa729] [&>svg]:h-full [&>svg]:w-full">
-              {item.icon}
-            </div>
-          </div>
-          <p className="text-base sm:text-3xl font-bold mb-1 sm:mb-3 text-[#ffa729]
-                      group-hover:scale-110 transition-transform duration-300 break-words">
-            {item.data}
-          </p>
-          <p className="text-[10px] sm:text-sm text-gray-300 font-medium">
-            {item.title}
-          </p>
-        </>
-      )}
-    </div>
-  </div>
-);
-
-interface DashboardData {
-  walletCount: StatsData;
-  volume: StatsData;
-  blockHeight: StatsData;
-  totalTransactions: StatsData;
-  marketCap: StatsData;
-  currentPrice: StatsData;
-  validatorCount: StatsData;
-  contractCount: StatsData;
-  syncing: boolean;
   dataInitialized: boolean;
 }
 
-export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.Element {
-  const [data, setData] = React.useState<DashboardData>({
-    walletCount: { value: "0", isLoading: true, error: false },
-    volume: { value: "0", isLoading: true, error: false },
-    blockHeight: { value: "0", isLoading: true, error: false },
-    totalTransactions: { value: "0", isLoading: true, error: false },
-    marketCap: { value: "0", isLoading: true, error: false },
-    currentPrice: { value: "0", isLoading: true, error: false },
-    validatorCount: { value: "0", isLoading: true, error: false },
-    contractCount: { value: "0", isLoading: true, error: false },
-    syncing: true,
-    dataInitialized: false
-  });
+// ── Helpers ──────────────────────────────────────────────────────────────────
 
-  React.useEffect(() => {
-    async function fetchData(): Promise<void> {
-      try {
-        if (config.handlerUrl) {
-          const [overviewResponse, latestBlockResponse, txsResponse] = await Promise.allSettled([
-            axios.get(config.handlerUrl + "/overview"),
-            axios.get(config.handlerUrl + "/latestblock"),
-            axios.get(config.handlerUrl + "/txs?page=1")
-          ]);
+const SLOTS_PER_EPOCH = 128;
+const SECONDS_PER_SLOT = 60;
 
-          setData(prevData => {
-            const newData = { ...prevData };
+function timeAgo(unixSeconds: number): string {
+  const now = Math.floor(Date.now() / 1000);
+  const diff = now - unixSeconds;
+  if (diff < 0) return 'just now';
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
 
-            // Handle overview response
-            if (overviewResponse.status === 'fulfilled') {
-              newData.walletCount = { value: overviewResponse.value.data.countwallets.toString(), isLoading: false, error: false };
-              newData.volume = { value: overviewResponse.value.data.volume.toString(), isLoading: false, error: false };
-              newData.marketCap = { value: overviewResponse.value.data.marketcap.toString(), isLoading: false, error: false };
-              newData.currentPrice = { value: overviewResponse.value.data.currentPrice.toString(), isLoading: false, error: false };
-              newData.validatorCount = { value: overviewResponse.value.data.validatorCount.toString(), isLoading: false, error: false };
-              newData.contractCount = { value: overviewResponse.value.data.contractCount.toString(), isLoading: false, error: false };
-              newData.syncing = overviewResponse.value.data.status.syncing;
-              newData.dataInitialized = overviewResponse.value.data.status.dataInitialized;
-            } else {
-              newData.walletCount = { value: "0", isLoading: false, error: true };
-              newData.volume = { value: "0", isLoading: false, error: true };
-              newData.marketCap = { value: "0", isLoading: false, error: true };
-              newData.currentPrice = { value: "0", isLoading: false, error: true };
-              newData.validatorCount = { value: "0", isLoading: false, error: true };
-              newData.contractCount = { value: "0", isLoading: false, error: true };
-            }
+function parseHex(hex: string): number {
+  if (!hex) return 0;
+  if (hex.startsWith('0x')) return parseInt(hex, 16);
+  return parseInt(hex, 10) || 0;
+}
 
-            // Handle latest block response
-            if (latestBlockResponse.status === 'fulfilled') {
-              newData.blockHeight.value = latestBlockResponse.value.data.blockNumber?.toString() || "0";
-              newData.blockHeight.isLoading = false;
-              newData.blockHeight.error = false;
-            } else {
-              newData.blockHeight.error = true;
-            }
+/** Derive recent epoch rows from epoch info */
+function deriveEpochs(epochInfo: EpochInfo | null): EpochRow[] {
+  if (!epochInfo) return [];
+  const head = parseInt(epochInfo.headEpoch);
+  const finalized = parseInt(epochInfo.finalizedEpoch);
+  const justified = parseInt(epochInfo.justifiedEpoch);
+  const now = Math.floor(Date.now() / 1000);
+  const epochDuration = SLOTS_PER_EPOCH * SECONDS_PER_SLOT; // 7680s
 
-            // Handle transactions response
-            if (txsResponse.status === 'fulfilled') {
-              newData.totalTransactions.value = txsResponse.value.data.total?.toString() || "0";
-              newData.totalTransactions.isLoading = false;
-              newData.totalTransactions.error = false;
-            } else {
-              newData.totalTransactions.error = true;
-            }
+  // Current epoch start time estimate
+  const slotInEpoch = epochInfo.slotInEpoch || 0;
+  const currentEpochStartTime = now - slotInEpoch * SECONDS_PER_SLOT;
 
-            return newData;
-          });
-        }
-      } catch (error) {
-        console.error("Failed to fetch overview data:", error);
-      }
-    }
+  const rows: EpochRow[] = [];
+  const count = Math.min(head + 1, 10);
+  for (let i = 0; i < count; i++) {
+    const epoch = head - i;
+    if (epoch < 0) break;
+    const epochStartTime = currentEpochStartTime - i * epochDuration;
+    let status: 'finalized' | 'justified' | 'pending';
+    if (epoch <= finalized) status = 'finalized';
+    else if (epoch <= justified) status = 'justified';
+    else status = 'pending';
+    rows.push({ epoch, time: epochStartTime, status });
+  }
+  return rows;
+}
 
-    fetchData();
-  }, []);
+interface EpochRow {
+  epoch: number;
+  time: number;
+  status: 'finalized' | 'justified' | 'pending';
+}
 
-  const blockchainStats = [
-    {
-      data: formatNumberWithCommas(data.walletCount.value),
-      title: "Wallet Count",
-      loading: data.walletCount.isLoading,
-      error: data.walletCount.error,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mb-2 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z" />
-        </svg>
-      )
-    },
-    {
-      data: toFixed(parseFloat(data.volume.value)) + " QRL",
-      title: "Daily Transactions Volume",
-      loading: data.volume.isLoading,
-      error: data.volume.error,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mb-2 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-        </svg>
-      )
-    },
-    {
-      data: formatNumberWithCommas(data.blockHeight.value),
-      title: "Block Height",
-      loading: data.blockHeight.isLoading,
-      error: data.blockHeight.error,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mb-2 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-        </svg>
-      )
-    },
-    {
-      data: formatNumberWithCommas(data.totalTransactions.value),
-      title: "Total Transactions",
-      loading: data.totalTransactions.isLoading,
-      error: data.totalTransactions.error,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mb-2 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
-        </svg>
-      )
-    },
-    {
-      data: formatNumberWithCommas(data.validatorCount.value),
-      title: "Active Validators",
-      loading: data.validatorCount.isLoading,
-      error: data.validatorCount.error,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mb-2 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-      )
-    },
-    {
-      data: formatNumberWithCommas(data.contractCount.value),
-      title: "Smart Contracts",
-      loading: data.contractCount.isLoading,
-      error: data.contractCount.error,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mb-2 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
-        </svg>
-      )
-    }
+// ── Icons ────────────────────────────────────────────────────────────────────
+
+const icons = {
+  epoch: (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  ),
+  slot: (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+    </svg>
+  ),
+  block: (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+    </svg>
+  ),
+  validators: (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+    </svg>
+  ),
+  transactions: (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+    </svg>
+  ),
+};
+
+// ── Stat Bar ─────────────────────────────────────────────────────────────────
+
+function StatBar({ data }: { data: HomeData }) {
+  const stats = [
+    { label: 'Epoch', value: data.epochInfo ? data.epochInfo.headEpoch : '—', icon: icons.epoch },
+    { label: 'Slot', value: data.epochInfo ? formatNumberWithCommas(data.epochInfo.headSlot) : '—', icon: icons.slot },
+    { label: 'Block Height', value: formatNumberWithCommas(data.blockHeight.toString()), icon: icons.block },
+    { label: 'Validators', value: formatNumberWithCommas(data.validatorCount.toString()), icon: icons.validators },
+    { label: 'Transactions', value: formatNumberWithCommas(data.totalTransactions.toString()), icon: icons.transactions },
   ];
 
-  const financialStats = [
-    {
-      data: "$" + formatNumberWithCommas(data.marketCap.value),
-      title: "Market Cap",
-      loading: data.marketCap.isLoading,
-      error: data.marketCap.error,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mb-2 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-      )
-    },
-    {
-      data: "$" + parseFloat(data.currentPrice.value).toFixed(4),
-      title: "Current Price",
-      loading: data.currentPrice.isLoading,
-      error: data.currentPrice.error,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mb-2 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-      )
-    }
-  ];
-
-  const videoContainerStyle: React.CSSProperties = {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    width: '100%',
-    height: '100%',
-    zIndex: -1,
-    overflow: 'hidden',
-  };
-
-  const videoStyle: React.CSSProperties = {
-    width: '100%',
-    height: '100%',
-    objectFit: 'cover',
-    opacity: 0.5, // Adjust this value to make the video more or less visible
-  };
-
-  const overlayStyle: React.CSSProperties = {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    width: '100%',
-    height: '100%',
-    backgroundColor: 'rgba(0, 0, 0, 0.5)', // Semi-transparent black overlay
-    zIndex: -1,
-  };
-
-  const seoTextItems = [
-    {
-      title: "What is ZondScan?",
-      text: "ZondScan is an independent blockchain explorer for QRL Zond, an EVM compatible blockchain secured by quantum resistant cryptography. Track blocks, transactions, smart contracts, and validators on a fast proof of stake network."
-    },
-    {
-      title: "What is QRL Zond?",
-      text: "QRL Zond is an EVM compatible blockchain built by the Quantum Resistant Ledger project with post quantum cryptography at its core. Most blockchains use cryptographic algorithms vulnerable to future quantum computers. QRL Zond uses SPHINCS+ instead, a NIST standardized signature scheme that provides security against both current and quantum era threats. Since it's EVM compatible, developers can deploy smart contracts using familiar Ethereum tools, libraries, and wallets. You get Ethereum compatibility plus quantum resistant security."
-    },
-    {
-      title: "Why Quantum Resistance Matters",
-      text: "Quantum computers will eventually break the cryptographic signatures that protect most blockchains today. When that happens, digital assets and identities on those chains become vulnerable. QRL Zond solves this with post quantum cryptography like SPHINCS+, ensuring your assets, contracts, and identity stay secure even when quantum computers arrive."
-    },
-    {
-      title: "Why SPHINCS+?",
-      text: "QRL Zond uses SPHINCS+, a stateless hash based signature scheme recently standardized by NIST. Unlike stateful schemes that require tracking signature usage, SPHINCS+ eliminates state management risks entirely. This makes development simpler and removes a major security headache for developers and enterprises. The tradeoff is slightly larger signatures and more computation, but that's manageable compared to the systemic risks of state tracking."
-    }
-  ];
   return (
-    <div className="relative">
-      {/* Video Background */}
-      <div style={videoContainerStyle}>
-        <video
-          autoPlay
-          loop
-          muted
-          playsInline
-          preload="metadata"
-          style={videoStyle}
-        >
-          <source src="/tree3.mp4" type="video/mp4" />
-          Your browser does not support the video tag.
-        </video>
-        <div style={overlayStyle}></div>
+    <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5">
+        {stats.map((stat, i) => (
+          <div
+            key={stat.label}
+            className={`px-4 py-4 sm:py-5 flex flex-col items-center justify-center text-center
+                        ${i < stats.length - 1 ? 'border-b lg:border-b-0 lg:border-r border-[#2a2a2a]' : ''}
+                        ${i % 2 === 0 && i < stats.length - 1 ? 'border-r sm:border-r border-[#2a2a2a]' : ''}
+                        `}
+          >
+            {data.loading ? (
+              <div className="h-7 w-20 bg-[#2a2a2a] rounded animate-pulse" />
+            ) : (
+              <span className="text-lg sm:text-xl font-semibold text-white tabular-nums">
+                {stat.value}
+              </span>
+            )}
+            <span className="flex items-center gap-1.5 text-[11px] text-gray-500 mt-1.5 uppercase tracking-wider">
+              <span className="text-gray-600">{stat.icon}</span>
+              {stat.label}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Status Badge ─────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: 'finalized' | 'justified' | 'pending' | 'proposed' }) {
+  const styles: Record<string, string> = {
+    finalized: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+    justified: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
+    pending: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/20',
+    proposed: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+  };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium border ${styles[status]}`}>
+      {status.charAt(0).toUpperCase() + status.slice(1)}
+    </span>
+  );
+}
+
+// ── Epoch Table ──────────────────────────────────────────────────────────────
+
+function EpochTable({ epochs, loading }: { epochs: EpochRow[]; loading: boolean }) {
+  return (
+    <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[#2a2a2a]">
+        <h2 className="flex items-center gap-2 text-[15px] font-semibold text-white">
+          <span className="text-[#ffa729]">{icons.epoch}</span>
+          Latest Epochs
+        </h2>
+        <Link href="/validators" className="text-xs text-[#ffa729] hover:text-[#ffb954] hover:underline transition-colors">
+          View all &rarr;
+        </Link>
       </div>
 
-      {/* Main Content */}
-      <div className="relative z-10 px-4 lg:px-8 pt-6.81 lg:pt-8">
+      {/* Table */}
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-[#2a2a2a]">
+              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Epoch</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Time</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              Array.from({ length: 8 }).map((_, i) => (
+                <tr key={i} className="border-b border-[#2a2a2a] last:border-b-0">
+                  <td className="px-4 py-2.5"><div className="h-4 w-12 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-2.5"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-2.5"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                </tr>
+              ))
+            ) : epochs.length === 0 ? (
+              <tr>
+                <td colSpan={3} className="px-4 py-8 text-center text-gray-500">No epoch data available</td>
+              </tr>
+            ) : (
+              epochs.map((epoch) => (
+                <tr
+                  key={epoch.epoch}
+                  className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
+                >
+                  <td className="px-4 py-2.5">
+                    <Link href="/validators" className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
+                      {formatNumberWithCommas(epoch.epoch.toString())}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-2.5 text-gray-400 tabular-nums">{timeAgo(epoch.time)}</td>
+                  <td className="px-4 py-2.5">
+                    <StatusBadge status={epoch.status} />
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ── Block Table ──────────────────────────────────────────────────────────────
+
+function BlockTable({ blocks, epochInfo, loading }: { blocks: BlockResult[]; epochInfo: EpochInfo | null; loading: boolean }) {
+  function getSlotFromBlock(blockNumber: string): number {
+    return parseHex(blockNumber);
+  }
+
+  function getEpochFromSlot(slot: number): number {
+    return Math.floor(slot / SLOTS_PER_EPOCH);
+  }
+
+  return (
+    <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[#2a2a2a]">
+        <h2 className="flex items-center gap-2 text-[15px] font-semibold text-white">
+          <span className="text-[#ffa729]">{icons.block}</span>
+          Latest Blocks
+        </h2>
+        <Link href="/blocks/1" className="text-xs text-[#ffa729] hover:text-[#ffb954] hover:underline transition-colors">
+          View all &rarr;
+        </Link>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-[#2a2a2a]">
+              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Block</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden sm:table-cell">Epoch</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Time</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Txns</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden md:table-cell">Proposer</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              Array.from({ length: 8 }).map((_, i) => (
+                <tr key={i} className="border-b border-[#2a2a2a] last:border-b-0">
+                  <td className="px-4 py-2.5"><div className="h-4 w-14 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-2.5 hidden sm:table-cell"><div className="h-4 w-10 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-2.5"><div className="h-4 w-14 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-2.5"><div className="h-4 w-6 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-2.5 hidden md:table-cell"><div className="h-4 w-24 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                </tr>
+              ))
+            ) : blocks.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-4 py-8 text-center text-gray-500">No blocks found</td>
+              </tr>
+            ) : (
+              blocks.map((block) => {
+                const blockNum = parseHex(block.number);
+                const slot = getSlotFromBlock(block.number);
+                const epoch = getEpochFromSlot(slot);
+                const timestamp = parseHex(block.timestamp);
+                const txCount = block.transactions?.length || 0;
+                const proposer = formatAddress(block.miner);
+
+                return (
+                  <tr
+                    key={block.hash}
+                    className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
+                  >
+                    <td className="px-4 py-2.5">
+                      <Link href={`/block/${blockNum}`} className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
+                        {formatNumberWithCommas(blockNum.toString())}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2.5 text-gray-400 tabular-nums hidden sm:table-cell">
+                      {formatNumberWithCommas(epoch.toString())}
+                    </td>
+                    <td className="px-4 py-2.5 text-gray-400 tabular-nums">{timeAgo(timestamp)}</td>
+                    <td className="px-4 py-2.5 text-gray-300 tabular-nums">{txCount}</td>
+                    <td className="px-4 py-2.5 hidden md:table-cell">
+                      <Link href={`/address/${proposer}`} className="text-gray-400 hover:text-[#ffa729] hover:underline font-mono text-xs transition-colors">
+                        {truncateHash(proposer, 8, 6)}
+                      </Link>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ── Main Component ───────────────────────────────────────────────────────────
+
+export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.Element {
+  const [data, setData] = React.useState<HomeData>({
+    blockHeight: 0,
+    totalTransactions: 0,
+    validatorCount: 0,
+    epochInfo: null,
+    blocks: [],
+    totalStaked: '0',
+    loading: true,
+    error: false,
+    dataInitialized: false,
+  });
+
+  const fetchData = React.useCallback(async () => {
+    try {
+      if (!config.handlerUrl) return;
+
+      const [overviewRes, latestBlockRes, txsRes, epochRes, blocksRes] = await Promise.allSettled([
+        axios.get(config.handlerUrl + '/overview'),
+        axios.get(config.handlerUrl + '/latestblock'),
+        axios.get(config.handlerUrl + '/txs?page=1'),
+        axios.get(config.handlerUrl + '/epoch'),
+        axios.get(config.handlerUrl + '/blocks?page=1&limit=10'),
+      ]);
+
+      setData((prev) => {
+        const next = { ...prev, loading: false };
+
+        if (overviewRes.status === 'fulfilled') {
+          next.validatorCount = overviewRes.value.data.validatorCount || 0;
+          next.dataInitialized = overviewRes.value.data.status?.dataInitialized ?? false;
+        }
+        if (latestBlockRes.status === 'fulfilled') {
+          next.blockHeight = latestBlockRes.value.data.blockNumber || 0;
+        }
+        if (txsRes.status === 'fulfilled') {
+          next.totalTransactions = txsRes.value.data.total || 0;
+        }
+        if (epochRes.status === 'fulfilled' && epochRes.value.data) {
+          next.epochInfo = epochRes.value.data;
+        }
+        if (blocksRes.status === 'fulfilled') {
+          next.blocks = blocksRes.value.data.blocks || [];
+        }
+
+        return next;
+      });
+    } catch (err) {
+      console.error('Failed to fetch homepage data:', err);
+      setData((prev) => ({ ...prev, loading: false, error: true }));
+    }
+  }, []);
+
+  React.useEffect(() => {
+    fetchData();
+    // Refresh every 30s (approx half a slot)
+    const interval = setInterval(fetchData, 30000);
+    return () => clearInterval(interval);
+  }, [fetchData]);
+
+  const epochs = React.useMemo(() => deriveEpochs(data.epochInfo), [data.epochInfo]);
+
+  return (
+    <div className="px-4 lg:px-8 pt-4 lg:pt-6">
+      <div className="max-w-6xl mx-auto">
         {/* Search Bar */}
-        <div className="max-w-6xl mx-auto mt-4">
-          <h1 className="text-base sm:text-xl font-bold mb-2 sm:mb-4 text-[#ffa729]">{pageTitle}</h1>
-          <div className="mb-4 sm:mb-10">
-            <SearchBar />
-          </div>
-
-          {!data.dataInitialized && (
-            <div className="mb-4 sm:mb-8 p-2 sm:p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-yellow-500">
-              <div className="flex items-center">
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 sm:h-5 w-4 sm:w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                <span className="text-xs sm:text-sm">Initializing explorer data... This may take a few minutes.</span>
-              </div>
-            </div>
-          )}
-
-          <div className="space-y-4 sm:space-y-8">
-            {/* Blockchain Stats */}
-            <div>
-              <h2 className="text-base sm:text-xl font-bold mb-2 sm:mb-4 text-[#ffa729]">Blockchain Statistics</h2>
-              <div className={`grid grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-4 ${!data.dataInitialized ? 'opacity-50' : ''}`}>
-                {blockchainStats.map((item, idx) => (
-                  <StatCard key={idx} item={item} />
-                ))}
-              </div>
-            </div>
-
-            {/* Financial Stats */}
-            <div>
-              <h2 className="text-base sm:text-xl font-bold mb-2 sm:mb-4 text-[#ffa729]">Financial Statistics</h2>
-              <div className={`grid grid-cols-2 gap-2 sm:gap-4 mb-4 ${!data.dataInitialized ? 'opacity-50' : ''}`}>
-                {financialStats.map((item, idx) => (
-                  <StatCard key={idx} item={item} />
-                ))}
-              </div>
-              <div className="max-w-6xl mx-auto">
-                <Charts />
-              </div>
-              
-            </div>
-          </div>
+        <h1 className="text-base sm:text-lg font-semibold mb-2 text-white">{pageTitle}</h1>
+        <div className="mb-6">
+          <SearchBar />
         </div>
-        <div className="max-w-6xl mx-auto px-4">
-        <SeoTextSection items={seoTextItems} />
+
+        {/* Init Warning */}
+        {!data.loading && !data.dataInitialized && (
+          <div className="mb-4 px-3 py-2.5 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-yellow-500 text-xs sm:text-sm flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            Initializing explorer data... This may take a few minutes.
+          </div>
+        )}
+
+        {/* Stats Bar */}
+        <div className="mb-6">
+          <StatBar data={data} />
         </div>
-        
+
+        {/* Side-by-Side Tables */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+          <EpochTable epochs={epochs} loading={data.loading} />
+          <BlockTable blocks={data.blocks} epochInfo={data.epochInfo} loading={data.loading} />
+        </div>
+
+        {/* TradingView Chart */}
+        <div className="mb-8">
+          <Charts />
+        </div>
       </div>
     </div>
   );

--- a/ExplorerFrontend/app/home-client.tsx
+++ b/ExplorerFrontend/app/home-client.tsx
@@ -199,8 +199,8 @@ function EpochTable({ epochs, loading }: { epochs: EpochRow[]; loading: boolean 
     <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-[#2a2a2a]">
-        <h2 className="flex items-center gap-2 text-[15px] font-semibold text-white">
-          <span className="text-[#ffa729]">{icons.epoch}</span>
+        <h2 className="flex items-center gap-2 text-[15px] font-semibold text-[#ffa729]">
+          {icons.epoch}
           Latest Epochs
         </h2>
         <Link href="/epochs/1" className="text-xs text-[#ffa729] hover:text-[#ffb954] hover:underline transition-colors">
@@ -238,7 +238,7 @@ function EpochTable({ epochs, loading }: { epochs: EpochRow[]; loading: boolean 
                   className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
                 >
                   <td className="px-4 py-2.5">
-                    <Link href="/epochs/1" className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
+                    <Link href={`/epoch/${epoch.epoch}`} className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
                       {formatNumberWithCommas(epoch.epoch.toString())}
                     </Link>
                   </td>
@@ -271,8 +271,8 @@ function BlockTable({ blocks, epochInfo, loading }: { blocks: BlockResult[]; epo
     <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-[#2a2a2a]">
-        <h2 className="flex items-center gap-2 text-[15px] font-semibold text-white">
-          <span className="text-[#ffa729]">{icons.block}</span>
+        <h2 className="flex items-center gap-2 text-[15px] font-semibold text-[#ffa729]">
+          {icons.block}
           Latest Blocks
         </h2>
         <Link href="/blocks/1" className="text-xs text-[#ffa729] hover:text-[#ffb954] hover:underline transition-colors">

--- a/ExplorerFrontend/app/home-client.tsx
+++ b/ExplorerFrontend/app/home-client.tsx
@@ -203,7 +203,7 @@ function EpochTable({ epochs, loading }: { epochs: EpochRow[]; loading: boolean 
           <span className="text-[#ffa729]">{icons.epoch}</span>
           Latest Epochs
         </h2>
-        <Link href="/validators" className="text-xs text-[#ffa729] hover:text-[#ffb954] hover:underline transition-colors">
+        <Link href="/epochs/1" className="text-xs text-[#ffa729] hover:text-[#ffb954] hover:underline transition-colors">
           View all &rarr;
         </Link>
       </div>
@@ -238,7 +238,7 @@ function EpochTable({ epochs, loading }: { epochs: EpochRow[]; loading: boolean 
                   className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
                 >
                   <td className="px-4 py-2.5">
-                    <Link href="/validators" className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
+                    <Link href="/epochs/1" className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
                       {formatNumberWithCommas(epoch.epoch.toString())}
                     </Link>
                   </td>

--- a/ExplorerFrontend/app/home-client.tsx
+++ b/ExplorerFrontend/app/home-client.tsx
@@ -4,9 +4,10 @@ import * as React from 'react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import axios from 'axios';
-import { formatNumberWithCommas } from './lib/helpers';
+import { formatNumberWithCommas, timeAgo, formatStaked } from './lib/helpers';
 import config from '../config.js';
 import SearchBar from './components/SearchBar';
+import StatusBadge from './components/StatusBadge';
 
 const Charts = dynamic(() => import('./components/Charts'), {
   loading: () => (
@@ -57,30 +58,10 @@ interface HomeData {
 const SLOTS_PER_EPOCH = 128;
 const SECONDS_PER_SLOT = 60;
 
-function timeAgo(unixSeconds: number): string {
-  const now = Math.floor(Date.now() / 1000);
-  const diff = now - unixSeconds;
-  if (diff < 0) return 'just now';
-  if (diff < 60) return `${diff}s ago`;
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-  return `${Math.floor(diff / 86400)}d ago`;
-}
-
 function parseHex(hex: string): number {
   if (!hex) return 0;
   if (hex.startsWith('0x')) return parseInt(hex, 16);
   return parseInt(hex, 10) || 0;
-}
-
-function formatStaked(gwei: string): string {
-  try {
-    const val = BigInt(gwei || '0');
-    const qrlBase = val / BigInt(1_000_000_000);
-    return formatNumberWithCommas(qrlBase.toString()) + ' QRL';
-  } catch {
-    return '0 QRL';
-  }
 }
 
 /** Derive recent epoch rows from epoch info */
@@ -196,22 +177,6 @@ function StatBar({ data }: { data: HomeData }) {
         ))}
       </div>
     </div>
-  );
-}
-
-// ── Status Badge ─────────────────────────────────────────────────────────────
-
-function StatusBadge({ status }: { status: 'finalized' | 'justified' | 'pending' | 'proposed' }) {
-  const styles: Record<string, string> = {
-    finalized: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
-    justified: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
-    pending: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/20',
-    proposed: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
-  };
-  return (
-    <span className={`inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium border ${styles[status]}`}>
-      {status.charAt(0).toUpperCase() + status.slice(1)}
-    </span>
   );
 }
 

--- a/ExplorerFrontend/app/home-client.tsx
+++ b/ExplorerFrontend/app/home-client.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import axios from 'axios';
-import { formatNumberWithCommas, truncateHash, formatAddress } from './lib/helpers';
+import { formatNumberWithCommas } from './lib/helpers';
 import config from '../config.js';
 import SearchBar from './components/SearchBar';
 
@@ -194,9 +194,16 @@ function StatusBadge({ status }: { status: 'finalized' | 'justified' | 'pending'
 
 // ── Epoch Table ──────────────────────────────────────────────────────────────
 
+const TABLE_ROWS = 10;
+
+const ROW_CLASS = 'flex items-center px-4 h-[38px] border-b border-[#2a2a2a] last:border-b-0 text-sm';
+const HEAD_CLASS = 'flex items-center px-4 py-2 border-b border-[#2a2a2a] text-[11px] font-normal text-gray-600 uppercase tracking-wider';
+
 function EpochTable({ epochs, loading }: { epochs: EpochRow[]; loading: boolean }) {
+  const padCount = loading ? 0 : Math.max(0, TABLE_ROWS - epochs.length);
+
   return (
-    <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden flex flex-col">
+    <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-[#2a2a2a]">
         <h2 className="flex items-center gap-2 text-[15px] font-semibold text-[#ffa729]">
@@ -208,49 +215,58 @@ function EpochTable({ epochs, loading }: { epochs: EpochRow[]; loading: boolean 
         </Link>
       </div>
 
-      {/* Table */}
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-[#2a2a2a]">
-              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Epoch</th>
-              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Time</th>
-              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {loading ? (
-              Array.from({ length: 8 }).map((_, i) => (
-                <tr key={i} className="border-b border-[#2a2a2a] last:border-b-0">
-                  <td className="px-4 py-2.5"><div className="h-4 w-12 bg-[#2a2a2a] rounded animate-pulse" /></td>
-                  <td className="px-4 py-2.5"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></td>
-                  <td className="px-4 py-2.5"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></td>
-                </tr>
-              ))
-            ) : epochs.length === 0 ? (
-              <tr>
-                <td colSpan={3} className="px-4 py-8 text-center text-gray-500">No epoch data available</td>
-              </tr>
-            ) : (
-              epochs.map((epoch) => (
-                <tr
-                  key={epoch.epoch}
-                  className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
-                >
-                  <td className="px-4 py-2.5">
-                    <Link href={`/epoch/${epoch.epoch}`} className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
-                      {formatNumberWithCommas(epoch.epoch.toString())}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-2.5 text-gray-400 tabular-nums">{timeAgo(epoch.time)}</td>
-                  <td className="px-4 py-2.5">
-                    <StatusBadge status={epoch.status} />
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+      {/* Column headers */}
+      <div className={HEAD_CLASS}>
+        <span className="w-20">Epoch</span>
+        <span className="flex-1">Time</span>
+        <span className="w-24 text-right">Status</span>
+      </div>
+
+      {/* Rows */}
+      <div>
+        {loading ? (
+          Array.from({ length: TABLE_ROWS }).map((_, i) => (
+            <div key={i} className={ROW_CLASS}>
+              <span className="w-20"><div className="h-4 w-12 bg-[#2a2a2a] rounded animate-pulse" /></span>
+              <span className="flex-1"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></span>
+              <span className="w-24 flex justify-end"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></span>
+            </div>
+          ))
+        ) : epochs.length === 0 ? (
+          Array.from({ length: TABLE_ROWS }).map((_, i) => (
+            <div key={i} className={ROW_CLASS}>
+              <span className="w-20 text-transparent select-none">—</span>
+              <span className="flex-1" />
+              <span className="w-24" />
+            </div>
+          ))
+        ) : (
+          <>
+            {epochs.map((epoch) => (
+              <div
+                key={epoch.epoch}
+                className={`${ROW_CLASS} hover:bg-[#252525] transition-colors`}
+              >
+                <span className="w-20">
+                  <Link href={`/epoch/${epoch.epoch}`} className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
+                    {formatNumberWithCommas(epoch.epoch.toString())}
+                  </Link>
+                </span>
+                <span className="flex-1 text-gray-400 tabular-nums">{timeAgo(epoch.time)}</span>
+                <span className="w-24 flex justify-end">
+                  <StatusBadge status={epoch.status} />
+                </span>
+              </div>
+            ))}
+            {Array.from({ length: padCount }).map((_, i) => (
+              <div key={`pad-${i}`} className={ROW_CLASS}>
+                <span className="w-20 text-transparent select-none">—</span>
+                <span className="flex-1" />
+                <span className="w-24" />
+              </div>
+            ))}
+          </>
+        )}
       </div>
     </div>
   );
@@ -258,7 +274,7 @@ function EpochTable({ epochs, loading }: { epochs: EpochRow[]; loading: boolean 
 
 // ── Block Table ──────────────────────────────────────────────────────────────
 
-function BlockTable({ blocks, epochInfo, loading }: { blocks: BlockResult[]; epochInfo: EpochInfo | null; loading: boolean }) {
+function BlockTable({ blocks, loading }: { blocks: BlockResult[]; loading: boolean }) {
   function getSlotFromBlock(blockNumber: string): number {
     return parseHex(blockNumber);
   }
@@ -268,7 +284,7 @@ function BlockTable({ blocks, epochInfo, loading }: { blocks: BlockResult[]; epo
   }
 
   return (
-    <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden flex flex-col">
+    <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-[#2a2a2a]">
         <h2 className="flex items-center gap-2 text-[15px] font-semibold text-[#ffa729]">
@@ -280,68 +296,61 @@ function BlockTable({ blocks, epochInfo, loading }: { blocks: BlockResult[]; epo
         </Link>
       </div>
 
-      {/* Table */}
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-[#2a2a2a]">
-              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Block</th>
-              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden sm:table-cell">Epoch</th>
-              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Time</th>
-              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Txns</th>
-              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden md:table-cell">Proposer</th>
-            </tr>
-          </thead>
-          <tbody>
-            {loading ? (
-              Array.from({ length: 8 }).map((_, i) => (
-                <tr key={i} className="border-b border-[#2a2a2a] last:border-b-0">
-                  <td className="px-4 py-2.5"><div className="h-4 w-14 bg-[#2a2a2a] rounded animate-pulse" /></td>
-                  <td className="px-4 py-2.5 hidden sm:table-cell"><div className="h-4 w-10 bg-[#2a2a2a] rounded animate-pulse" /></td>
-                  <td className="px-4 py-2.5"><div className="h-4 w-14 bg-[#2a2a2a] rounded animate-pulse" /></td>
-                  <td className="px-4 py-2.5"><div className="h-4 w-6 bg-[#2a2a2a] rounded animate-pulse" /></td>
-                  <td className="px-4 py-2.5 hidden md:table-cell"><div className="h-4 w-24 bg-[#2a2a2a] rounded animate-pulse" /></td>
-                </tr>
-              ))
-            ) : blocks.length === 0 ? (
-              <tr>
-                <td colSpan={5} className="px-4 py-8 text-center text-gray-500">No blocks found</td>
-              </tr>
-            ) : (
-              blocks.map((block) => {
-                const blockNum = parseHex(block.number);
-                const slot = getSlotFromBlock(block.number);
-                const epoch = getEpochFromSlot(slot);
-                const timestamp = parseHex(block.timestamp);
-                const txCount = block.transactions?.length || 0;
-                const proposer = formatAddress(block.miner);
+      {/* Column headers */}
+      <div className={HEAD_CLASS}>
+        <span className="w-20">Block</span>
+        <span className="w-16 hidden sm:block">Epoch</span>
+        <span className="flex-1">Time</span>
+        <span className="w-12 text-right">Txns</span>
+      </div>
 
-                return (
-                  <tr
-                    key={block.hash}
-                    className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
-                  >
-                    <td className="px-4 py-2.5">
-                      <Link href={`/block/${blockNum}`} className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
-                        {formatNumberWithCommas(blockNum.toString())}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2.5 text-gray-400 tabular-nums hidden sm:table-cell">
-                      {formatNumberWithCommas(epoch.toString())}
-                    </td>
-                    <td className="px-4 py-2.5 text-gray-400 tabular-nums">{timeAgo(timestamp)}</td>
-                    <td className="px-4 py-2.5 text-gray-300 tabular-nums">{txCount}</td>
-                    <td className="px-4 py-2.5 hidden md:table-cell">
-                      <Link href={`/address/${proposer}`} className="text-gray-400 hover:text-[#ffa729] hover:underline font-mono text-xs transition-colors">
-                        {truncateHash(proposer, 8, 6)}
-                      </Link>
-                    </td>
-                  </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
+      {/* Rows */}
+      <div>
+        {loading ? (
+          Array.from({ length: TABLE_ROWS }).map((_, i) => (
+            <div key={i} className={ROW_CLASS}>
+              <span className="w-20"><div className="h-4 w-14 bg-[#2a2a2a] rounded animate-pulse" /></span>
+              <span className="w-16 hidden sm:block"><div className="h-4 w-10 bg-[#2a2a2a] rounded animate-pulse" /></span>
+              <span className="flex-1"><div className="h-4 w-14 bg-[#2a2a2a] rounded animate-pulse" /></span>
+              <span className="w-12 flex justify-end"><div className="h-4 w-6 bg-[#2a2a2a] rounded animate-pulse" /></span>
+            </div>
+          ))
+        ) : blocks.length === 0 ? (
+          Array.from({ length: TABLE_ROWS }).map((_, i) => (
+            <div key={i} className={ROW_CLASS}>
+              <span className="w-20 text-transparent select-none">—</span>
+              <span className="w-16 hidden sm:block" />
+              <span className="flex-1" />
+              <span className="w-12" />
+            </div>
+          ))
+        ) : (
+          blocks.slice(0, TABLE_ROWS).map((block) => {
+            const blockNum = parseHex(block.number);
+            const slot = getSlotFromBlock(block.number);
+            const epoch = getEpochFromSlot(slot);
+            const timestamp = parseHex(block.timestamp);
+            const txCount = block.transactions?.length || 0;
+
+            return (
+              <div
+                key={block.hash}
+                className={`${ROW_CLASS} hover:bg-[#252525] transition-colors`}
+              >
+                <span className="w-20">
+                  <Link href={`/block/${blockNum}`} className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
+                    {formatNumberWithCommas(blockNum.toString())}
+                  </Link>
+                </span>
+                <span className="w-16 text-gray-400 tabular-nums hidden sm:block">
+                  {formatNumberWithCommas(epoch.toString())}
+                </span>
+                <span className="flex-1 text-gray-400 tabular-nums">{timeAgo(timestamp)}</span>
+                <span className="w-12 text-right text-gray-300 tabular-nums">{txCount}</span>
+              </div>
+            );
+          })
+        )}
       </div>
     </div>
   );
@@ -438,11 +447,11 @@ export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.El
         {/* Side-by-Side Tables */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
           <EpochTable epochs={epochs} loading={data.loading} />
-          <BlockTable blocks={data.blocks} epochInfo={data.epochInfo} loading={data.loading} />
+          <BlockTable blocks={data.blocks} loading={data.loading} />
         </div>
 
         {/* TradingView Chart */}
-        <div className="mb-8">
+        <div className="mb-2">
           <Charts />
         </div>
       </div>

--- a/ExplorerFrontend/app/layout.tsx
+++ b/ExplorerFrontend/app/layout.tsx
@@ -8,19 +8,19 @@ import Footer from './components/Footer';
 
 export const metadata: Metadata = {
   ...sharedMetadata,
-  title: 'QRL Zond Blockchain Explorer',
+  title: 'ZondScan - QRL v2 Explorer',
   description:
     'Blockchain explorer for QRL Zond, an EVM-compatible blockchain secured with post-quantum cryptography. Track transactions, smart contracts, blocks, and validators.',
   openGraph: {
     ...sharedMetadata.openGraph,
-    title: 'QRL Zond Blockchain Explorer',
+    title: 'ZondScan - QRL v2 Explorer',
     description:
       'Blockchain explorer for QRL Zond. Track smart contracts, blocks, and transactions on a quantum-resistant EVM-compatible chain.',
     url: 'https://zondscan.com',
   },
   twitter: {
     ...sharedMetadata.twitter,
-    title: 'QRL Zond Blockchain Explorer',
+    title: 'ZondScan - QRL v2 Explorer',
     description:
       'Blockchain explorer for QRL Zond. Track transactions, blocks, smart contracts, and validators on a post-quantum EVM chain.',
   },

--- a/ExplorerFrontend/app/lib/helpers.ts
+++ b/ExplorerFrontend/app/lib/helpers.ts
@@ -143,8 +143,8 @@ export function normalizeHexString(hexData: string | undefined | null): string {
     return hexData.slice(2);
   }
 
-  // If it starts with Z or z, remove the prefix
-  if (typeof hexData === 'string' && (hexData.startsWith('Z') || hexData.startsWith('z'))) {
+  // If it starts with Q or q, remove the prefix
+  if (typeof hexData === 'string' && (hexData.startsWith('Q') || hexData.startsWith('q'))) {
     return hexData.slice(1);
   }
 
@@ -219,14 +219,14 @@ export function truncateHash(hash: string | undefined | null, startLength = 6, e
 }
 
 /**
- * Formats an address to ensure it has the correct prefix (Z for QRL addresses, 0x for contract addresses)
+ * Formats an address to ensure it has the correct prefix (Q for QRL addresses, 0x for contract addresses)
  */
 export function formatAddress(address: string | undefined | null): string {
   if (!address) return '';
 
-  // If already has Z/z prefix, normalize to uppercase Z
-  if (address.startsWith('Z') || address.startsWith('z')) {
-    return 'Z' + address.slice(1);
+  // If already has Q/q prefix, normalize to uppercase Q
+  if (address.startsWith('Q') || address.startsWith('q')) {
+    return 'Q' + address.slice(1);
   }
 
   // If has 0x prefix
@@ -235,13 +235,13 @@ export function formatAddress(address: string | undefined | null): string {
     if (address.startsWith('0x7')) {
       return address;
     }
-    // For regular addresses, convert to Z prefix
-    return 'Z' + address.slice(2);
+    // For regular addresses, convert to Q prefix
+    return 'Q' + address.slice(2);
   }
 
-  // If no prefix but is a valid hex string, add Z prefix
+  // If no prefix but is a valid hex string, add Q prefix
   if (/^[0-9a-fA-F]+$/.test(address)) {
-    return 'Z' + address;
+    return 'Q' + address;
   }
 
   // If invalid format, return as is
@@ -283,7 +283,7 @@ export function decodeTokenTransferInput(inputData: string | undefined | null): 
     try {
       // Extract recipient address (bytes 10-74, last 40 chars are the address)
       const toAddressPadded = data.slice(10, 74);
-      const toAddress = 'Z' + toAddressPadded.slice(-40);
+      const toAddress = 'Q' + toAddressPadded.slice(-40);
 
       // Extract amount (bytes 74-138)
       const amountHex = '0x' + data.slice(74);
@@ -311,11 +311,11 @@ export function decodeTokenTransferInput(inputData: string | undefined | null): 
     try {
       // Extract from address (bytes 10-74)
       const fromAddressPadded = data.slice(10, 74);
-      const fromAddress = 'Z' + fromAddressPadded.slice(-40);
+      const fromAddress = 'Q' + fromAddressPadded.slice(-40);
 
       // Extract to address (bytes 74-138)
       const toAddressPadded = data.slice(74, 138);
-      const toAddress = 'Z' + toAddressPadded.slice(-40);
+      const toAddress = 'Q' + toAddressPadded.slice(-40);
 
       // Extract amount (bytes 138-202)
       const amountHex = '0x' + data.slice(138);

--- a/ExplorerFrontend/app/lib/helpers.ts
+++ b/ExplorerFrontend/app/lib/helpers.ts
@@ -1,3 +1,26 @@
+export function timeAgo(unixSeconds: number): string {
+  const now = Math.floor(Date.now() / 1000);
+  const diff = now - unixSeconds;
+  if (diff < 0) return 'just now';
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+export function formatStaked(gwei: string): string {
+  try {
+    const val = BigInt(gwei || '0');
+    const qrlBase = val / BigInt(1_000_000_000);
+    const remainder = val % BigInt(1_000_000_000);
+    const decimalStr = remainder.toString().padStart(9, '0').replace(/0+$/, '');
+    const result = formatNumberWithCommas(qrlBase.toString());
+    return decimalStr.length > 0 ? `${result}.${decimalStr} QRL` : `${result} QRL`;
+  } catch {
+    return '0 QRL';
+  }
+}
+
 export function decodeToHex(input: string, format?: string): string {
   const decoded = atob(input);
   let hex = '';

--- a/ExplorerFrontend/app/lib/seo/metaData.ts
+++ b/ExplorerFrontend/app/lib/seo/metaData.ts
@@ -4,7 +4,7 @@ import { Metadata } from 'next';
 export const sharedMetadata: Partial<Metadata> = {
   metadataBase: new URL('https://zondscan.com'),
   keywords:
-    'QRL, Proof of Stake, ZOND, blockchain explorer, Web3, EVM, quantum resistant, cryptocurrency, blockchain, smart contracts, validators, transactions, blocks',
+    'QRL, Proof of Stake, Zond, QRL v2 blockchain explorer, Web3, EVM, quantum resistant, cryptocurrency, blockchain, smart contracts, validators, transactions, blocks',
   alternates: {
     languages: {
       'en-US': 'https://zondscan.com',

--- a/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
+++ b/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
@@ -47,7 +47,7 @@ const formatTimestamp = (timestamp: number): string => {
 };
 
 const isZeroAddress = (addr: string): boolean =>
-  addr === 'Z0' || addr === 'Z' + '0'.repeat(40);
+  addr === 'Q0' || addr === 'Q' + '0'.repeat(40);
 
 const AddressDisplay = ({ address, isMobile }: { address: string, isMobile: boolean }): JSX.Element => {
   const displayAddress = isMobile ? `${address.slice(0, 8)}...${address.slice(-6)}` : address;

--- a/ExplorerFrontend/app/types/block.ts
+++ b/ExplorerFrontend/app/types/block.ts
@@ -6,13 +6,12 @@ export interface Block {
   timestamp: number;
   hash: string;
   parentHash: string;
-  nonce: string;
-  difficulty: string;
   gasLimit: string;
   gasUsed: string;
   miner: string;
   extraData: string;
   transactions: string[];
+  prevRandao: string;
 }
 
 /**

--- a/ExplorerFrontend/app/types/jsx.d.ts
+++ b/ExplorerFrontend/app/types/jsx.d.ts
@@ -9,4 +9,7 @@ declare global {
   }
 }
 
+// Allow CSS imports
+declare module '*.css' {}
+
 export {};

--- a/ExplorerFrontend/app/validators/components/ValidatorTable.tsx
+++ b/ExplorerFrontend/app/validators/components/ValidatorTable.tsx
@@ -247,10 +247,10 @@ export default function ValidatorTable({ validators, loading }: ValidatorTablePr
                     className="text-gray-300 hover:text-[#ffa729] font-mono"
                   >
                     <span className="hidden md:inline">
-                      Z{validator.address.slice(0, 16)}...{validator.address.slice(-8)}
+                      Q{validator.address.slice(0, 16)}...{validator.address.slice(-8)}
                     </span>
                     <span className="md:hidden">
-                      Z{validator.address.slice(0, 8)}...
+                      Q{validator.address.slice(0, 8)}...
                     </span>
                   </Link>
                 </td>

--- a/ExplorerFrontend/app/validators/validators-client.tsx
+++ b/ExplorerFrontend/app/validators/validators-client.tsx
@@ -98,10 +98,10 @@ export default function ValidatorsWrapper(): JSX.Element {
         axios.get(`${config.handlerUrl}/validators/history?limit=100`).catch((err) => { console.error('Failed to fetch validator history:', err); return { data: { history: [] } }; }),
       ]);
 
-      // Process validators - add Z prefix to addresses
+      // Process validators - add Q prefix to addresses
       const processedValidators = (validatorsRes.data.validators || []).map((v: any) => ({
         ...v,
-        address: v.address.startsWith('Z') ? v.address : 'Z' + v.address,
+        address: v.address.startsWith('Q') ? v.address : 'Q' + v.address,
       }));
 
       setValidators(processedValidators);

--- a/ExplorerFrontend/tsconfig.json
+++ b/ExplorerFrontend/tsconfig.json
@@ -27,7 +27,7 @@
       "node",
       "jest"
     ],
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
     "skipDefaultLibCheck": true,
     "target": "ES2017",
     "baseUrl": ".",

--- a/ExplorerFrontend/tsconfig.json
+++ b/ExplorerFrontend/tsconfig.json
@@ -27,7 +27,7 @@
       "node",
       "jest"
     ],
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "skipDefaultLibCheck": true,
     "target": "ES2017",
     "baseUrl": ".",

--- a/Zond2mongoDB/configs/const.go
+++ b/Zond2mongoDB/configs/const.go
@@ -10,7 +10,7 @@ import (
 const QUANTA float64 = 1000000000000000000
 
 // QRL address constants
-const QRLZeroAddress = "Z0000000000000000000000000000000000000000"
+const QRLZeroAddress = "Q0000000000000000000000000000000000000000"
 
 // Collection names
 const (

--- a/Zond2mongoDB/db/coinbase.go
+++ b/Zond2mongoDB/db/coinbase.go
@@ -22,8 +22,8 @@ func InsertManyCoinbase(doc []interface{}) {
 }
 
 func InsertCoinbaseDocument(blockHash string, blockNumber uint64, from string, hash string, nonce uint64, transactionIndex uint64, blockproposerReward uint64, attestorReward uint64, feeReward uint64, txType uint8, chainId uint8, signature string, pk string) (*mongo.InsertOneResult, error) {
-	// Normalize address to canonical Z-prefix form
-	from = validation.ConvertToZAddress(from)
+	// Normalize address to canonical Q-prefix form
+	from = validation.ConvertToQAddress(from)
 
 	doc := primitive.D{
 		{Key: "blockhash", Value: blockHash},

--- a/Zond2mongoDB/db/contracts.go
+++ b/Zond2mongoDB/db/contracts.go
@@ -21,9 +21,9 @@ func StoreContract(contract models.ContractInfo) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	// Normalize addresses to canonical Z-prefix form
-	contract.Address = validation.ConvertToZAddress(contract.Address)
-	contract.CreatorAddress = validation.ConvertToZAddress(contract.CreatorAddress)
+	// Normalize addresses to canonical Q-prefix form
+	contract.Address = validation.ConvertToQAddress(contract.Address)
+	contract.CreatorAddress = validation.ConvertToQAddress(contract.CreatorAddress)
 
 	collection := configs.GetContractsCollection()
 	filter := bson.M{"address": contract.Address}
@@ -41,8 +41,8 @@ func StoreContract(contract models.ContractInfo) error {
 
 		// Merge fields from the new 'contract' object, only if the new value is non-empty/non-zero
 		// and the existing value *is* empty/zero. This prioritizes data from the creation tx.
-		// Treat bare "Z" (from legacy ConvertToZAddress("")) as empty.
-		if (merged.CreatorAddress == "" || merged.CreatorAddress == "Z") && contract.CreatorAddress != "" && contract.CreatorAddress != "Z" {
+		// Treat bare "Q" (from legacy ConvertToQAddress("")) as empty.
+		if (merged.CreatorAddress == "" || merged.CreatorAddress == "Q") && contract.CreatorAddress != "" && contract.CreatorAddress != "Q" {
 			merged.CreatorAddress = contract.CreatorAddress
 		}
 		if merged.CreationTransaction == "" && contract.CreationTransaction != "" {
@@ -115,8 +115,8 @@ func GetContract(address string) (*models.ContractInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	// Normalize address to canonical Z-prefix form
-	address = validation.ConvertToZAddress(address)
+	// Normalize address to canonical Q-prefix form
+	address = validation.ConvertToQAddress(address)
 
 	var contract models.ContractInfo
 	err := configs.GetContractsCollection().FindOne(ctx, bson.M{"address": address}).Decode(&contract)
@@ -223,8 +223,8 @@ func processContracts(tx *models.Transaction) (string, string, string, bool) {
 // IsAddressContract checks if an address is a contract by querying the contractCode collection
 // and falling back to RPC getCode call if not found
 func IsAddressContract(address string) bool {
-	// Normalize address to canonical Z-prefix form
-	address = validation.ConvertToZAddress(address)
+	// Normalize address to canonical Q-prefix form
+	address = validation.ConvertToQAddress(address)
 
 	// First check our database
 	contract := getContractFromDB(address)
@@ -333,13 +333,13 @@ func ReprocessIncompleteContracts() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Find contracts with missing information, including bare "Z" creator addresses
+	// Find contracts with missing information, including bare "Q" creator addresses
 	filter := bson.M{
 		"$or": []bson.M{
 			{"contractCode": ""},
 			{"isToken": true, "totalSupply": ""},
 			{"isToken": false, "name": "", "symbol": ""},
-			{"creatorAddress": "Z"},
+			{"creatorAddress": "Q"},
 			{"creatorAddress": ""},
 		},
 	}
@@ -409,7 +409,7 @@ func ReprocessIncompleteContracts() error {
 
 		// Restore original creation information to ensure it's not lost
 		// Only restore if the original had values and current values are empty
-		if creatorAddress != "" && creatorAddress != "Z" && contract.CreatorAddress == "" {
+		if creatorAddress != "" && creatorAddress != "Q" && contract.CreatorAddress == "" {
 			contract.CreatorAddress = creatorAddress
 		}
 		if creationTransaction != "" && contract.CreationTransaction == "" {
@@ -425,7 +425,7 @@ func ReprocessIncompleteContracts() error {
 			if creationTx != nil {
 				contract.CreationTransaction = creationTx.TxHash
 				contract.CreationBlockNumber = creationTx.BlockNumber
-				if creationTx.From != "" && creationTx.From != "Z" {
+				if creationTx.From != "" && creationTx.From != "Q" {
 					contract.CreatorAddress = creationTx.From
 					configs.Logger.Info("Backfilled creation info from transfer collection",
 						zap.String("contract", contract.Address),
@@ -436,10 +436,10 @@ func ReprocessIncompleteContracts() error {
 		}
 
 		// Backfill missing creator address from creation transaction via RPC
-		if (contract.CreatorAddress == "" || contract.CreatorAddress == "Z") && contract.CreationTransaction != "" {
+		if (contract.CreatorAddress == "" || contract.CreatorAddress == "Q") && contract.CreationTransaction != "" {
 			txDetails, txErr := rpc.GetTxDetailsByHash(contract.CreationTransaction)
 			if txErr == nil && txDetails != nil && txDetails.From != "" {
-				contract.CreatorAddress = validation.ConvertToZAddress(txDetails.From)
+				contract.CreatorAddress = validation.ConvertToQAddress(txDetails.From)
 				configs.Logger.Info("Backfilled creator address from creation transaction",
 					zap.String("contract", contract.Address),
 					zap.String("creator", contract.CreatorAddress))
@@ -505,7 +505,7 @@ func findCreationTransaction(contractAddress string) *creationTxInfo {
 	}
 	err = configs.GetTokenTransfersCollection().FindOne(ctx, bson.M{
 		"contractAddress": contractAddress,
-		"from":            "Z0",
+		"from":            "Q0",
 	}).Decode(&mint)
 	if err != nil || mint.TxHash == "" {
 		return nil

--- a/Zond2mongoDB/db/token_detection.go
+++ b/Zond2mongoDB/db/token_detection.go
@@ -105,7 +105,7 @@ func EnsureTokenInDatabase(contractAddress string, blockNumber string, txHash st
 		if creationTx := findCreationTransaction(contractAddress); creationTx != nil {
 			contractInfo.CreationTransaction = creationTx.TxHash
 			contractInfo.CreationBlockNumber = creationTx.BlockNumber
-			if creationTx.From != "" && creationTx.From != "Z" {
+			if creationTx.From != "" && creationTx.From != "Q" {
 				contractInfo.CreatorAddress = creationTx.From
 			}
 		}

--- a/Zond2mongoDB/db/tokenbalances.go
+++ b/Zond2mongoDB/db/tokenbalances.go
@@ -16,8 +16,8 @@ import (
 
 // StoreTokenBalance updates the token balance for a given address
 func StoreTokenBalance(contractAddress string, holderAddress string, amount string, blockNumber string) error {
-	// Normalize addresses to canonical Z-prefix form
-	contractAddress = validation.ConvertToZAddress(contractAddress)
+	// Normalize addresses to canonical Q-prefix form
+	contractAddress = validation.ConvertToQAddress(contractAddress)
 
 	// Debug-level log for per-record operations; Info is reserved for batch summaries.
 	configs.Logger.Debug("Attempting to store token balance",
@@ -26,11 +26,11 @@ func StoreTokenBalance(contractAddress string, holderAddress string, amount stri
 		zap.String("transferAmount", amount),
 		zap.String("blockNumber", blockNumber))
 
-	// Normalize holder address to canonical Z-prefix form
-	holderAddress = validation.ConvertToZAddress(holderAddress)
+	// Normalize holder address to canonical Q-prefix form
+	holderAddress = validation.ConvertToQAddress(holderAddress)
 
-	// Special handling for zero address (QRL uses Z prefix)
-	if holderAddress == "Z0" ||
+	// Special handling for zero address (QRL uses Q prefix)
+	if holderAddress == "Q0" ||
 		holderAddress == configs.QRLZeroAddress ||
 		holderAddress == "0x0" ||
 		holderAddress == "0x0000000000000000000000000000000000000000" {

--- a/Zond2mongoDB/db/tokentransfers.go
+++ b/Zond2mongoDB/db/tokentransfers.go
@@ -32,10 +32,10 @@ func StoreTokenTransfer(transfer models.TokenTransfer) error {
 		transfer.To = configs.QRLZeroAddress // Normalize empty to address to zero address
 	}
 
-	// Normalize addresses to canonical Z-prefix form
-	transfer.From = validation.ConvertToZAddress(transfer.From)
-	transfer.To = validation.ConvertToZAddress(transfer.To)
-	transfer.ContractAddress = validation.ConvertToZAddress(transfer.ContractAddress)
+	// Normalize addresses to canonical Q-prefix form
+	transfer.From = validation.ConvertToQAddress(transfer.From)
+	transfer.To = validation.ConvertToQAddress(transfer.To)
+	transfer.ContractAddress = validation.ConvertToQAddress(transfer.ContractAddress)
 
 	// Debug-level log for per-record operations; Info is reserved for batch summaries.
 	configs.Logger.Debug("Inserting token transfer document",
@@ -199,11 +199,11 @@ func ProcessBlockTokenTransfers(blockNumber string, blockTimestamp string) error
 			continue
 		}
 
-		// Extract from and to addresses using canonical Z-prefix form.
+		// Extract from and to addresses using canonical Q-prefix form.
 		// topics[1] and topics[2] are 32-byte padded addresses; strip the 12-byte
 		// zero-padding (24 hex chars) to recover the 20-byte address.
-		from := "Z" + strings.ToLower(rpc.TrimLeftZeros(log.Topics[1][26:]))
-		to := "Z" + strings.ToLower(rpc.TrimLeftZeros(log.Topics[2][26:]))
+		from := "Q" + strings.ToLower(rpc.TrimLeftZeros(log.Topics[1][26:]))
+		to := "Q" + strings.ToLower(rpc.TrimLeftZeros(log.Topics[2][26:]))
 
 		configs.Logger.Debug("Token transfer details",
 			zap.String("from", from),
@@ -230,11 +230,11 @@ func ProcessBlockTokenTransfers(blockNumber string, blockTimestamp string) error
 		}
 
 		// Normalize addresses to ensure consistency.
-		if from == "" || from == "z" || from == "Z" {
+		if from == "" || from == "q" || from == "Q" {
 			from = configs.QRLZeroAddress
 		}
 
-		if to == "" || to == "z" || to == "Z" {
+		if to == "" || to == "q" || to == "Q" {
 			to = configs.QRLZeroAddress
 		}
 

--- a/Zond2mongoDB/db/transactions.go
+++ b/Zond2mongoDB/db/transactions.go
@@ -398,13 +398,13 @@ func processTransactionData(tx *models.Transaction, blockTimestamp string, to st
 }
 
 func TransferCollection(blockNumber string, blockTimestamp string, from string, to string, hash string, pk string, signature string, nonce string, value float64, data string, contractAddress string, status string, size string, paidFees float64) (*mongo.InsertOneResult, error) {
-	// Normalize addresses to canonical Z-prefix form
-	from = validation.ConvertToZAddress(from)
+	// Normalize addresses to canonical Q-prefix form
+	from = validation.ConvertToQAddress(from)
 	if to != "" {
-		to = validation.ConvertToZAddress(to)
+		to = validation.ConvertToQAddress(to)
 	}
 	if contractAddress != "" {
-		contractAddress = validation.ConvertToZAddress(contractAddress)
+		contractAddress = validation.ConvertToQAddress(contractAddress)
 	}
 
 	var doc bson.D
@@ -447,15 +447,15 @@ func TransferCollection(blockNumber string, blockTimestamp string, from string, 
 }
 
 func InternalTransactionByAddressCollection(transactionType string, callType string, hash string, from string, to string, input string, output string, traceAddress []int, value float64, gas string, gasUsed string, addressFunctionIdentifier string, amountFunctionIdentifier string, blockTimestamp string) (*mongo.InsertOneResult, error) {
-	// Normalize addresses to canonical Z-prefix form
+	// Normalize addresses to canonical Q-prefix form
 	if from != "" {
-		from = validation.ConvertToZAddress(from)
+		from = validation.ConvertToQAddress(from)
 	}
 	if to != "" {
-		to = validation.ConvertToZAddress(to)
+		to = validation.ConvertToQAddress(to)
 	}
 	if addressFunctionIdentifier != "" {
-		addressFunctionIdentifier = validation.ConvertToZAddress(addressFunctionIdentifier)
+		addressFunctionIdentifier = validation.ConvertToQAddress(addressFunctionIdentifier)
 	}
 
 	doc := bson.D{
@@ -488,10 +488,10 @@ func InternalTransactionByAddressCollection(transactionType string, callType str
 }
 
 func TransactionByAddressCollection(timeStamp string, txType string, from string, to string, hash string, amount float64, paidFees float64, blockNumber string) (*mongo.InsertOneResult, error) {
-	// Normalize addresses to canonical Z-prefix form
-	from = validation.ConvertToZAddress(from)
+	// Normalize addresses to canonical Q-prefix form
+	from = validation.ConvertToQAddress(from)
 	if to != "" {
-		to = validation.ConvertToZAddress(to)
+		to = validation.ConvertToQAddress(to)
 	}
 
 	doc := bson.D{
@@ -517,8 +517,8 @@ func TransactionByAddressCollection(timeStamp string, txType string, from string
 }
 
 func UpsertTransactions(address string, value float64, isContract bool) (*mongo.UpdateResult, error) {
-	// Normalize address to canonical Z-prefix form
-	address = validation.ConvertToZAddress(address)
+	// Normalize address to canonical Q-prefix form
+	address = validation.ConvertToQAddress(address)
 	filter := bson.D{{Key: "id", Value: address}}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/Zond2mongoDB/models/contract.go
+++ b/Zond2mongoDB/models/contract.go
@@ -55,7 +55,7 @@ type ContractInfo struct {
 	MaxTxLimit      string `bson:"maxTxLimit,omitempty" json:"maxTxLimit,omitempty"`
 }
 
-// LogsResponse represents the response from zond_getLogs
+// LogsResponse represents the response from qrl_getLogs
 type LogsResponse struct {
 	Jsonrpc string     `json:"jsonrpc"`
 	ID      int        `json:"id"`
@@ -66,7 +66,7 @@ type LogsResponse struct {
 	} `json:"error,omitempty"`
 }
 
-// LogEntry represents a single log entry from zond_getLogs
+// LogEntry represents a single log entry from qrl_getLogs
 type LogEntry struct {
 	Address          string   `json:"address"`
 	Topics           []string `json:"topics"`

--- a/Zond2mongoDB/models/pending.go
+++ b/Zond2mongoDB/models/pending.go
@@ -23,8 +23,8 @@ type PendingTransaction struct {
 	CreatedAt            time.Time `bson:"createdAt" json:"createdAt"`
 }
 
-// PendingTransactionResponse represents the RPC response for zond_pendingTransactions
-// Note: This method returns empty on most Zond nodes - use TxPoolContentResponse instead
+// PendingTransactionResponse represents the RPC response for pending transactions
+// Note: Pending transactions are fetched via txpool_content - use TxPoolContentResponse instead
 type PendingTransactionResponse struct {
 	Jsonrpc string               `json:"jsonrpc"`
 	Id      int                  `json:"id"`

--- a/Zond2mongoDB/models/zond.go
+++ b/Zond2mongoDB/models/zond.go
@@ -35,10 +35,10 @@ type ZondDatabaseBlockWithInt struct {
 }
 
 type Withdrawal struct {
-	Index          string   `json:"index"`
-	ValidatorIndex string   `json:"validatorIndex"`
-	Address        string   `json:"address"`
-	Amount         *big.Int `json:"amount"`
+	Index          string `json:"index"`
+	ValidatorIndex string `json:"validatorIndex"`
+	Address        string `json:"address"`
+	Amount         string `json:"amount"`
 }
 
 type Transaction struct {
@@ -72,16 +72,11 @@ type PreResult struct {
 	Timestamp        string        `json:"timestamp"`
 	Transactions     []Transaction `json:"transactions"`
 	TransactionsRoot string        `json:"transactionsRoot"`
-	Difficulty       string        `json:"difficulty"`
 	ExtraData        string        `json:"extraData"`
 	LogsBloom        string        `json:"logsBloom"`
 	Miner            string        `json:"miner"`
-	MixHash          string        `json:"mixHash"`
-	Nonce            string        `json:"nonce"`
-	Sha3Uncles       string        `json:"sha3Uncles"`
 	Size             string        `json:"size"`
-	TotalDifficulty  string        `json:"totalDifficulty"`
-	Uncles           []interface{} `json:"uncles"`
+	PrevRandao       string        `json:"prevRandao"`
 	Withdrawals      []Withdrawal  `json:"withdrawals"`
 	WithdrawalsRoot  string        `json:"withdrawalsRoot"`
 }
@@ -98,16 +93,11 @@ type Result struct {
 	Timestamp        string        `json:"timestamp"`
 	Transactions     []Transaction `json:"transactions"`
 	TransactionsRoot string        `json:"transactionsRoot"`
-	Difficulty       string        `json:"difficulty"`
 	ExtraData        string        `json:"extraData"`
 	LogsBloom        string        `json:"logsBloom"`
 	Miner            string        `json:"miner"`
-	MixHash          string        `json:"mixHash"`
-	Nonce            string        `json:"nonce"`
-	Sha3Uncles       string        `json:"sha3Uncles"`
 	Size             string        `json:"size"`
-	TotalDifficulty  string        `json:"totalDifficulty"`
-	Uncles           []interface{} `json:"uncles"`
+	PrevRandao       string        `json:"prevRandao"`
 	Withdrawals      []Withdrawal  `json:"withdrawals"`
 	WithdrawalsRoot  string        `json:"withdrawalsRoot"`
 }
@@ -144,7 +134,7 @@ type ZondResponse struct {
 	Result  string `json:"result"`
 }
 
-// ZondLogsResponse represents the response from zond_getLogs RPC call
+// ZondLogsResponse represents the response from qrl_getLogs RPC call
 // It uses the Log struct defined in models/receipt.go
 type ZondLogsResponse struct {
 	Id      int    `json:"id"`

--- a/Zond2mongoDB/rpc/calls.go
+++ b/Zond2mongoDB/rpc/calls.go
@@ -25,7 +25,7 @@ func GetLatestBlock() (string, error) {
 
 	group := models.JsonRPC{
 		Jsonrpc: "2.0",
-		Method:  "zond_blockNumber",
+		Method:  "qrl_blockNumber",
 		Params:  []interface{}{},
 		ID:      1,
 	}
@@ -102,7 +102,7 @@ func GetBlockByNumberMainnet(blockNumber string) (*models.ZondDatabaseBlock, err
 
 	group := models.JsonRPC{
 		Jsonrpc: "2.0",
-		Method:  "zond_getBlockByNumber",
+		Method:  "qrl_getBlockByNumber",
 		Params:  []interface{}{blockNumber, true},
 		ID:      1,
 	}
@@ -171,7 +171,7 @@ func GetContractAddress(txHash string) (string, string, error) {
 	}
 	group := models.JsonRPC{
 		Jsonrpc: "2.0",
-		Method:  "zond_getTransactionReceipt",
+		Method:  "qrl_getTransactionReceipt",
 		Params:  []interface{}{txHash},
 		ID:      1,
 	}
@@ -231,9 +231,9 @@ type DebugTraceResult struct {
 	TransactionType string
 	// CallType is the sub-call type (e.g. "call", "delegatecall").
 	CallType string
-	// From is the caller address in Z-prefix format.
+	// From is the caller address in Q-prefix format.
 	From string
-	// To is the callee address in Z-prefix format.
+	// To is the callee address in Q-prefix format.
 	To string
 	// Input is always 0 in the current implementation (field reserved for future use).
 	Input uint64
@@ -263,7 +263,14 @@ func emptyTrace(err error) DebugTraceResult {
 
 // CallDebugTraceTransaction calls debug_traceTransaction and returns the parsed
 // result as a DebugTraceResult struct.
+// On Testnet V2+, debug_ APIs are not available. Set ENABLE_DEBUG_TRACE=true to
+// re-enable if the node supports it.
 func CallDebugTraceTransaction(hash string) DebugTraceResult {
+	// Skip debug tracing when disabled (default for V2 nodes without debug_ API)
+	if os.Getenv("ENABLE_DEBUG_TRACE") != "true" {
+		return emptyTrace(nil)
+	}
+
 	// Validate transaction hash
 	if err := validation.ValidateHexString(hash, validation.HashLength); err != nil {
 		zap.L().Error("Invalid transaction hash", zap.Error(err))
@@ -370,19 +377,19 @@ func CallDebugTraceTransaction(hash string) DebugTraceResult {
 		return emptyTrace(nil)
 	}
 
-	// Validate addresses and convert to Z format
+	// Validate addresses and convert to Q format
 	if tracerResponse.Result.From != "" {
 		if err := validation.ValidateAddress(tracerResponse.Result.From); err != nil {
 			zap.L().Error("Invalid from address", zap.Error(err))
 		}
-		res.From = validation.ConvertToZAddress(tracerResponse.Result.From)
+		res.From = validation.ConvertToQAddress(tracerResponse.Result.From)
 	}
 
 	if tracerResponse.Result.To != "" {
 		if err := validation.ValidateAddress(tracerResponse.Result.To); err != nil {
 			zap.L().Error("Invalid to address", zap.Error(err))
 		}
-		res.To = validation.ConvertToZAddress(tracerResponse.Result.To)
+		res.To = validation.ConvertToQAddress(tracerResponse.Result.To)
 	}
 
 	// Validate and process output
@@ -433,7 +440,7 @@ func CallDebugTraceTransaction(hash string) DebugTraceResult {
 			if len(data) >= 64 {
 				extractedAddr := "0x" + data[24:64]
 				if err := validation.ValidateAddress(extractedAddr); err == nil {
-					res.AddressFunctionIdentifier = validation.ConvertToZAddress(extractedAddr)
+					res.AddressFunctionIdentifier = validation.ConvertToQAddress(extractedAddr)
 				} else {
 					zap.L().Error("Invalid extracted address", zap.Error(err))
 				}
@@ -475,7 +482,7 @@ func GetBalance(address string) (string, error) {
 
 	group := models.JsonRPC{
 		Jsonrpc: "2.0",
-		Method:  "zond_getBalance",
+		Method:  "qrl_getBalance",
 		Params:  []interface{}{address, "latest"},
 		ID:      1,
 	}
@@ -531,7 +538,7 @@ func GetValidators() error {
 	}
 
 	// Base URL for the validators endpoint
-	baseURL := strings.TrimRight(beaconchainURL, "/") + "/zond/v1alpha1/validators"
+	baseURL := strings.TrimRight(beaconchainURL, "/") + "/qrl/v1alpha1/validators"
 	client := GetHTTPClient()
 
 	// Get current epoch from latest block
@@ -607,7 +614,7 @@ func GetBeaconChainHead() (*models.BeaconChainHeadResponse, error) {
 		return nil, fmt.Errorf("BEACONCHAIN_API environment variable not set")
 	}
 
-	url := strings.TrimRight(beaconchainURL, "/") + "/zond/v1alpha1/beacon/chainhead"
+	url := strings.TrimRight(beaconchainURL, "/") + "/qrl/v1alpha1/beacon/chainhead"
 	client := GetHTTPClient()
 
 	req, err := http.NewRequest("GET", url, nil)
@@ -651,7 +658,7 @@ func GetCode(address string, blockNrOrHash string) (string, error) {
 
 	group := models.JsonRPC{
 		Jsonrpc: "2.0",
-		Method:  "zond_getCode",
+		Method:  "qrl_getCode",
 		Params:  []interface{}{address, "latest"},
 		ID:      1,
 	}
@@ -704,8 +711,8 @@ func ZondCall(contractAddress string) (*models.ZondResponse, error) {
 	}
 
 	data := map[string]interface{}{
-		"from":     "0x20748ad4e06597dbca756e2731cd26094c05273a",
-		"chainId":  "0x0",
+		"from":     "Q20748ad4e06597dbca756e2731cd26094c05273a",
+		"chainId":  "0x7e7e",
 		"nonce":    "0x0",
 		"gas":      "0x61184",
 		"gasPrice": "0x2710",
@@ -720,7 +727,7 @@ func ZondCall(contractAddress string) (*models.ZondResponse, error) {
 	payload := models.ZondCallPayload{
 		Jsonrpc: "2.0",
 		Id:      1,
-		Method:  "zond_call",
+		Method:  "qrl_call",
 		Params:  []interface{}{data, blockData},
 	}
 
@@ -777,7 +784,7 @@ func ZondGetBlockLogs(blockNumber string, topics []string) (*models.ZondLogsResp
 
 	group := models.JsonRPC{
 		Jsonrpc: "2.0",
-		Method:  "zond_getLogs",
+		Method:  "qrl_getLogs",
 		Params:  []interface{}{filter},
 		ID:      1,
 	}
@@ -832,7 +839,7 @@ func GetTxDetailsByHash(txHash string) (*models.TransactionResult, error) {
 
 	group := models.JsonRPC{
 		Jsonrpc: "2.0",
-		Method:  "zond_getTransactionByHash",
+		Method:  "qrl_getTransactionByHash",
 		Params:  []interface{}{txHash},
 		ID:      1,
 	}

--- a/Zond2mongoDB/rpc/pending.go
+++ b/Zond2mongoDB/rpc/pending.go
@@ -26,7 +26,7 @@ func GetPendingTransactions() string {
 	}
 
 	// Use txpool_content which actually works on Zond nodes
-	// zond_pendingTransactions returns empty on most nodes
+	// Pending transactions are fetched via txpool_content (not a dedicated pending RPC method)
 	rpcReq := models.JsonRPC{
 		Jsonrpc: "2.0",
 		Method:  "txpool_content",

--- a/Zond2mongoDB/rpc/tokenscalls.go
+++ b/Zond2mongoDB/rpc/tokenscalls.go
@@ -47,11 +47,7 @@ func CallContractMethod(contractAddress string, methodSig string) (string, error
 		zap.String("methodSig", methodSig[:10]+"...")) // Log just the beginning of the signature for brevity
 
 	// Ensure contract address has Q prefix for QRL RPC
-	if strings.HasPrefix(contractAddress, "0x") {
-		contractAddress = "Q" + contractAddress[2:]
-	} else if !strings.HasPrefix(contractAddress, "Q") {
-		contractAddress = "Q" + contractAddress
-	}
+	contractAddress = validation.ConvertToQAddress(contractAddress)
 
 	group := models.JsonRPC{
 		Jsonrpc: "2.0",
@@ -339,23 +335,14 @@ func GetTokenBalance(contractAddress string, holderAddress string) (string, erro
 	}
 
 	// Ensure contract address has Q prefix for QRL RPC
-	if strings.HasPrefix(contractAddress, "0x") {
-		contractAddress = "Q" + contractAddress[2:]
-	} else if !strings.HasPrefix(contractAddress, "Q") {
-		contractAddress = "Q" + contractAddress
-	}
+	contractAddress = validation.ConvertToQAddress(contractAddress)
 
 	// Ensure holder address has Q prefix for RPC
 	originalHolderAddress := holderAddress // Keep original for logging
-
-	if strings.HasPrefix(holderAddress, "0x") {
-		holderAddress = "Q" + holderAddress[2:]
-	} else if !strings.HasPrefix(holderAddress, "Q") {
-		holderAddress = "Q" + holderAddress
-	}
+	holderAddress = validation.ConvertToQAddress(holderAddress)
 
 	// Extract the raw address (without prefix) for padding
-	rawAddress := strings.TrimPrefix(holderAddress, "Q")
+	rawAddress := validation.StripAddressPrefix(holderAddress)
 
 	// Pad address to 32 bytes (64 hex chars) for ABI encoding
 	paddedAddress := rawAddress
@@ -434,8 +421,8 @@ func DecodeTransferEvent(data string) (string, string, string) {
 			return "", "", ""
 		}
 
-		// Extract recipient address (remove leading zeros), canonical Q-prefix form
-		recipient := "Q" + strings.ToLower(TrimLeftZeros(data[34:74]))
+		// Extract recipient address, canonical Q-prefix form
+		recipient := "Q" + strings.ToLower(data[34:74])
 		if len(recipient) != 41 { // Check if it's a valid address length (Z + 40 hex chars)
 			return "", "", ""
 		}
@@ -551,9 +538,9 @@ func IsValidRecipient(recipient string) bool {
 // ParseTransferEvent parses a transfer event log.
 // Addresses are returned in canonical Q-prefix form.
 func ParseTransferEvent(log models.Log) (string, string, *big.Int, error) {
-	// Extract addresses from topics (32-byte padded, strip leading zeros)
-	from := "Q" + strings.ToLower(TrimLeftZeros(log.Topics[1][26:]))
-	to := "Q" + strings.ToLower(TrimLeftZeros(log.Topics[2][26:]))
+	// Extract addresses from topics (32-byte padded, take last 40 hex chars)
+	from := "Q" + strings.ToLower(log.Topics[1][26:])
+	to := "Q" + strings.ToLower(log.Topics[2][26:])
 
 	// Validate addresses
 	if !validation.IsValidAddress(from) {

--- a/Zond2mongoDB/rpc/tokenscalls.go
+++ b/Zond2mongoDB/rpc/tokenscalls.go
@@ -40,22 +40,22 @@ const (
 // Transfer event signature: keccak256("Transfer(address,address,uint256)")
 const TransferEventSignature = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
 
-// CallContractMethod makes a zond_call to a contract method and returns the result
+// CallContractMethod makes a qrl_call to a contract method and returns the result
 func CallContractMethod(contractAddress string, methodSig string) (string, error) {
 	zap.L().Debug("Calling contract method",
 		zap.String("contractAddress", contractAddress),
 		zap.String("methodSig", methodSig[:10]+"...")) // Log just the beginning of the signature for brevity
 
-	// Ensure contract address has Z prefix for Zond RPC
+	// Ensure contract address has Q prefix for QRL RPC
 	if strings.HasPrefix(contractAddress, "0x") {
-		contractAddress = "Z" + contractAddress[2:]
-	} else if !strings.HasPrefix(contractAddress, "Z") {
-		contractAddress = "Z" + contractAddress
+		contractAddress = "Q" + contractAddress[2:]
+	} else if !strings.HasPrefix(contractAddress, "Q") {
+		contractAddress = "Q" + contractAddress
 	}
 
 	group := models.JsonRPC{
 		Jsonrpc: "2.0",
-		Method:  "zond_call",
+		Method:  "qrl_call",
 		Params: []interface{}{
 			map[string]string{
 				"to":   contractAddress,
@@ -78,7 +78,7 @@ func CallContractMethod(contractAddress string, methodSig string) (string, error
 	nodeUrl := os.Getenv("NODE_URL")
 	zap.L().Debug("Sending RPC request",
 		zap.String("url", nodeUrl),
-		zap.String("method", "zond_call"))
+		zap.String("method", "qrl_call"))
 
 	req, err := http.NewRequest("POST", nodeUrl, bytes.NewBuffer(b))
 	if err != nil {
@@ -328,8 +328,8 @@ func GetTokenBalance(contractAddress string, holderAddress string) (string, erro
 
 	// Special handling for zero address (common in mint events)
 	// Handle multiple formats of zero address
-	if holderAddress == "Z0" ||
-		holderAddress == "Z0000000000000000000000000000000000000000" ||
+	if holderAddress == "Q0" ||
+		holderAddress == "Q0000000000000000000000000000000000000000" ||
 		holderAddress == "0x0" ||
 		holderAddress == "0x0000000000000000000000000000000000000000" {
 		zap.L().Info("Zero address detected, returning zero balance",
@@ -338,24 +338,24 @@ func GetTokenBalance(contractAddress string, holderAddress string) (string, erro
 		return "0", nil
 	}
 
-	// Ensure contract address has Z prefix for Zond RPC
+	// Ensure contract address has Q prefix for QRL RPC
 	if strings.HasPrefix(contractAddress, "0x") {
-		contractAddress = "Z" + contractAddress[2:]
-	} else if !strings.HasPrefix(contractAddress, "Z") {
-		contractAddress = "Z" + contractAddress
+		contractAddress = "Q" + contractAddress[2:]
+	} else if !strings.HasPrefix(contractAddress, "Q") {
+		contractAddress = "Q" + contractAddress
 	}
 
-	// Ensure holder address has Z prefix for RPC
+	// Ensure holder address has Q prefix for RPC
 	originalHolderAddress := holderAddress // Keep original for logging
 
 	if strings.HasPrefix(holderAddress, "0x") {
-		holderAddress = "Z" + holderAddress[2:]
-	} else if !strings.HasPrefix(holderAddress, "Z") {
-		holderAddress = "Z" + holderAddress
+		holderAddress = "Q" + holderAddress[2:]
+	} else if !strings.HasPrefix(holderAddress, "Q") {
+		holderAddress = "Q" + holderAddress
 	}
 
 	// Extract the raw address (without prefix) for padding
-	rawAddress := strings.TrimPrefix(holderAddress, "Z")
+	rawAddress := strings.TrimPrefix(holderAddress, "Q")
 
 	// Pad address to 32 bytes (64 hex chars) for ABI encoding
 	paddedAddress := rawAddress
@@ -434,8 +434,8 @@ func DecodeTransferEvent(data string) (string, string, string) {
 			return "", "", ""
 		}
 
-		// Extract recipient address (remove leading zeros), canonical Z-prefix form
-		recipient := "Z" + strings.ToLower(TrimLeftZeros(data[34:74]))
+		// Extract recipient address (remove leading zeros), canonical Q-prefix form
+		recipient := "Q" + strings.ToLower(TrimLeftZeros(data[34:74]))
 		if len(recipient) != 41 { // Check if it's a valid address length (Z + 40 hex chars)
 			return "", "", ""
 		}
@@ -461,7 +461,7 @@ func GetTransactionReceipt(txHash string) (*models.TransactionReceipt, error) {
 
 	group := models.JsonRPC{
 		Jsonrpc: "2.0",
-		Method:  "zond_getTransactionReceipt",
+		Method:  "qrl_getTransactionReceipt",
 		Params:  []interface{}{txHash},
 		ID:      1,
 	}
@@ -549,11 +549,11 @@ func IsValidRecipient(recipient string) bool {
 }
 
 // ParseTransferEvent parses a transfer event log.
-// Addresses are returned in canonical Z-prefix form.
+// Addresses are returned in canonical Q-prefix form.
 func ParseTransferEvent(log models.Log) (string, string, *big.Int, error) {
 	// Extract addresses from topics (32-byte padded, strip leading zeros)
-	from := "Z" + strings.ToLower(TrimLeftZeros(log.Topics[1][26:]))
-	to := "Z" + strings.ToLower(TrimLeftZeros(log.Topics[2][26:]))
+	from := "Q" + strings.ToLower(TrimLeftZeros(log.Topics[1][26:]))
+	to := "Q" + strings.ToLower(TrimLeftZeros(log.Topics[2][26:]))
 
 	// Validate addresses
 	if !validation.IsValidAddress(from) {
@@ -615,9 +615,9 @@ func GetCustomTokenInfo(contractAddress string) (map[string]string, error) {
 	if err == nil && owner != "" && owner != "0x" && len(owner) >= 42 {
 		// Extract address - typically format is 0x + 32 bytes (64 chars) with address in last 20 bytes
 		if len(owner) >= 66 {
-			// Extract the address from the last 40 characters (20 bytes), canonical Z-prefix
+			// Extract the address from the last 40 characters (20 bytes), canonical Q-prefix
 			addressHex := strings.ToLower(owner[len(owner)-40:])
-			result["tokenOwner"] = "Z" + addressHex
+			result["tokenOwner"] = "Q" + addressHex
 		}
 	}
 

--- a/Zond2mongoDB/scripts/reindex_contracts.py
+++ b/Zond2mongoDB/scripts/reindex_contracts.py
@@ -51,11 +51,11 @@ def make_rpc_call(method, params):
 
 def get_contract_code(address):
     """Get contract bytecode from the node."""
-    return make_rpc_call("zond_getCode", [address, "latest"])
+    return make_rpc_call("qrl_getCode", [address, "latest"])
 
 def get_transaction_receipt(tx_hash):
     """Get transaction receipt from the node."""
-    return make_rpc_call("zond_getTransactionReceipt", [tx_hash])
+    return make_rpc_call("qrl_getTransactionReceipt", [tx_hash])
 
 def call_contract_method(contract_address, method_signature):
     """Call a contract method using eth_call."""
@@ -63,7 +63,7 @@ def call_contract_method(contract_address, method_signature):
         "to": contract_address,
         "data": method_signature
     }
-    return make_rpc_call("zond_call", [data, "latest"])
+    return make_rpc_call("qrl_call", [data, "latest"])
 
 def get_token_info(contract_address):
     """Get ERC20 token information from a contract."""
@@ -144,7 +144,7 @@ def process_contract_creation(transfer_doc, contracts_collection):
         return False
         
     contract_address = receipt['contractAddress'].lower()  # Store as lowercase hex
-    creator_address = ("Z" + transfer_doc['from'].hex() if isinstance(transfer_doc['from'], bytes) else transfer_doc['from']).lower()
+    creator_address = ("Q" + transfer_doc['from'].hex() if isinstance(transfer_doc['from'], bytes) else transfer_doc['from']).lower()
     
     # Get contract code
     contract_code = get_contract_code(contract_address)
@@ -233,9 +233,9 @@ def main():
             
             # Convert bytes to hex strings if needed
             if isinstance(contract_address, bytes):
-                contract_address = "Z" + contract_address.hex()
+                contract_address = "Q" + contract_address.hex()
             if isinstance(creator_address, bytes):
-                creator_address = "Z" + creator_address.hex()
+                creator_address = "Q" + creator_address.hex()
                 
             contract_address = contract_address.lower()
             creator_address = creator_address.lower()

--- a/Zond2mongoDB/scripts/reindex_tokens.py
+++ b/Zond2mongoDB/scripts/reindex_tokens.py
@@ -65,7 +65,7 @@ def get_token_balance(contract_address, holder_address):
     """Get token balance for a specific address."""
     # balanceOf(address) signature
     method_sig = "0x70a08231000000000000000000000000" + holder_address[2:].lower().zfill(40)
-    result = make_rpc_call("zond_call", [{
+    result = make_rpc_call("qrl_call", [{
         "to": contract_address,
         "data": method_sig
     }, "latest"])
@@ -76,7 +76,7 @@ def get_token_balance(contract_address, holder_address):
 
 def get_logs(contract_address, from_block, to_block):
     """Get Transfer event logs for a contract."""
-    return make_rpc_call("zond_getLogs", [{
+    return make_rpc_call("qrl_getLogs", [{
         "address": contract_address,
         "topics": [TRANSFER_EVENT_SIGNATURE],
         "fromBlock": hex(from_block),
@@ -92,14 +92,14 @@ def process_transfer_logs(logs, contract_address, token_balances_collection, tok
             continue
         
         try:
-            from_addr = 'Z' + topics[1][-40:]  # Remove padding
-            to_addr = 'Z' + topics[2][-40:]  # Remove padding
+            from_addr = 'Q' + topics[1][-40:]  # Remove padding
+            to_addr = 'Q' + topics[2][-40:]  # Remove padding
             amount = int(log.get('data', '0x0'), 16)
             block_number = log.get('blockNumber')
             tx_hash = log.get('transactionHash')
             
             # Get block timestamp
-            block = make_rpc_call("zond_getBlockByNumber", [block_number, False])
+            block = make_rpc_call("qrl_getBlockByNumber", [block_number, False])
             if not block:
                 logger.error(f"Could not get block {block_number}")
                 continue
@@ -130,7 +130,7 @@ def process_transfer_logs(logs, contract_address, token_balances_collection, tok
                     logger.error(f"Failed to store transfer {tx_hash}: {e}")
             
             # Update balances as strings to avoid integer overflow
-            if from_addr != '0x0000000000000000000000000000000000000000' and from_addr != 'Z0000000000000000000000000000000000000000':
+            if from_addr != '0x0000000000000000000000000000000000000000' and from_addr != 'Q0000000000000000000000000000000000000000':
                 # Get current balance
                 current_from_balance_doc = token_balances_collection.find_one(
                     {'contractAddress': contract_address, 'holderAddress': from_addr}
@@ -155,7 +155,7 @@ def process_transfer_logs(logs, contract_address, token_balances_collection, tok
                     upsert=True
                 )
             
-            if to_addr != '0x0000000000000000000000000000000000000000' and to_addr != 'Z0000000000000000000000000000000000000000':
+            if to_addr != '0x0000000000000000000000000000000000000000' and to_addr != 'Q0000000000000000000000000000000000000000':
                 # Get current balance
                 current_to_balance_doc = token_balances_collection.find_one(
                     {'contractAddress': contract_address, 'holderAddress': to_addr}
@@ -206,8 +206,8 @@ def get_last_processed_block(token_balances_collection, contract_address):
 
 # Helper function to validate address format
 def is_valid_address(address):
-    # Check for Z-prefix format
-    if address.startswith('Z'):
+    # Check for Q-prefix format
+    if address.startswith('Q'):
         # Check if the rest is valid hex
         try:
             int(address[1:], 16)
@@ -266,7 +266,7 @@ def update_missing_creation_blocks(contracts_collection):
             tx_hash = contract['creationTransaction']
             try:
                 # Get transaction receipt to find the block number
-                receipt = make_rpc_call("zond_getTransactionReceipt", [tx_hash])
+                receipt = make_rpc_call("qrl_getTransactionReceipt", [tx_hash])
                 if receipt and receipt.get('blockNumber'):
                     block_number = receipt['blockNumber']
                     
@@ -319,7 +319,7 @@ def main():
     
     # Get latest block number
     logger.info("\nGetting latest block number...")
-    latest_block = int(make_rpc_call("zond_blockNumber", []), 16)
+    latest_block = int(make_rpc_call("qrl_blockNumber", []), 16)
     logger.info(f"Latest block: {latest_block}")
     
     for i, contract in enumerate(token_contracts, 1):

--- a/Zond2mongoDB/services/validator_service.go
+++ b/Zond2mongoDB/services/validator_service.go
@@ -142,19 +142,20 @@ func storeValidatorHistoryFromDB(epoch string, currentEpochInt int64) error {
 		}
 	}
 
-	record := &models.ValidatorHistoryRecord{
-		Epoch:           epoch,
-		Timestamp:       time.Now().Unix(),
-		ValidatorsCount: int(totalCount),
-		ActiveCount:     activeCount,
-		PendingCount:    pendingCount,
-		ExitedCount:     exitedCount,
-		SlashedCount:    slashedCount,
-		TotalStaked:     totalStaked.String(),
+	record := bson.M{
+		"epoch":           epoch,
+		"epochInt":        currentEpochInt,
+		"timestamp":       time.Now().Unix(),
+		"validatorsCount": int(totalCount),
+		"activeCount":     activeCount,
+		"pendingCount":    pendingCount,
+		"exitedCount":     exitedCount,
+		"slashedCount":    slashedCount,
+		"totalStaked":     totalStaked.String(),
 	}
 
 	opts := options.Update().SetUpsert(true)
-	filter := bson.M{"epoch": record.Epoch}
+	filter := bson.M{"epoch": epoch}
 	update := bson.M{"$set": record}
 
 	_, err = configs.ValidatorHistoryCollections.UpdateOne(ctx, filter, update, opts)
@@ -163,8 +164,8 @@ func storeValidatorHistoryFromDB(epoch string, currentEpochInt int64) error {
 	}
 
 	configs.Logger.Debug("Stored validator history",
-		zap.String("epoch", record.Epoch),
-		zap.Int("validatorsCount", record.ValidatorsCount))
+		zap.String("epoch", epoch),
+		zap.Int("validatorsCount", int(totalCount)))
 	return nil
 }
 
@@ -270,6 +271,145 @@ func StoreEpochInfo(chainHead *models.BeaconChainHeadResponse) error {
 	configs.Logger.Debug("Stored epoch info",
 		zap.String("headEpoch", epochInfo.HeadEpoch),
 		zap.String("headSlot", epochInfo.HeadSlot))
+	return nil
+}
+
+// BackfillValidatorHistory fills in missing epoch records in validator_history.
+// currentEpoch is the current epoch number derived from the latest block.
+// Since all validators on this chain have been active since genesis with unchanged
+// balances, we use the current validator state for all past epochs and compute
+// timestamps from genesis time + epoch duration.
+func BackfillValidatorHistory(currentEpoch int64) error {
+	if currentEpoch <= 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const slotsPerEpoch = 128
+	const secondsPerSlot = 60
+	const epochDuration = int64(slotsPerEpoch * secondsPerSlot) // 7680s
+
+	// Find which epochs already have records
+	cursor, err := configs.ValidatorHistoryCollections.Find(ctx, bson.M{},
+		options.Find().SetProjection(bson.M{"epoch": 1}))
+	if err != nil {
+		return fmt.Errorf("query existing history: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	existingEpochs := make(map[string]bool)
+	for cursor.Next(ctx) {
+		var rec struct {
+			Epoch string `bson:"epoch"`
+		}
+		if err := cursor.Decode(&rec); err == nil {
+			existingEpochs[rec.Epoch] = true
+		}
+	}
+
+	// If all epochs exist, nothing to do
+	if int64(len(existingEpochs)) >= currentEpoch {
+		configs.Logger.Debug("Validator history is complete, no backfill needed",
+			zap.Int64("currentEpoch", currentEpoch),
+			zap.Int("existingRecords", len(existingEpochs)))
+		return nil
+	}
+
+	// Get current validator data
+	totalCount, err := configs.ValidatorsCollections.CountDocuments(ctx, bson.M{})
+	if err != nil || totalCount == 0 {
+		return fmt.Errorf("no validators to backfill from: %w", err)
+	}
+
+	valCursor, err := configs.ValidatorsCollections.Find(ctx, bson.M{},
+		options.Find().SetProjection(bson.M{
+			"slashed": 1, "activationEpoch": 1, "exitEpoch": 1, "effectiveBalance": 1,
+		}))
+	if err != nil {
+		return fmt.Errorf("find validators for backfill: %w", err)
+	}
+	defer valCursor.Close(ctx)
+
+	var docs []models.ValidatorDocument
+	if err := valCursor.All(ctx, &docs); err != nil {
+		return fmt.Errorf("decode validators for backfill: %w", err)
+	}
+
+	// Get genesis time from block 0
+	var block0 struct {
+		Result struct {
+			Timestamp string `bson:"timestamp"`
+		} `bson:"result"`
+	}
+	err = configs.BlocksCollections.FindOne(ctx, bson.M{"blockNumberInt": int64(0)}).Decode(&block0)
+	genesisTime := int64(0)
+	if err == nil && block0.Result.Timestamp != "" {
+		genesisTime, _ = strconv.ParseInt(block0.Result.Timestamp, 0, 64)
+	}
+	if genesisTime == 0 {
+		genesisTime = time.Now().Unix() - currentEpoch*epochDuration
+	}
+
+	// Build batch of missing epoch records
+	writeModels := make([]mongo.WriteModel, 0)
+	for epoch := int64(0); epoch < currentEpoch; epoch++ {
+		epochStr := strconv.FormatInt(epoch, 10)
+		if existingEpochs[epochStr] {
+			continue
+		}
+
+		var activeCount, pendingCount, exitedCount, slashedCount int
+		totalStaked := big.NewInt(0)
+		for _, d := range docs {
+			status := models.GetValidatorStatus(d.ActivationEpoch, d.ExitEpoch, d.Slashed, epoch)
+			switch status {
+			case "active":
+				activeCount++
+			case "pending":
+				pendingCount++
+			case "exited":
+				exitedCount++
+			case "slashed":
+				slashedCount++
+			}
+			if balance, ok := new(big.Int).SetString(d.EffectiveBalance, 10); ok {
+				totalStaked.Add(totalStaked, balance)
+			}
+		}
+
+		doc := bson.M{
+			"epoch":           epochStr,
+			"epochInt":        epoch,
+			"timestamp":       genesisTime + epoch*epochDuration,
+			"validatorsCount": int(totalCount),
+			"activeCount":     activeCount,
+			"pendingCount":    pendingCount,
+			"exitedCount":     exitedCount,
+			"slashedCount":    slashedCount,
+			"totalStaked":     totalStaked.String(),
+		}
+
+		filter := bson.M{"epoch": epochStr}
+		update := bson.M{"$set": doc}
+		writeModels = append(writeModels, mongo.NewUpdateOneModel().
+			SetFilter(filter).SetUpdate(update).SetUpsert(true))
+	}
+
+	if len(writeModels) == 0 {
+		return nil
+	}
+
+	result, err := configs.ValidatorHistoryCollections.BulkWrite(ctx, writeModels, options.BulkWrite().SetOrdered(false))
+	if err != nil {
+		return fmt.Errorf("bulk write backfill: %w", err)
+	}
+
+	configs.Logger.Info("Backfilled validator history",
+		zap.Int64("upserted", result.UpsertedCount),
+		zap.Int64("modified", result.ModifiedCount),
+		zap.Int64("currentEpoch", currentEpoch))
 	return nil
 }
 

--- a/Zond2mongoDB/services/validator_service.go
+++ b/Zond2mongoDB/services/validator_service.go
@@ -349,7 +349,28 @@ func BackfillValidatorHistory(currentEpoch int64) error {
 		genesisTime, _ = strconv.ParseInt(block0.Result.Timestamp, 0, 64)
 	}
 	if genesisTime == 0 {
-		genesisTime = time.Now().Unix() - currentEpoch*epochDuration
+		return fmt.Errorf("cannot backfill: block 0 not yet synced, genesis timestamp unavailable")
+	}
+
+	// Pre-parse validator balances to avoid repeated string→BigInt parsing in the loop
+	type parsedValidator struct {
+		ActivationEpoch string
+		ExitEpoch       string
+		Slashed         bool
+		Balance         *big.Int
+	}
+	parsed := make([]parsedValidator, 0, len(docs))
+	for _, d := range docs {
+		bal := big.NewInt(0)
+		if b, ok := new(big.Int).SetString(d.EffectiveBalance, 10); ok {
+			bal = b
+		}
+		parsed = append(parsed, parsedValidator{
+			ActivationEpoch: d.ActivationEpoch,
+			ExitEpoch:       d.ExitEpoch,
+			Slashed:         d.Slashed,
+			Balance:         bal,
+		})
 	}
 
 	// Build batch of missing epoch records
@@ -362,8 +383,8 @@ func BackfillValidatorHistory(currentEpoch int64) error {
 
 		var activeCount, pendingCount, exitedCount, slashedCount int
 		totalStaked := big.NewInt(0)
-		for _, d := range docs {
-			status := models.GetValidatorStatus(d.ActivationEpoch, d.ExitEpoch, d.Slashed, epoch)
+		for _, v := range parsed {
+			status := models.GetValidatorStatus(v.ActivationEpoch, v.ExitEpoch, v.Slashed, epoch)
 			switch status {
 			case "active":
 				activeCount++
@@ -374,9 +395,7 @@ func BackfillValidatorHistory(currentEpoch int64) error {
 			case "slashed":
 				slashedCount++
 			}
-			if balance, ok := new(big.Int).SetString(d.EffectiveBalance, 10); ok {
-				totalStaked.Add(totalStaked, balance)
-			}
+			totalStaked.Add(totalStaked, v.Balance)
 		}
 
 		doc := bson.M{

--- a/Zond2mongoDB/synchroniser/periodic_tasks.go
+++ b/Zond2mongoDB/synchroniser/periodic_tasks.go
@@ -388,6 +388,12 @@ func syncValidators() error {
 		return err
 	}
 
+	// Backfill any missing epoch history records
+	currentEpochInt, _ := strconv.ParseInt(currentEpoch, 10, 64)
+	if err := services.BackfillValidatorHistory(currentEpochInt); err != nil {
+		configs.Logger.Warn("Failed to backfill validator history", zap.Error(err))
+	}
+
 	configs.Logger.Info("Successfully synced validators", zap.String("epoch", currentEpoch))
 	return nil
 }

--- a/Zond2mongoDB/validation/hex.go
+++ b/Zond2mongoDB/validation/hex.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 )
 
-// hasZPrefix reports whether s begins with 'Z' or 'z'.
-func hasZPrefix(s string) bool {
-	return len(s) > 0 && (s[0] == 'Z' || s[0] == 'z')
+// hasQPrefix reports whether s begins with 'Q' or 'q'.
+func hasQPrefix(s string) bool {
+	return len(s) > 0 && (s[0] == 'Q' || s[0] == 'q')
 }
 
 // hasHexPrefix reports whether s begins with "0x" or "0X".
@@ -16,7 +16,7 @@ func hasHexPrefix(s string) bool {
 }
 
 const (
-	AddressLength = 40 // Length of address without prefix (0x or Z)
+	AddressLength = 40 // Length of address without prefix (0x or Q)
 	HashLength    = 64 // Length of transaction/block hash without 0x prefix
 )
 
@@ -35,18 +35,18 @@ func IsValidHexString(hex string) bool {
 	return true
 }
 
-// IsValidAddress checks if a string is a valid Zond address
-// Supports both legacy 0x format and new Z format (case-insensitive Z prefix)
+// IsValidAddress checks if a string is a valid QRL address
+// Supports both legacy 0x format and new Q format (case-insensitive Q prefix)
 func IsValidAddress(address string) bool {
-	// Check for new Z-prefix format (uppercase or lowercase)
-	if hasZPrefix(address) {
+	// Check for new Q-prefix format (uppercase or lowercase)
+	if hasQPrefix(address) {
 		// Validate the rest of the address is hex
 		for _, c := range address[1:] {
 			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
 				return false
 			}
 		}
-		return len(address) == AddressLength+1 // +1 for "Z" or "z" prefix
+		return len(address) == AddressLength+1 // +1 for "Q" or "q" prefix
 	}
 
 	// Check for legacy 0x format
@@ -87,7 +87,7 @@ func ValidateHexString(hex string, expectedLength int) error {
 }
 
 // ValidateAddress validates an address string and returns an error if invalid
-// Supports both legacy 0x format and new Z format
+// Supports both legacy 0x format and new Q format
 func ValidateAddress(address string) error {
 	if !IsValidAddress(address) {
 		return fmt.Errorf("invalid address format: %s", address)
@@ -103,32 +103,32 @@ func StripHexPrefix(hex string) string {
 	return hex
 }
 
-// StripAddressPrefix removes "0x", "Z", or "z" prefix if present
+// StripAddressPrefix removes "0x", "Q", or "q" prefix if present
 func StripAddressPrefix(address string) string {
 	if hasHexPrefix(address) {
 		return address[2:]
 	}
-	if hasZPrefix(address) {
+	if hasQPrefix(address) {
 		return address[1:]
 	}
 	return address
 }
 
-// ConvertToZAddress converts any address format to canonical Z-prefix form.
-// The canonical storage format is "Z" + lowercase hex.
-// Returns empty string for empty input to avoid producing bare "Z".
-func ConvertToZAddress(address string) string {
+// ConvertToQAddress converts any address format to canonical Q-prefix form.
+// The canonical storage format is "Q" + lowercase hex.
+// Returns empty string for empty input to avoid producing bare "Q".
+func ConvertToQAddress(address string) string {
 	if address == "" {
 		return ""
 	}
 
-	if hasZPrefix(address) {
-		return "Z" + strings.ToLower(address[1:])
+	if hasQPrefix(address) {
+		return "Q" + strings.ToLower(address[1:])
 	}
 
 	if hasHexPrefix(address) {
-		return "Z" + strings.ToLower(address[2:])
+		return "Q" + strings.ToLower(address[2:])
 	}
 
-	return "Z" + strings.ToLower(address)
+	return "Q" + strings.ToLower(address)
 }

--- a/backendAPI/db/address.go
+++ b/backendAPI/db/address.go
@@ -26,7 +26,7 @@ func ReturnSingleAddress(query string) (models.Address, error) {
 	var result models.Address
 	defer cancel()
 
-	// Normalize address to canonical Z-prefix form
+	// Normalize address to canonical Q-prefix form
 	addressHex := normalizeAddress(query)
 
 	// Try to find existing address
@@ -95,7 +95,7 @@ func ReturnRankAddress(address string) (int64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	// Normalize address to canonical Z-prefix form (matches storage format)
+	// Normalize address to canonical Q-prefix form (matches storage format)
 	addressHex := normalizeAddress(address)
 
 	// Look up the target address to get its balance
@@ -121,17 +121,17 @@ func ReturnRankAddress(address string) (int64, error) {
 func GetBalance(address string) (float64, string) {
 	var result models.Balance
 
-	// Ensure address has Z prefix for RPC calls
+	// Ensure address has Q prefix for RPC calls
 	rpcAddress := address
 	if strings.HasPrefix(rpcAddress, "0x") {
-		rpcAddress = "Z" + rpcAddress[2:]
-	} else if !strings.HasPrefix(rpcAddress, "Z") {
-		rpcAddress = "Z" + rpcAddress
+		rpcAddress = "Q" + rpcAddress[2:]
+	} else if !strings.HasPrefix(rpcAddress, "Q") {
+		rpcAddress = "Q" + rpcAddress
 	}
 
 	group := models.JsonRPC{
 		Jsonrpc: "2.0",
-		Method:  "zond_getBalance",
+		Method:  "qrl_getBalance",
 		Params:  []interface{}{rpcAddress, "latest"},
 		ID:      1,
 	}

--- a/backendAPI/db/contract.go
+++ b/backendAPI/db/contract.go
@@ -30,10 +30,10 @@ func ReturnContracts(page int64, limit int64, search string, isTokenFilter *bool
 
 	// Add search if provided, using correct field names
 	if search != "" {
-		// Normalize the search address to canonical Z-prefix form
+		// Normalize the search address to canonical Q-prefix form
 		normalizedSearch := normalizeAddress(search)
 
-		// Zond addresses start with 'Z'. Search by normalized address or token name.
+		// Zond addresses start with 'Q'. Search by normalized address or token name.
 		searchFilter := bson.D{
 			{Key: "$or", Value: bson.A{
 				bson.D{{Key: "address", Value: normalizedSearch}},        // Match contract address
@@ -87,7 +87,7 @@ func ReturnContractCode(address string) (models.ContractInfo, error) {
 
 	var result models.ContractInfo
 
-	// Normalize address to canonical Z-prefix form
+	// Normalize address to canonical Q-prefix form
 	normalizedAddr := normalizeAddress(address)
 
 	// Query for contract code

--- a/backendAPI/db/token.go
+++ b/backendAPI/db/token.go
@@ -18,7 +18,7 @@ func GetTokenBalancesByAddress(address string) ([]models.TokenBalance, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	// Normalize address to canonical Z-prefix form
+	// Normalize address to canonical Q-prefix form
 	searchAddresses := normalizeAddressBoth(address)
 
 	collection := configs.GetCollection(configs.DB, "tokenBalances")
@@ -108,19 +108,19 @@ func GetTokenBalancesByAddress(address string) ([]models.TokenBalance, error) {
 	return results, nil
 }
 
-// normalizeAddress converts any address format to the canonical Z-prefix
-// form that the syncer stores in MongoDB (uppercase Z + lowercase hex).
+// normalizeAddress converts any address format to the canonical Q-prefix
+// form that the syncer stores in MongoDB (uppercase Q + lowercase hex).
 func normalizeAddress(address string) string {
 	if strings.HasPrefix(address, "0x") || strings.HasPrefix(address, "0X") {
-		return "Z" + strings.ToLower(address[2:])
+		return "Q" + strings.ToLower(address[2:])
 	}
-	if strings.HasPrefix(address, "Z") || strings.HasPrefix(address, "z") {
-		return "Z" + strings.ToLower(address[1:])
+	if strings.HasPrefix(address, "Q") || strings.HasPrefix(address, "q") {
+		return "Q" + strings.ToLower(address[1:])
 	}
-	return "Z" + strings.ToLower(address)
+	return "Q" + strings.ToLower(address)
 }
 
-// normalizeAddressBoth returns the canonical Z-prefix address as a slice.
+// normalizeAddressBoth returns the canonical Q-prefix address as a slice.
 // The slice form is kept so callers using "$in" can remain unchanged.
 func normalizeAddressBoth(address string) []string {
 	return []string{normalizeAddress(address)}

--- a/backendAPI/db/transaction.go
+++ b/backendAPI/db/transaction.go
@@ -67,7 +67,7 @@ func ReturnAllInternalTransactionsByAddress(address string) ([]models.TraceResul
 
 	var transactions []models.TraceResult
 
-	// Normalize to canonical Z-prefix format used by the syncer.
+	// Normalize to canonical Q-prefix format used by the syncer.
 	normalizedAddress := normalizeAddress(address)
 
 	filter := primitive.D{{Key: "$or", Value: []primitive.D{
@@ -128,7 +128,7 @@ func ReturnAllTransactionsByAddress(address string) ([]models.TransactionByAddre
 
 	var transactions []models.TransactionByAddress
 
-	// Normalize to the canonical Z-prefix form stored by the syncer.
+	// Normalize to the canonical Q-prefix form stored by the syncer.
 	normalizedAddress := normalizeAddress(address)
 	filter := primitive.D{{Key: "$or", Value: []primitive.D{
 		{{Key: "from", Value: normalizedAddress}},
@@ -260,8 +260,8 @@ func ReturnTransactions(address string, page, limit int) ([]models.TransactionBy
 		opts.SetLimit(int64(limit))
 	}
 
-	// Normalize address to handle both uppercase and lowercase Z prefix
-	normalizedAddress := strings.TrimPrefix(strings.TrimPrefix(address, "Z"), "z")
+	// Normalize address to handle both uppercase and lowercase Q prefix
+	normalizedAddress := strings.TrimPrefix(strings.TrimPrefix(address, "Q"), "q")
 	decoded, err := hex.DecodeString(normalizedAddress)
 	if err != nil {
 		log.Printf("error decoding address hex: %v", err)
@@ -301,7 +301,7 @@ func CountTransactions(address string) (int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	// Normalize to canonical Z-prefix — matches syncer write format.
+	// Normalize to canonical Q-prefix — matches syncer write format.
 	normalizedAddress := normalizeAddress(address)
 
 	filter := primitive.D{{Key: "$or", Value: []primitive.D{
@@ -503,7 +503,7 @@ func ReturnNonZeroTransactions(address string, page, limit int) ([]models.Transa
 		SetProjection(projection).
 		SetSort(primitive.D{{Key: "timeStamp", Value: -1}})
 
-	// Normalize to canonical Z-prefix form stored by the syncer.
+	// Normalize to canonical Q-prefix form stored by the syncer.
 	normalizedAddress := normalizeAddress(address)
 	filter := bson.M{
 		"$and": []bson.M{

--- a/backendAPI/db/validator.go
+++ b/backendAPI/db/validator.go
@@ -246,6 +246,75 @@ func GetValidatorByID(id string) (*models.ValidatorDetailResponse, error) {
 	}, nil
 }
 
+// GetEpochs returns a paginated list of epochs from validator_history,
+// augmented with finalized/justified status from epoch_info.
+func GetEpochs(page, limit int) (*models.EpochsResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Get current epoch state for finalized/justified status
+	var epochInfo models.EpochInfo
+	err := configs.EpochInfoCollection.FindOne(ctx, bson.M{"_id": "current"}).Decode(&epochInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get epoch info: %v", err)
+	}
+	finalizedEpoch := parseEpoch(epochInfo.FinalizedEpoch)
+	justifiedEpoch := parseEpoch(epochInfo.JustifiedEpoch)
+
+	// Count total epoch records
+	total, err := configs.ValidatorHistoryCollection.CountDocuments(ctx, bson.M{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to count epochs: %v", err)
+	}
+
+	// Query with pagination, sorted newest first
+	skip := int64((page - 1) * limit)
+	findOpts := options.Find().
+		SetSort(bson.D{{Key: "epoch", Value: -1}}).
+		SetSkip(skip).
+		SetLimit(int64(limit))
+
+	cursor, err := configs.ValidatorHistoryCollection.Find(ctx, bson.M{}, findOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query epochs: %v", err)
+	}
+	defer cursor.Close(ctx)
+
+	var records []models.ValidatorHistoryRecord
+	if err := cursor.All(ctx, &records); err != nil {
+		return nil, fmt.Errorf("failed to decode epochs: %v", err)
+	}
+
+	epochs := make([]models.EpochListItem, 0, len(records))
+	for _, r := range records {
+		epochNum := parseEpoch(r.Epoch)
+		var status string
+		if epochNum <= finalizedEpoch {
+			status = "finalized"
+		} else if epochNum <= justifiedEpoch {
+			status = "justified"
+		} else {
+			status = "pending"
+		}
+
+		epochs = append(epochs, models.EpochListItem{
+			Epoch:           r.Epoch,
+			Timestamp:       r.Timestamp,
+			Status:          status,
+			ValidatorsCount: r.ValidatorsCount,
+			ActiveCount:     r.ActiveCount,
+			TotalStaked:     r.TotalStaked,
+		})
+	}
+
+	return &models.EpochsResponse{
+		Epochs:         epochs,
+		Total:          total,
+		FinalizedEpoch: epochInfo.FinalizedEpoch,
+		JustifiedEpoch: epochInfo.JustifiedEpoch,
+	}, nil
+}
+
 // GetValidatorStats returns aggregated validator statistics using a MongoDB aggregation
 // pipeline instead of loading all validators into Go memory.
 func GetValidatorStats() (*models.ValidatorStatsResponse, error) {

--- a/backendAPI/db/validator.go
+++ b/backendAPI/db/validator.go
@@ -267,10 +267,10 @@ func GetEpochs(page, limit int) (*models.EpochsResponse, error) {
 		return nil, fmt.Errorf("failed to count epochs: %v", err)
 	}
 
-	// Query with pagination, sorted newest first
+	// Query with pagination, sorted newest first by numeric epoch
 	skip := int64((page - 1) * limit)
 	findOpts := options.Find().
-		SetSort(bson.D{{Key: "epoch", Value: -1}}).
+		SetSort(bson.D{{Key: "epochInt", Value: -1}}).
 		SetSkip(skip).
 		SetLimit(int64(limit))
 

--- a/backendAPI/db/validator.go
+++ b/backendAPI/db/validator.go
@@ -315,6 +315,128 @@ func GetEpochs(page, limit int) (*models.EpochsResponse, error) {
 	}, nil
 }
 
+// GetEpochDetail returns full epoch information including all slots (proposed/missed).
+func GetEpochDetail(epochId string) (*models.EpochDetailResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	epochNum, err := strconv.ParseInt(epochId, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid epoch number: %v", err)
+	}
+
+	startSlot := epochNum * SlotsPerEpoch
+	endSlot := (epochNum + 1) * SlotsPerEpoch
+
+	// Get epoch_info for chain head status
+	var epochInfo models.EpochInfo
+	err = configs.EpochInfoCollection.FindOne(ctx, bson.M{"_id": "current"}).Decode(&epochInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get epoch info: %v", err)
+	}
+
+	headEpoch := parseEpoch(epochInfo.HeadEpoch)
+	if epochNum > headEpoch {
+		return nil, fmt.Errorf("epoch %d has not yet occurred (head: %d)", epochNum, headEpoch)
+	}
+
+	finalizedEpoch := parseEpoch(epochInfo.FinalizedEpoch)
+	justifiedEpoch := parseEpoch(epochInfo.JustifiedEpoch)
+
+	var status string
+	if epochNum <= finalizedEpoch {
+		status = "finalized"
+	} else if epochNum <= justifiedEpoch {
+		status = "justified"
+	} else {
+		status = "pending"
+	}
+
+	// Get validator_history record (may not exist for very recent epochs)
+	var historyRecord models.ValidatorHistoryRecord
+	_ = configs.ValidatorHistoryCollection.FindOne(ctx, bson.M{"epoch": epochId}).Decode(&historyRecord)
+
+	// Get blocks in this epoch's slot range
+	blockFilter := bson.M{
+		"blockNumberInt": bson.M{"$gte": startSlot, "$lt": endSlot},
+	}
+	projection := bson.D{
+		{Key: "blockNumberInt", Value: 1},
+		{Key: "result.number", Value: 1},
+		{Key: "result.timestamp", Value: 1},
+		{Key: "result.miner", Value: 1},
+		{Key: "result.transactions", Value: 1},
+		{Key: "result.gasUsed", Value: 1},
+		{Key: "result.hash", Value: 1},
+	}
+	findOpts := options.Find().
+		SetProjection(projection).
+		SetSort(bson.D{{Key: "blockNumberInt", Value: 1}})
+
+	cursor, err := configs.BlocksCollection.Find(ctx, blockFilter, findOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query blocks: %v", err)
+	}
+	defer cursor.Close(ctx)
+
+	blockMap := make(map[int64]models.EpochDetailBlock)
+	for cursor.Next(ctx) {
+		var doc struct {
+			BlockNumberInt int64        `bson:"blockNumberInt"`
+			Result         models.Result `bson:"result"`
+		}
+		if err := cursor.Decode(&doc); err != nil {
+			continue
+		}
+		blockMap[doc.BlockNumberInt] = models.EpochDetailBlock{
+			Slot:         doc.BlockNumberInt,
+			Status:       "proposed",
+			Timestamp:    doc.Result.Timestamp,
+			Proposer:     doc.Result.Miner,
+			Transactions: len(doc.Result.Transactions),
+			GasUsed:      doc.Result.GasUsed,
+			BlockHash:    doc.Result.Hash,
+		}
+	}
+
+	// Build full 128-slot list
+	blocks := make([]models.EpochDetailBlock, 0, SlotsPerEpoch)
+	proposedCount := 0
+	missedCount := 0
+	for slot := startSlot; slot < endSlot; slot++ {
+		if b, ok := blockMap[slot]; ok {
+			blocks = append(blocks, b)
+			proposedCount++
+		} else {
+			blocks = append(blocks, models.EpochDetailBlock{
+				Slot:   slot,
+				Status: "missed",
+			})
+			missedCount++
+		}
+	}
+
+	return &models.EpochDetailResponse{
+		Epoch:           epochId,
+		Timestamp:       historyRecord.Timestamp,
+		Status:          status,
+		ValidatorsCount: historyRecord.ValidatorsCount,
+		ActiveCount:     historyRecord.ActiveCount,
+		PendingCount:    historyRecord.PendingCount,
+		ExitedCount:     historyRecord.ExitedCount,
+		SlashedCount:    historyRecord.SlashedCount,
+		TotalStaked:     historyRecord.TotalStaked,
+		StartSlot:       startSlot,
+		EndSlot:         endSlot,
+		Blocks:          blocks,
+		FinalizedEpoch:  epochInfo.FinalizedEpoch,
+		JustifiedEpoch:  epochInfo.JustifiedEpoch,
+		HeadEpoch:       epochInfo.HeadEpoch,
+		ProposedCount:   proposedCount,
+		MissedCount:     missedCount,
+	}, nil
+}
+
 // GetValidatorStats returns aggregated validator statistics using a MongoDB aggregation
 // pipeline instead of loading all validators into Go memory.
 func GetValidatorStats() (*models.ValidatorStatsResponse, error) {

--- a/backendAPI/db/validator.go
+++ b/backendAPI/db/validator.go
@@ -81,8 +81,10 @@ func ReturnValidators(pageToken string) (*models.ValidatorResponse, error) {
 	}
 
 	return &models.ValidatorResponse{
-		Validators:  validators,
-		TotalStaked: fmt.Sprintf("%d", totalStaked),
+		Validators:     validators,
+		ValidatorCount: len(validators),
+		Epoch:          fmt.Sprintf("%d", currentEpoch),
+		TotalStaked:    fmt.Sprintf("%d", totalStaked),
 	}, nil
 }
 

--- a/backendAPI/models/validator.go
+++ b/backendAPI/models/validator.go
@@ -45,8 +45,10 @@ type ValidatorRecord struct {
 
 // ValidatorResponse represents the API response format
 type ValidatorResponse struct {
-	Validators  []Validator `json:"validators"`
-	TotalStaked string      `json:"totalStaked"` // Total amount staked in hex
+	Validators     []Validator `json:"validators"`
+	ValidatorCount int         `json:"validatorCount"`
+	Epoch          string      `json:"epoch"`
+	TotalStaked    string      `json:"totalStaked"`
 }
 
 // Validator represents a single validator in the API response

--- a/backendAPI/models/validator.go
+++ b/backendAPI/models/validator.go
@@ -130,3 +130,21 @@ type ValidatorStatsResponse struct {
 	TotalStaked     string `json:"totalStaked"`
 	CurrentEpoch    string `json:"currentEpoch"`
 }
+
+// EpochListItem represents a single epoch in the paginated listing
+type EpochListItem struct {
+	Epoch           string `json:"epoch"`
+	Timestamp       int64  `json:"timestamp"`
+	Status          string `json:"status"` // finalized, justified, pending
+	ValidatorsCount int    `json:"validatorsCount"`
+	ActiveCount     int    `json:"activeCount"`
+	TotalStaked     string `json:"totalStaked"`
+}
+
+// EpochsResponse represents the paginated epochs API response
+type EpochsResponse struct {
+	Epochs         []EpochListItem `json:"epochs"`
+	Total          int64           `json:"total"`
+	FinalizedEpoch string          `json:"finalizedEpoch"`
+	JustifiedEpoch string          `json:"justifiedEpoch"`
+}

--- a/backendAPI/models/validator.go
+++ b/backendAPI/models/validator.go
@@ -131,6 +131,38 @@ type ValidatorStatsResponse struct {
 	CurrentEpoch    string `json:"currentEpoch"`
 }
 
+// EpochDetailBlock represents a single slot within an epoch detail view
+type EpochDetailBlock struct {
+	Slot         int64  `json:"slot"`
+	Status       string `json:"status"` // proposed or missed
+	Timestamp    string `json:"timestamp,omitempty"`
+	Proposer     string `json:"proposer,omitempty"`
+	Transactions int    `json:"transactions"`
+	GasUsed      string `json:"gasUsed,omitempty"`
+	BlockHash    string `json:"blockHash,omitempty"`
+}
+
+// EpochDetailResponse represents the full epoch detail API response
+type EpochDetailResponse struct {
+	Epoch           string             `json:"epoch"`
+	Timestamp       int64              `json:"timestamp"`
+	Status          string             `json:"status"`
+	ValidatorsCount int                `json:"validatorsCount"`
+	ActiveCount     int                `json:"activeCount"`
+	PendingCount    int                `json:"pendingCount"`
+	ExitedCount     int                `json:"exitedCount"`
+	SlashedCount    int                `json:"slashedCount"`
+	TotalStaked     string             `json:"totalStaked"`
+	StartSlot       int64              `json:"startSlot"`
+	EndSlot         int64              `json:"endSlot"`
+	Blocks          []EpochDetailBlock `json:"blocks"`
+	FinalizedEpoch  string             `json:"finalizedEpoch"`
+	JustifiedEpoch  string             `json:"justifiedEpoch"`
+	HeadEpoch       string             `json:"headEpoch"`
+	ProposedCount   int                `json:"proposedCount"`
+	MissedCount     int                `json:"missedCount"`
+}
+
 // EpochListItem represents a single epoch in the paginated listing
 type EpochListItem struct {
 	Epoch           string `json:"epoch"`

--- a/backendAPI/models/zond.go
+++ b/backendAPI/models/zond.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	"math/big"
-
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -13,10 +11,10 @@ type ZondDatabaseBlock struct {
 }
 
 type Withdrawal struct {
-	Index          string   `json:"index"`
-	ValidatorIndex string   `json:"validatorIndex"`
-	Address        string   `json:"address"`
-	Amount         *big.Int `json:"amount"`
+	Index          string `json:"index"`
+	ValidatorIndex string `json:"validatorIndex"`
+	Address        string `json:"address"`
+	Amount         string `json:"amount"`
 }
 
 type Transaction struct {
@@ -85,16 +83,11 @@ type ResultOld struct {
 	Timestamp        string        `json:"timestamp"`
 	Transactions     []Transaction `json:"transactions"`
 	TransactionsRoot string        `json:"transactionsRoot"`
-	Difficulty       string        `json:"difficulty"`
 	ExtraData        string        `json:"extraData"`
 	LogsBloom        string        `json:"logsBloom"`
 	Miner            string        `json:"miner"`
-	MixHash          string        `json:"mixHash"`
-	Nonce            string        `json:"nonce"`
-	Sha3Uncles       string        `json:"sha3Uncles"`
 	Size             string        `json:"size"`
-	TotalDifficulty  string        `json:"totalDifficulty"`
-	Uncles           []interface{} `json:"uncles"`
+	PrevRandao       string        `json:"prevRandao"`
 	Withdrawals      []Withdrawal  `json:"withdrawals"`
 	WithdrawalsRoot  string        `json:"withdrawalsRoot"`
 }
@@ -111,16 +104,11 @@ type Result struct {
 	Timestamp        string        `json:"timestamp"`
 	Transactions     []Transaction `json:"transactions"`
 	TransactionsRoot string        `json:"transactionsRoot"`
-	Difficulty       string        `json:"difficulty"`
 	ExtraData        string        `json:"extraData"`
 	LogsBloom        string        `json:"logsBloom"`
 	Miner            string        `json:"miner"`
-	MixHash          string        `json:"mixHash"`
-	Nonce            string        `json:"nonce"`
-	Sha3Uncles       string        `json:"sha3Uncles"`
 	Size             string        `json:"size"`
-	TotalDifficulty  string        `json:"totalDifficulty"`
-	Uncles           []interface{} `json:"uncles"`
+	PrevRandao       string        `json:"prevRandao"`
 	Withdrawals      []Withdrawal  `json:"withdrawals"`
 	WithdrawalsRoot  string        `json:"withdrawalsRoot"`
 }

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -538,6 +538,23 @@ func UserRoute(router *gin.Engine) {
 		c.JSON(http.StatusOK, validatorResponse)
 	})
 
+	// Get epoch detail by ID
+	router.GET("/epoch/:id", func(c *gin.Context) {
+		epochId := c.Param("id")
+		epochDetail, err := db.GetEpochDetail(epochId)
+		if err != nil {
+			if strings.Contains(err.Error(), "not yet occurred") || strings.Contains(err.Error(), "invalid epoch") {
+				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": fmt.Sprintf("Failed to fetch epoch detail: %v", err),
+			})
+			return
+		}
+		c.JSON(http.StatusOK, epochDetail)
+	})
+
 	// Get current epoch information
 	router.GET("/epoch", func(c *gin.Context) {
 		epochInfo, err := db.GetEpochInfo()

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -506,6 +506,25 @@ func UserRoute(router *gin.Engine) {
 		c.JSON(http.StatusOK, gin.H{"response": query})
 	})
 
+	// Paginated epochs listing
+	router.GET("/epochs", func(c *gin.Context) {
+		page, limit := getPaginationParams(c, 1, 15)
+
+		result, err := db.GetEpochs(page, limit)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": fmt.Sprintf("Failed to fetch epochs: %v", err),
+			})
+			return
+		}
+
+		if result.Epochs == nil {
+			result.Epochs = make([]models.EpochListItem, 0)
+		}
+
+		c.JSON(http.StatusOK, result)
+	})
+
 	router.GET("/validators", func(c *gin.Context) {
 		pageToken := c.Query("page_token")
 		validatorResponse, err := db.ReturnValidators(pageToken)

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -302,7 +302,7 @@ func UserRoute(router *gin.Engine) {
 
 	router.GET("/address/aggregate/:query", func(c *gin.Context) {
 		param := c.Param("query")
-		// db functions normalize the address to canonical lowercase z-prefix internally.
+		// db functions normalize the address to canonical q-prefix internally.
 
 		// Single Address data
 		addressData, err := db.ReturnSingleAddress(param)
@@ -599,7 +599,7 @@ func UserRoute(router *gin.Engine) {
 			return
 		}
 
-		// Addresses are stored and returned as lowercase z-prefix (canonical form).
+		// Addresses are stored and returned as q-prefix (canonical form).
 		// No presentation-layer conversion needed.
 
 		c.JSON(http.StatusOK, gin.H{

--- a/docs/backend-api.md
+++ b/docs/backend-api.md
@@ -22,7 +22,7 @@ Comprehensive documentation for the ZondScan backend API server -- a Go + Gin RE
                                     │   http://localhost:8545   │
                                     └────────────┬─────────────┘
                                                  │
-                                    (zond_getBalance calls)
+                                    (qrl_getBalance calls)
                                                  │
 ┌──────────────┐    REST API     ┌───────────────▼──────────────┐     Reads      ┌───────────────┐
 │  Frontend    │◀───────────────▶│     backendAPI (Go + Gin)    │◀──────────────▶│   MongoDB     │
@@ -244,8 +244,8 @@ Paginated network-wide transactions list.
     {
       "InOut": 0,
       "TxType": "transfer",
-      "From": "Z2019ea...",
-      "To": "Z5a330c...",
+      "From": "Q2019ea...",
+      "To": "Q5a330c...",
       "TxHash": "0xabc...",
       "TimeStamp": "1706123456",
       "Amount": "1.500000000000000000",
@@ -272,8 +272,8 @@ Single transaction by hash.
   "response": {
     "blockNumber": "0x1a4",
     "blockTimestamp": "0x65abc123",
-    "from": "Z2019ea...",
-    "to": "Z5a330c...",
+    "from": "Q2019ea...",
+    "to": "Q5a330c...",
     "txHash": "0xabc...",
     "value": "0x1bc16d674ec80000",
     "gasUsed": "0x5208",
@@ -284,16 +284,16 @@ Single transaction by hash.
   },
   "latestBlock": 420,
   "contractCreated": {
-    "address": "Z5a330c...",
+    "address": "Q5a330c...",
     "isToken": true,
     "name": "MyToken",
     "symbol": "MTK",
     "decimals": 18
   },
   "tokenTransfer": {
-    "contractAddress": "Z5a330c...",
-    "from": "Z2019ea...",
-    "to": "Zaaabbb...",
+    "contractAddress": "Q5a330c...",
+    "from": "Q2019ea...",
+    "to": "Qaaabbb...",
     "amount": "1000000000000000000",
     "tokenName": "MyToken",
     "tokenSymbol": "MTK",
@@ -343,13 +343,13 @@ Coinbase transaction lookup (uses the same `ReturnSingleTransfer` function as `/
 #### `GET /address/aggregate/:query`
 Aggregated address data: balance, rank, transactions, internal transactions, and contract code.
 
-**Path Parameter:** Address with `Z` prefix (e.g., `Z2019ea08f4e24201b98f9154906da4b924a04892`)
+**Path Parameter:** Address with `Q` prefix (e.g., `Q2019ea08f4e24201b98f9154906da4b924a04892`)
 
 **Response:**
 ```json
 {
   "address": {
-    "id": "z2019ea08f4e24201b98f9154906da4b924a04892",
+    "id": "q2019ea08f4e24201b98f9154906da4b924a04892",
     "balance": 100.5,
     "nonce": 42
   },
@@ -359,8 +359,8 @@ Aggregated address data: balance, rank, transactions, internal transactions, and
     {
       "InOut": 0,
       "TxType": "transfer",
-      "From": "Z2019ea...",
-      "To": "Z5a330c...",
+      "From": "Q2019ea...",
+      "To": "Q5a330c...",
       "TxHash": "0xabc...",
       "TimeStamp": "1706123456",
       "Amount": "1.500000000000000000",
@@ -370,8 +370,8 @@ Aggregated address data: balance, rank, transactions, internal transactions, and
   ],
   "internal_transactions_by_address": [...],
   "contract_code": {
-    "address": "Z2019ea...",
-    "creatorAddress": "Z5a330c...",
+    "address": "Q2019ea...",
+    "creatorAddress": "Q5a330c...",
     "contractCode": "0x606060...",
     "isToken": false
   },
@@ -380,8 +380,8 @@ Aggregated address data: balance, rank, transactions, internal transactions, and
 ```
 
 **Notes:**
-- Normalizes `z` prefix to `Z` on input.
-- If the address is not found in the `addresses` collection, it queries the Zond node RPC (`zond_getBalance`) and creates a new entry.
+- Normalizes `q` prefix to `Q` on input.
+- If the address is not found in the `addresses` collection, it queries the Zond node RPC (`qrl_getBalance`) and creates a new entry.
 - Transaction queries use case-insensitive regex matching.
 - Internal transactions query the `internalTransactionByAddress` collection using hex-decoded byte-level matching.
 
@@ -412,11 +412,11 @@ All ERC20 token balances held by an address. Designed for wallet integration (e.
 **Response:**
 ```json
 {
-  "address": "Z2019ea...",
+  "address": "Q2019ea...",
   "tokens": [
     {
-      "contractAddress": "Z5a330c...",
-      "holderAddress": "Z2019ea...",
+      "contractAddress": "Q5a330c...",
+      "holderAddress": "Q2019ea...",
       "balance": "1000000000000000000",
       "blockNumber": "0x1a4",
       "name": "MyToken",
@@ -431,14 +431,14 @@ All ERC20 token balances held by an address. Designed for wallet integration (e.
 **Notes:**
 - Uses MongoDB aggregation pipeline with `$lookup` to join `tokenBalances` with `contractCode` for metadata.
 - Sorted by balance descending (highest value tokens first).
-- Searches both `Z` and `z` prefix variants of the address.
+- Searches both `Q` and `q` prefix variants of the address.
 
 #### `POST /getBalance`
 Get balance for an address directly from the Zond node RPC.
 
 **Request Body (form-encoded):**
 ```
-address=Z2019ea08f4e24201b98f9154906da4b924a04892
+address=Q2019ea08f4e24201b98f9154906da4b924a04892
 ```
 
 **Response:**
@@ -446,7 +446,7 @@ address=Z2019ea08f4e24201b98f9154906da4b924a04892
 { "balance": 100.5 }
 ```
 
-**Notes:** Makes a live `zond_getBalance` RPC call to the Zond node. Balance is returned in QRL (divided by 1e18 from wei).
+**Notes:** Makes a live `qrl_getBalance` RPC call to the Zond node. Balance is returned in QRL (divided by 1e18 from wei).
 
 #### `GET /walletdistribution/:query`
 Count wallets with balance greater than the specified threshold (in units of 1e12 wei).
@@ -465,7 +465,7 @@ Top 50 addresses by balance.
 ```json
 {
   "richlist": [
-    { "id": "z2019ea...", "balance": 1000000.5, "nonce": 100 }
+    { "id": "q2019ea...", "balance": 1000000.5, "nonce": 100 }
   ]
 }
 ```
@@ -490,8 +490,8 @@ Paginated list of deployed smart contracts.
 {
   "response": [
     {
-      "address": "Z5a330c...",
-      "creatorAddress": "Z2019ea...",
+      "address": "Q5a330c...",
+      "creatorAddress": "Q2019ea...",
       "contractCode": "0x606060...",
       "creationTransaction": "0xabc...",
       "creationBlockNumber": "0x1a4",
@@ -509,7 +509,7 @@ Paginated list of deployed smart contracts.
 
 **Notes:**
 - Search is case-insensitive.
-- Addresses in the response are normalized to uppercase `Z` prefix.
+- Addresses in the response are normalized to uppercase `Q` prefix.
 - Sorted by `_id` descending (latest first).
 
 ---
@@ -522,14 +522,14 @@ Summary information about a specific ERC20 token.
 **Response:**
 ```json
 {
-  "contractAddress": "Z5a330c...",
+  "contractAddress": "Q5a330c...",
   "name": "MyToken",
   "symbol": "MTK",
   "decimals": 18,
   "totalSupply": "1000000000000000000000",
   "holderCount": 42,
   "transferCount": 150,
-  "creatorAddress": "Z2019ea...",
+  "creatorAddress": "Q2019ea...",
   "creationTxHash": "0xabc...",
   "creationBlock": "0x1a4"
 }
@@ -547,11 +547,11 @@ Paginated token holder list sorted by balance descending.
 **Response:**
 ```json
 {
-  "contractAddress": "Z5a330c...",
+  "contractAddress": "Q5a330c...",
   "holders": [
     {
-      "contractAddress": "Z5a330c...",
-      "holderAddress": "Z2019ea...",
+      "contractAddress": "Q5a330c...",
+      "holderAddress": "Q2019ea...",
       "balance": "500000000000000000000"
     }
   ],
@@ -575,12 +575,12 @@ Paginated token transfer history.
 **Response:**
 ```json
 {
-  "contractAddress": "Z5a330c...",
+  "contractAddress": "Q5a330c...",
   "transfers": [
     {
-      "contractAddress": "Z5a330c...",
-      "from": "Z2019ea...",
-      "to": "Zaaabbb...",
+      "contractAddress": "Q5a330c...",
+      "from": "Q2019ea...",
+      "to": "Qaaabbb...",
       "amount": "1000000000000000000",
       "blockNumber": "0x1a4",
       "txHash": "0xabc...",
@@ -735,8 +735,8 @@ Paginated list of pending (mempool) transactions.
   "transactions": [
     {
       "hash": "0xabc...",
-      "from": "Z2019ea...",
-      "to": "Z5a330c...",
+      "from": "Q2019ea...",
+      "to": "Q5a330c...",
       "value": "0x1bc16d674ec80000",
       "gas": "0x5208",
       "gasPrice": "0x3b9aca00",
@@ -784,7 +784,7 @@ All collections are in the `qrldata-z` database. Collection references are initi
 
 | Collection | Purpose | Key Query Patterns |
 |------------|---------|-------------------|
-| `contractCode` | Smart contract deployments & token metadata | Find by `address` (both Z/z prefix); search by `name` regex; filter by `isToken` |
+| `contractCode` | Smart contract deployments & token metadata | Find by `address` (both Q/q prefix); search by `name` regex; filter by `isToken` |
 | `tokenBalances` | Token holder balances per contract | Find by `holderAddress` or `contractAddress` (both prefix variants); aggregation with `$lookup` to `contractCode` |
 | `tokenTransfers` | ERC20 transfer events | Find by `contractAddress` or `txHash`; sorted by `blockNumber` desc |
 
@@ -835,7 +835,7 @@ On startup, `initializeCollections()` creates default documents (via `$setOnInse
 ```go
 type Address struct {
     ObjectId primitive.ObjectID `bson:"_id"`
-    ID       string             `json:"id"`       // Lowercase hex with z prefix
+    ID       string             `json:"id"`       // Lowercase hex with q prefix
     Balance  float64            `json:"balance"`   // QRL units (not wei)
     Nonce    uint64             `json:"nonce"`
 }
@@ -1038,7 +1038,7 @@ type PendingTransaction struct {
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `MONGOURI` | Yes | -- | MongoDB connection string (e.g., `mongodb://localhost:27017`) |
-| `NODE_URL` | No | `http://127.0.0.1:8545` | Zond node RPC endpoint (used for `zond_getBalance`) |
+| `NODE_URL` | No | `http://127.0.0.1:8545` | Zond node RPC endpoint (used for `qrl_getBalance`) |
 | `APP_ENV` | No | `development` | Environment mode. Set to `production` for HTTPS. |
 | `HTTP_PORT` | No | `:8080` | HTTP listen port (development mode) |
 | `HTTPS_PORT` | No* | -- | HTTPS listen port (production mode; required if `APP_ENV=production`) |
@@ -1127,13 +1127,13 @@ MONGOURI=mongodb://localhost:27017 \
 
 ### Address Normalization
 
-QRL Zond addresses use a `Z` prefix (instead of Ethereum's `0x`). The codebase handles multiple address formats:
+QRL Zond addresses use a `Q` prefix (instead of Ethereum's `0x`). The codebase handles multiple address formats:
 
-- **Storage in MongoDB:** Most addresses are stored with lowercase `z` prefix by the synchronizer.
-- **API input:** Accepts both `Z` and `z` prefixes. Routes normalize `z` to `Z` on input.
-- **Database queries:** Use both variants via `normalizeAddressBoth()` which returns `["z...", "Z..."]`.
+- **Storage in MongoDB:** Most addresses are stored with lowercase `q` prefix by the synchronizer.
+- **API input:** Accepts both `Q` and `q` prefixes. Routes normalize `q` to `Q` on input.
+- **Database queries:** Use both variants via `normalizeAddressBoth()` which returns `["q...", "Q..."]`.
 - **Case-insensitive matching:** Transaction lookups use MongoDB regex with the `i` option.
-- **RPC calls:** `GetBalance` ensures uppercase `Z` prefix for Zond node RPC.
+- **RPC calls:** `GetBalance` ensures uppercase `Q` prefix for Zond node RPC.
 
 ### Pagination Patterns
 

--- a/docs/db-syncer.md
+++ b/docs/db-syncer.md
@@ -102,7 +102,7 @@ The `Sync()` function performs the initial catch-up:
 
 2. **Store initial sync start**: Records `0x1` in `sync_initial_state` collection (used later for token processing range).
 
-3. **Get chain head**: Calls `zond_blockNumber` to get the latest block on the network (with retry up to 5 times with exponential backoff).
+3. **Get chain head**: Calls `qrl_blockNumber` to get the latest block on the network (with retry up to 5 times with exponential backoff).
 
 4. **Batch processing**: Uses a producer/consumer pattern to process blocks in parallel:
    - Batch size: **64** blocks (normal) or **128** blocks (when >1000 blocks behind)
@@ -229,12 +229,12 @@ Stores complete block data as fetched from the Zond node.
       {
         "blockHash": "0x...",
         "blockNumber": "0x1a",
-        "from": "Z...",
+        "from": "Q...",
         "gas": "0x...",
         "gasPrice": "0x...",
         "hash": "0x...",
         "nonce": "0x...",
-        "to": "Z...",
+        "to": "Q...",
         "transactionIndex": "0x0",
         "type": "0x0",
         "value": "0x...",
@@ -299,8 +299,8 @@ Internal transactions from `debug_traceTransaction` calls.
 | `type` | string | Transaction type (e.g., "CALL") |
 | `callType` | string | Call type (e.g., "delegatecall") |
 | `hash` | string | Transaction hash |
-| `from` | string | Internal caller (lowercase, Z-prefix) |
-| `to` | string | Internal callee (lowercase, Z-prefix) |
+| `from` | string | Internal caller (lowercase, Q-prefix) |
+| `to` | string | Internal callee (lowercase, Q-prefix) |
 | `input` | string | Input data (hex) |
 | `output` | string | Output data (hex) |
 | `traceAddress` | []int | Trace position |
@@ -580,14 +580,14 @@ All calls go through a shared HTTP client with connection pooling (100 max idle 
 
 | RPC Method | File | Purpose |
 |------------|------|---------|
-| `zond_blockNumber` | `rpc/calls.go` | Get latest block number |
-| `zond_getBlockByNumber` | `rpc/calls.go` | Fetch full block with transactions (`true` for full tx objects) |
-| `zond_getTransactionReceipt` | `rpc/calls.go`, `rpc/tokenscalls.go` | Get tx receipt (contract address, status, logs) |
-| `zond_getBalance` | `rpc/calls.go` | Get address balance |
-| `zond_getCode` | `rpc/calls.go` | Get contract bytecode |
-| `zond_call` | `rpc/calls.go`, `rpc/tokenscalls.go` | Call contract method (read-only) |
-| `zond_getLogs` | `rpc/calls.go` | Get event logs for a block (Transfer events) |
-| `zond_getTransactionByHash` | `rpc/calls.go` | Get transaction details by hash |
+| `qrl_blockNumber` | `rpc/calls.go` | Get latest block number |
+| `qrl_getBlockByNumber` | `rpc/calls.go` | Fetch full block with transactions (`true` for full tx objects) |
+| `qrl_getTransactionReceipt` | `rpc/calls.go`, `rpc/tokenscalls.go` | Get tx receipt (contract address, status, logs) |
+| `qrl_getBalance` | `rpc/calls.go` | Get address balance |
+| `qrl_getCode` | `rpc/calls.go` | Get contract bytecode |
+| `qrl_call` | `rpc/calls.go`, `rpc/tokenscalls.go` | Call contract method (read-only) |
+| `qrl_getLogs` | `rpc/calls.go` | Get event logs for a block (Transfer events) |
+| `qrl_getTransactionByHash` | `rpc/calls.go` | Get transaction details by hash |
 | `debug_traceTransaction` | `rpc/calls.go` | Trace internal calls (callTracer) |
 | `txpool_content` | `rpc/pending.go` | Get mempool pending/queued transactions |
 
@@ -595,8 +595,8 @@ All calls go through a shared HTTP client with connection pooling (100 max idle 
 
 | Endpoint | File | Purpose |
 |----------|------|---------|
-| `GET /zond/v1alpha1/validators` | `rpc/calls.go` | Fetch validator list (paginated, up to 3 pages) |
-| `GET /zond/v1alpha1/beacon/chainhead` | `rpc/calls.go` | Get current chain head (epoch, slot, finality) |
+| `GET /qrl/v1alpha1/validators` | `rpc/calls.go` | Fetch validator list (paginated, up to 3 pages) |
+| `GET /qrl/v1alpha1/beacon/chainhead` | `rpc/calls.go` | Get current chain head (epoch, slot, finality) |
 
 ### 4.3 CoinGecko API
 
@@ -606,7 +606,7 @@ All calls go through a shared HTTP client with connection pooling (100 max idle 
 
 ### 4.4 ERC20 Token Method Calls (`rpc/tokenscalls.go`)
 
-These are made via `zond_call` to detect and query ERC20 tokens:
+These are made via `qrl_call` to detect and query ERC20 tokens:
 
 | Method Signature | Function | Purpose |
 |-----------------|----------|---------|
@@ -648,7 +648,7 @@ During `ProcessTransactions()` for each block:
 ### 5.3 Block-Level Token Transfer Processing
 
 `ProcessBlockTokenTransfers()` takes a different approach for bulk processing:
-1. Calls `zond_getLogs` for the block with the Transfer event signature topic filter.
+1. Calls `qrl_getLogs` for the block with the Transfer event signature topic filter.
 2. For each log with 3 topics (standard Transfer event):
    - Extracts the contract address from `log.Address`.
    - Calls `EnsureTokenInDatabase()` to verify/create the token in `contractCode`.
@@ -684,8 +684,8 @@ After the initial block sync completes, `ProcessTokensAfterInitialSync()`:
 ### 6.1 New Contract Detection (`db/contracts.go`)
 
 When a transaction has an empty `to` field (contract creation):
-1. Calls `zond_getTransactionReceipt` to get the deployed contract address and status.
-2. Calls `zond_getCode` to fetch the contract bytecode.
+1. Calls `qrl_getTransactionReceipt` to get the deployed contract address and status.
+2. Calls `qrl_getCode` to fetch the contract bytecode.
 3. Calls `GetTokenInfo()` which sequentially tries `name()`, `symbol()`, and `decimals()`. If all three succeed, the contract is flagged as an ERC20 token.
 4. If it's a token, fetches `totalSupply()`.
 5. Stores everything in the `contractCode` collection via `StoreContract()`.
@@ -694,7 +694,7 @@ When a transaction has an empty `to` field (contract creation):
 
 When a transaction targets an existing address, `IsAddressContract()`:
 1. Checks the `contractCode` collection in MongoDB.
-2. If not found, calls `zond_getCode` via RPC.
+2. If not found, calls `qrl_getCode` via RPC.
 3. If code exists (not `0x` or empty), it's a contract - stores it with token detection.
 
 ### 6.3 Contract Reprocessing (`db/contracts.go`)
@@ -728,9 +728,9 @@ func DetectToken(contractAddress string) TokenDetectionResult {
 
 Every 6 hours (`updateValidatorsPeriodically`):
 
-1. **Get chain head**: `GET /zond/v1alpha1/beacon/chainhead` returns current epoch, slot, and finality info. Stored in the `epoch_info` collection.
+1. **Get chain head**: `GET /qrl/v1alpha1/beacon/chainhead` returns current epoch, slot, and finality info. Stored in the `epoch_info` collection.
 
-2. **Fetch validators**: `GET /zond/v1alpha1/validators` with pagination (up to 3 pages). Each page contains a list of validators with their details.
+2. **Fetch validators**: `GET /qrl/v1alpha1/validators` with pagination (up to 3 pages). Each page contains a list of validators with their details.
 
 3. **Store validators** (`services/validator_service.go`):
    - Converts base64-encoded public keys and withdrawal credentials to hex.
@@ -863,7 +863,7 @@ When a new block is processed (`UpdatePendingTransactionsInBlock`):
 | Constant | Value | Description |
 |----------|-------|-------------|
 | `QUANTA` | 1e18 | Wei-to-QRL divisor |
-| `QRLZeroAddress` | `Z000...000` | Zero address (40 hex chars + Z) |
+| `QRLZeroAddress` | `Q000...000` | Zero address (40 hex chars + Q) |
 | `LOG_FILENAME` | `zond_sync.log` | Log file name (in `logs/` directory) |
 
 ---
@@ -952,7 +952,7 @@ Located in `scripts/`, these Python scripts are used for one-time reindexing ope
 1. Connects to MongoDB and the Zond RPC node.
 2. Queries `transfer` collection for documents with `contractAddress`.
 3. For each contract creation:
-   - Gets the contract bytecode via `zond_getCode`.
+   - Gets the contract bytecode via `qrl_getCode`.
    - Calls `name()`, `symbol()`, `decimals()` to detect ERC20 tokens.
    - Upserts the contract data into `contractCode`.
 
@@ -1031,12 +1031,12 @@ In `processSubsequentBlocks()`:
 
 QRL Zond uses two address formats:
 - **Legacy**: `0x` prefix (standard Ethereum format)
-- **Zond native**: `Z` prefix
+- **Zond native**: `Q` prefix
 
 The synchronizer normalizes addresses:
 - Stored in MongoDB as **lowercase** (via `strings.ToLower()`).
 - The `validation` package handles both formats.
-- `ConvertToZAddress()` converts `0x` to `Z` prefix.
+- `ConvertToQAddress()` converts `0x` to `Q` prefix.
 
 ### 12.6 Hex Number Handling
 


### PR DESCRIPTION
## Summary
- Port all three components (syncer, backend API, frontend) to V2 breaking changes
- RPC namespace `zond_*` → `qrl_*`, beacon API `/zond/v1alpha1/` → `/qrl/v1alpha1/`
- Address prefix `Z` → `Q` across validation, normalization, display, and search
- Block model: remove PoW fields (difficulty, mixHash, nonce, sha3Uncles, totalDifficulty, uncles), add prevRandao
- `Withdrawal.Amount` type: `*big.Int` → `string` (V2 returns hex strings)
- `debug_traceTransaction` gracefully disabled via `ENABLE_DEBUG_TRACE` env var (unavailable on V2)
- `ZondCall` updated: Q-prefix from address, chainId `0x7e7e`
- Update syncer + backend API documentation for V2
- Fix `/validators` endpoint to return `validatorCount` and `epoch` fields
- Gitignore Go binary artifacts

## Test plan
- [x] Syncer builds and syncs against V2 node (`46.225.120.209:8545`)
- [x] Backend API builds and serves V2 data correctly
- [x] Frontend builds and renders explorer pages
- [x] Validator data verified against beacon chain API (512 validators, 20.48M QRL staked)
- [x] All Q-prefix addresses resolve correctly in search and display
- [ ] Send a transaction on V2 testnet and verify end-to-end display