### PR TITLE
feat: redesign homepage with beacon chain explorer UI + epoch pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ backendAPI/backendAPI.log
 backendAPI/backendAPI
 Zond2mongoDB/syncer
 Zond2mongoDB/backendAPI
+backendAPI/handler/main
+ExplorerFrontend/tsconfig.tsbuildinfo

--- a/ExplorerFrontend/app/components/Charts.tsx
+++ b/ExplorerFrontend/app/components/Charts.tsx
@@ -7,7 +7,7 @@ export default function Charts(): JSX.Element {
     <div className="w-full mb-4">
       <div className="bg-[#1e1e1e] border border-[#2a2a2a] rounded-xl overflow-hidden">
         <div className="px-4 py-3 border-b border-[#2a2a2a]">
-          <h2 className="text-sm font-semibold text-white">
+          <h2 className="text-[15px] font-semibold text-[#ffa729]">
             QRL/USDT Chart
           </h2>
         </div>

--- a/ExplorerFrontend/app/components/Charts.tsx
+++ b/ExplorerFrontend/app/components/Charts.tsx
@@ -5,11 +5,13 @@ import TradingViewWidget from './TradingViewWidget';
 export default function Charts(): JSX.Element {
   return (
     <div className="w-full mb-4">
-      <div className="bg-[#1f1f1f] border border-[#3d3d3d] rounded-2xl hover:border-[#ffa729] transition-colors duration-300">
+      <div className="bg-[#1e1e1e] border border-[#2a2a2a] rounded-xl overflow-hidden">
+        <div className="px-4 py-3 border-b border-[#2a2a2a]">
+          <h2 className="text-sm font-semibold text-white">
+            QRL/USDT Chart
+          </h2>
+        </div>
         <div className="p-4">
-          <p className="text-[#ffa729] text-sm sm:text-xl font-bold mb-0">
-            MEXC QRL/USDT Chart
-          </p>
           <div className="h-[400px] mt-2">
             <TradingViewWidget />
           </div>

--- a/ExplorerFrontend/app/components/Sidebar.tsx
+++ b/ExplorerFrontend/app/components/Sidebar.tsx
@@ -33,6 +33,7 @@ const navGroups: NavGroup[] = [
       { name: 'Latest Transactions', description: 'View all Transactions', href: '/transactions/1', imgSrc: PartnerHandshakeIcon },
       { name: 'Pending Transactions', description: 'View pending transactions', href: '/pending/1', imgSrc: PartnerHandshakeIcon },
       { name: 'Latest Blocks', description: 'View all Blocks', href: '/blocks/1', imgSrc: BlockchainIcon },
+      { name: 'Epochs', description: 'View all Epochs', href: '/epochs/1', imgSrc: BlockchainIcon },
       { name: 'Validators', description: 'Network Validators', href: '/validators', imgSrc: ContractIcon },
     ],
   },
@@ -63,6 +64,7 @@ function isActive(pathname: string, href: string): boolean {
   if (basePath !== href && pathname.startsWith(basePath + '/')) return true
   // Match parent paths for detail pages (e.g., /block/123 matches /blocks/1)
   if (href.startsWith('/blocks') && pathname.startsWith('/block/')) return true
+  if (href.startsWith('/epochs') && pathname.startsWith('/epochs/')) return true
   if (href.startsWith('/transactions') && pathname.startsWith('/tx/')) return true
   if (href === '/contracts' && pathname.startsWith('/contracts')) return true
   return false

--- a/ExplorerFrontend/app/epoch/[id]/epoch-detail-client.tsx
+++ b/ExplorerFrontend/app/epoch/[id]/epoch-detail-client.tsx
@@ -1,0 +1,287 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
+import axios from 'axios';
+import config from '../../../config';
+import { formatNumberWithCommas, truncateHash, formatAddress, formatTimestamp } from '../../lib/helpers';
+import SearchBar from '../../components/SearchBar';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface EpochSlot {
+  slot: number;
+  status: string;
+  timestamp?: string;
+  proposer?: string;
+  transactions: number;
+  gasUsed?: string;
+  blockHash?: string;
+}
+
+interface EpochDetail {
+  epoch: string;
+  timestamp: number;
+  status: string;
+  validatorsCount: number;
+  activeCount: number;
+  pendingCount: number;
+  exitedCount: number;
+  slashedCount: number;
+  totalStaked: string;
+  startSlot: number;
+  endSlot: number;
+  blocks: EpochSlot[];
+  finalizedEpoch: string;
+  justifiedEpoch: string;
+  headEpoch: string;
+  proposedCount: number;
+  missedCount: number;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function parseHex(hex: string): number {
+  if (!hex) return 0;
+  if (hex.startsWith('0x')) return parseInt(hex, 16);
+  return parseInt(hex, 10) || 0;
+}
+
+function timeAgo(unixSeconds: number): string {
+  const now = Math.floor(Date.now() / 1000);
+  const diff = now - unixSeconds;
+  if (diff < 0) return 'just now';
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+function formatStaked(gwei: string): string {
+  try {
+    const val = BigInt(gwei || '0');
+    const qrl = val / BigInt(1_000_000_000);
+    return formatNumberWithCommas(qrl.toString()) + ' QRL';
+  } catch {
+    return '0 QRL';
+  }
+}
+
+function formatGasUsed(hex: string): string {
+  const val = parseHex(hex);
+  return formatNumberWithCommas(val.toString());
+}
+
+// ── Status Badge ─────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    finalized: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+    justified: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
+    pending: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/20',
+    proposed: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+    missed: 'bg-red-500/15 text-red-400 border-red-500/20',
+  };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium border ${styles[status] || styles.pending}`}>
+      {status.charAt(0).toUpperCase() + status.slice(1)}
+    </span>
+  );
+}
+
+// ── Summary Row ──────────────────────────────────────────────────────────────
+
+function SummaryRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center py-2.5 border-b border-[#2a2a2a] last:border-b-0">
+      <span className="text-gray-500 text-sm w-40 flex-shrink-0 mb-0.5 sm:mb-0">{label}:</span>
+      <span className="text-gray-200 text-sm">{children}</span>
+    </div>
+  );
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export default function EpochDetailClient({ epochId }: { epochId: string }): JSX.Element {
+  const [data, setData] = useState<EpochDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const epochNum = parseInt(epochId);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        setLoading(true);
+        setError(null);
+        const res = await axios.get(`${config.handlerUrl}/epoch/${epochId}`);
+        setData(res.data);
+      } catch (err: any) {
+        setError(err.response?.data?.error || 'Failed to load epoch data');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, [epochId]);
+
+  const headEpoch = data ? parseInt(data.headEpoch) : 0;
+
+  return (
+    <div className="p-4 sm:p-8 max-w-6xl mx-auto">
+      {/* Header with navigation */}
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="flex items-center gap-2 text-xl sm:text-2xl font-bold text-[#ffa729]">
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 sm:h-6 sm:w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          Epoch {formatNumberWithCommas(epochId)}
+        </h1>
+        <div className="flex items-center gap-2">
+          {epochNum > 0 ? (
+            <Link
+              href={`/epoch/${epochNum - 1}`}
+              className="px-3 py-1.5 rounded-lg bg-[#1e1e1e] border border-[#2a2a2a] text-gray-300 text-sm hover:border-[#ffa729] transition-colors"
+            >
+              &larr; Prev
+            </Link>
+          ) : (
+            <span className="px-3 py-1.5 rounded-lg bg-[#1e1e1e] border border-[#2a2a2a] text-gray-600 text-sm cursor-not-allowed">
+              &larr; Prev
+            </span>
+          )}
+          {!loading && epochNum < headEpoch ? (
+            <Link
+              href={`/epoch/${epochNum + 1}`}
+              className="px-3 py-1.5 rounded-lg bg-[#1e1e1e] border border-[#2a2a2a] text-gray-300 text-sm hover:border-[#ffa729] transition-colors"
+            >
+              Next &rarr;
+            </Link>
+          ) : (
+            <span className="px-3 py-1.5 rounded-lg bg-[#1e1e1e] border border-[#2a2a2a] text-gray-600 text-sm cursor-not-allowed">
+              Next &rarr;
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="mb-6">
+        <SearchBar />
+      </div>
+
+      {/* Loading */}
+      {loading && (
+        <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] p-8 text-center">
+          <div className="animate-pulse text-gray-500">Loading epoch data...</div>
+        </div>
+      )}
+
+      {/* Error */}
+      {error && !loading && (
+        <div className="rounded-xl bg-red-900/20 border border-red-800 p-6 text-center">
+          <p className="text-red-400 font-semibold mb-1">Epoch not found</p>
+          <p className="text-gray-400 text-sm">{error}</p>
+        </div>
+      )}
+
+      {/* Content */}
+      {data && !loading && (
+        <>
+          {/* Summary Panel */}
+          <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden mb-6">
+            <div className="px-4 py-3 border-b border-[#2a2a2a]">
+              <h2 className="text-[15px] font-semibold text-[#ffa729]">Epoch Details</h2>
+            </div>
+            <div className="px-4 py-2">
+              <SummaryRow label="Epoch">{formatNumberWithCommas(data.epoch)}</SummaryRow>
+              <SummaryRow label="Status"><StatusBadge status={data.status} /></SummaryRow>
+              <SummaryRow label="Time">
+                {data.timestamp > 0 ? (
+                  <span>
+                    {timeAgo(data.timestamp)}
+                    <span className="text-gray-500 ml-2">({formatTimestamp(data.timestamp)})</span>
+                  </span>
+                ) : '—'}
+              </SummaryRow>
+              <SummaryRow label="Validators">{formatNumberWithCommas(data.validatorsCount.toString())}</SummaryRow>
+              <SummaryRow label="Active">{formatNumberWithCommas(data.activeCount.toString())}</SummaryRow>
+              {data.pendingCount > 0 && <SummaryRow label="Pending">{data.pendingCount}</SummaryRow>}
+              {data.exitedCount > 0 && <SummaryRow label="Exited">{data.exitedCount}</SummaryRow>}
+              {data.slashedCount > 0 && <SummaryRow label="Slashed">{data.slashedCount}</SummaryRow>}
+              <SummaryRow label="Total Staked">{formatStaked(data.totalStaked)}</SummaryRow>
+              <SummaryRow label="Slots">
+                {data.proposedCount + data.missedCount} ({data.proposedCount} Proposed{data.missedCount > 0 ? `, ${data.missedCount} Missed` : ''})
+              </SummaryRow>
+            </div>
+          </div>
+
+          {/* Slots Table */}
+          <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden">
+            <div className="px-4 py-3 border-b border-[#2a2a2a]">
+              <h2 className="text-[15px] font-semibold text-[#ffa729]">Slots</h2>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-[#2a2a2a]">
+                    <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Slot</th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Status</th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Time</th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden sm:table-cell">Proposer</th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Txns</th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden md:table-cell">Gas Used</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.blocks.map((slot) => {
+                    const isProposed = slot.status === 'proposed';
+                    const timestamp = isProposed ? parseHex(slot.timestamp || '0') : 0;
+                    const proposer = isProposed ? formatAddress(slot.proposer || '') : '';
+
+                    return (
+                      <tr
+                        key={slot.slot}
+                        className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
+                      >
+                        <td className="px-4 py-2 tabular-nums">
+                          {isProposed ? (
+                            <Link href={`/block/${slot.slot}`} className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium">
+                              {formatNumberWithCommas(slot.slot.toString())}
+                            </Link>
+                          ) : (
+                            <span className="text-gray-600">{formatNumberWithCommas(slot.slot.toString())}</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-2">
+                          <StatusBadge status={slot.status} />
+                        </td>
+                        <td className="px-4 py-2 text-gray-400 tabular-nums">
+                          {isProposed ? timeAgo(timestamp) : '—'}
+                        </td>
+                        <td className="px-4 py-2 hidden sm:table-cell">
+                          {isProposed && proposer ? (
+                            <Link href={`/address/${proposer}`} className="text-gray-400 hover:text-[#ffa729] hover:underline font-mono text-xs transition-colors">
+                              {truncateHash(proposer, 8, 6)}
+                            </Link>
+                          ) : (
+                            <span className="text-gray-600">—</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-2 text-gray-300 tabular-nums">
+                          {isProposed ? slot.transactions : '—'}
+                        </td>
+                        <td className="px-4 py-2 text-gray-400 tabular-nums hidden md:table-cell">
+                          {isProposed && slot.gasUsed ? formatGasUsed(slot.gasUsed) : '—'}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ExplorerFrontend/app/epoch/[id]/epoch-detail-client.tsx
+++ b/ExplorerFrontend/app/epoch/[id]/epoch-detail-client.tsx
@@ -60,8 +60,11 @@ function timeAgo(unixSeconds: number): string {
 function formatStaked(gwei: string): string {
   try {
     const val = BigInt(gwei || '0');
-    const qrl = val / BigInt(1_000_000_000);
-    return formatNumberWithCommas(qrl.toString()) + ' QRL';
+    const qrlBase = val / BigInt(1_000_000_000);
+    const remainder = val % BigInt(1_000_000_000);
+    const decimalStr = remainder.toString().padStart(9, '0').replace(/0+$/, '');
+    const result = formatNumberWithCommas(qrlBase.toString());
+    return decimalStr.length > 0 ? `${result}.${decimalStr} QRL` : `${result} QRL`;
   } catch {
     return '0 QRL';
   }

--- a/ExplorerFrontend/app/epoch/[id]/page.tsx
+++ b/ExplorerFrontend/app/epoch/[id]/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from 'next';
+import EpochDetailClient from './epoch-detail-client';
+import { sharedMetadata } from '../../lib/seo/metaData';
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
+  const resolvedParams = await params;
+  const epochId = resolvedParams.id;
+
+  return {
+    ...sharedMetadata,
+    title: `Epoch ${epochId} | ZondScan`,
+    description: `View detailed information for epoch ${epochId} on the QRL Zond beacon chain.`,
+    alternates: {
+      ...sharedMetadata.alternates,
+      canonical: `https://zondscan.com/epoch/${epochId}`,
+    },
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title: `Epoch ${epochId} | ZondScan`,
+      description: `View detailed information for epoch ${epochId} on the QRL Zond beacon chain.`,
+      url: `https://zondscan.com/epoch/${epochId}`,
+      siteName: 'ZondScan',
+      type: 'website',
+    },
+  };
+}
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function Page({ params }: PageProps): Promise<JSX.Element> {
+  const resolvedParams = await params;
+  return <EpochDetailClient epochId={resolvedParams.id} />;
+}

--- a/ExplorerFrontend/app/epochs/[query]/epochs-client.tsx
+++ b/ExplorerFrontend/app/epochs/[query]/epochs-client.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import axios from 'axios';
+import config from '../../../config';
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { formatNumberWithCommas } from '../../lib/helpers';
+import SearchBar from '../../components/SearchBar';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface EpochItem {
+  epoch: string;
+  timestamp: number;
+  status: string;
+  validatorsCount: number;
+  activeCount: number;
+  totalStaked: string;
+}
+
+interface EpochsData {
+  epochs: EpochItem[];
+  total: number;
+  finalizedEpoch: string;
+  justifiedEpoch: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const ITEMS_PER_PAGE = 15;
+
+function timeAgo(unixSeconds: number): string {
+  const now = Math.floor(Date.now() / 1000);
+  const diff = now - unixSeconds;
+  if (diff < 0) return 'just now';
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+function formatStaked(gwei: string): string {
+  try {
+    const val = BigInt(gwei);
+    const qrl = val / BigInt(1_000_000_000);
+    return formatNumberWithCommas(qrl.toString()) + ' QRL';
+  } catch {
+    return '0 QRL';
+  }
+}
+
+// ── Status Badge ─────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    finalized: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+    justified: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
+    pending: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/20',
+  };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium border ${styles[status] || styles.pending}`}>
+      {status.charAt(0).toUpperCase() + status.slice(1)}
+    </span>
+  );
+}
+
+// ── Data Fetching ────────────────────────────────────────────────────────────
+
+const fetchEpochs = async (page: string): Promise<EpochsData> => {
+  const response = await axios.get<EpochsData>(`${config.handlerUrl}/epochs?page=${page}&limit=${ITEMS_PER_PAGE}`);
+  return response.data;
+};
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+interface EpochsClientProps {
+  initialData: EpochsData;
+  initialPage: string;
+}
+
+export default function EpochsClient({ initialData, initialPage }: EpochsClientProps): JSX.Element {
+  const router = useRouter();
+  const currentPage = parseInt(initialPage);
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['epochs', initialPage],
+    queryFn: () => fetchEpochs(initialPage),
+    staleTime: 60000,
+    gcTime: 5 * 60 * 1000,
+    retry: 2,
+    initialData,
+  });
+
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / ITEMS_PER_PAGE)) : 1;
+
+  const goToNextPage = (): void => {
+    router.push(`/epochs/${Math.min(currentPage + 1, totalPages)}`);
+  };
+
+  const goToPreviousPage = (): void => {
+    router.push(`/epochs/${Math.max(currentPage - 1, 1)}`);
+  };
+
+  if (isError) {
+    return (
+      <div className="p-4 sm:p-8 max-w-6xl mx-auto">
+        <h1 className="text-xl sm:text-2xl font-bold mb-4 text-[#ffa729]">Epochs</h1>
+        <div className="bg-red-900/50 border border-red-500 text-red-200 px-4 py-3 rounded-xl">
+          <p className="font-bold">Error:</p>
+          <p className="text-sm">{error instanceof Error ? error.message : 'Failed to load epochs'}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 sm:p-8 max-w-6xl mx-auto">
+      <h1 className="flex items-center gap-2 text-xl sm:text-2xl font-bold mb-4 text-[#ffa729]">
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 sm:h-6 sm:w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        Epochs
+      </h1>
+
+      <div className="mb-6">
+        <SearchBar />
+      </div>
+
+      {/* Epochs Table */}
+      <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden mb-6">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[#2a2a2a]">
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Epoch</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Time</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Status</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden sm:table-cell">Validators</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden sm:table-cell">Active</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden md:table-cell">Total Staked</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading ? (
+                Array.from({ length: ITEMS_PER_PAGE }).map((_, i) => (
+                  <tr key={i} className="border-b border-[#2a2a2a] last:border-b-0">
+                    <td className="px-4 py-3"><div className="h-4 w-12 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                    <td className="px-4 py-3"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                    <td className="px-4 py-3"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                    <td className="px-4 py-3 hidden sm:table-cell"><div className="h-4 w-10 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                    <td className="px-4 py-3 hidden sm:table-cell"><div className="h-4 w-10 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                    <td className="px-4 py-3 hidden md:table-cell"><div className="h-4 w-24 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  </tr>
+                ))
+              ) : !data?.epochs?.length ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-12 text-center text-gray-500">
+                    No epoch data available yet. The explorer is still syncing.
+                  </td>
+                </tr>
+              ) : (
+                data.epochs.map((epoch) => (
+                  <tr
+                    key={epoch.epoch}
+                    className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
+                  >
+                    <td className="px-4 py-3">
+                      <Link href="/validators" className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
+                        {formatNumberWithCommas(epoch.epoch)}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3 text-gray-400 tabular-nums">{timeAgo(epoch.timestamp)}</td>
+                    <td className="px-4 py-3">
+                      <StatusBadge status={epoch.status} />
+                    </td>
+                    <td className="px-4 py-3 text-gray-300 tabular-nums hidden sm:table-cell">
+                      {formatNumberWithCommas(epoch.validatorsCount.toString())}
+                    </td>
+                    <td className="px-4 py-3 text-gray-300 tabular-nums hidden sm:table-cell">
+                      {formatNumberWithCommas(epoch.activeCount.toString())}
+                    </td>
+                    <td className="px-4 py-3 text-gray-400 tabular-nums hidden md:table-cell">
+                      {formatStaked(epoch.totalStaked)}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Pagination */}
+      <div className="flex justify-center items-center gap-3 text-sm text-gray-300">
+        <button
+          onClick={goToPreviousPage}
+          disabled={currentPage === 1}
+          className="px-4 py-2 rounded-lg bg-[#1e1e1e] text-gray-300 border border-[#2a2a2a]
+                     hover:border-[#ffa729] disabled:opacity-50 disabled:hover:border-[#2a2a2a]
+                     transition-colors"
+        >
+          Previous
+        </button>
+        <span className="tabular-nums">Page {currentPage} of {totalPages}</span>
+        <button
+          onClick={goToNextPage}
+          disabled={currentPage >= totalPages}
+          className="px-4 py-2 rounded-lg bg-[#1e1e1e] text-gray-300 border border-[#2a2a2a]
+                     hover:border-[#ffa729] disabled:opacity-50 disabled:hover:border-[#2a2a2a]
+                     transition-colors"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ExplorerFrontend/app/epochs/[query]/epochs-client.tsx
+++ b/ExplorerFrontend/app/epochs/[query]/epochs-client.tsx
@@ -43,9 +43,12 @@ function timeAgo(unixSeconds: number): string {
 
 function formatStaked(gwei: string): string {
   try {
-    const val = BigInt(gwei);
-    const qrl = val / BigInt(1_000_000_000);
-    return formatNumberWithCommas(qrl.toString()) + ' QRL';
+    const val = BigInt(gwei || '0');
+    const qrlBase = val / BigInt(1_000_000_000);
+    const remainder = val % BigInt(1_000_000_000);
+    const decimalStr = remainder.toString().padStart(9, '0').replace(/0+$/, '');
+    const result = formatNumberWithCommas(qrlBase.toString());
+    return decimalStr.length > 0 ? `${result}.${decimalStr} QRL` : `${result} QRL`;
   } catch {
     return '0 QRL';
   }

--- a/ExplorerFrontend/app/epochs/[query]/epochs-client.tsx
+++ b/ExplorerFrontend/app/epochs/[query]/epochs-client.tsx
@@ -167,7 +167,7 @@ export default function EpochsClient({ initialData, initialPage }: EpochsClientP
                     className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
                   >
                     <td className="px-4 py-3">
-                      <Link href="/validators" className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
+                      <Link href={`/epoch/${epoch.epoch}`} className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
                         {formatNumberWithCommas(epoch.epoch)}
                       </Link>
                     </td>

--- a/ExplorerFrontend/app/epochs/[query]/page.tsx
+++ b/ExplorerFrontend/app/epochs/[query]/page.tsx
@@ -1,0 +1,77 @@
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import EpochsClient from './epochs-client';
+import config from '../../../config';
+import { sharedMetadata } from '../../lib/seo/metaData';
+
+export const dynamic = 'force-dynamic';
+
+interface EpochsData {
+  epochs: any[];
+  total: number;
+  finalizedEpoch: string;
+  justifiedEpoch: string;
+}
+
+async function getEpochs(page: string): Promise<EpochsData> {
+  try {
+    const response = await fetch(`${config.handlerUrl}/epochs?page=${page}&limit=15`, {
+      method: 'GET',
+      headers: { 'Accept': 'application/json' },
+    });
+
+    if (!response.ok) {
+      if (response.status === 404) notFound();
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    return response.json();
+  } catch (error) {
+    console.error('Error fetching epochs:', error);
+    throw error;
+  }
+}
+
+interface PageProps {
+  params: Promise<{ query: string }>;
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ query: string }> }): Promise<Metadata> {
+  const resolvedParams = await params;
+  const pageNumber = resolvedParams.query || '1';
+
+  return {
+    ...sharedMetadata,
+    title: `Epochs - Page ${pageNumber} | ZondScan`,
+    description: `View epochs on the QRL Zond beacon chain. Page ${pageNumber} of the epochs list.`,
+    alternates: {
+      ...sharedMetadata.alternates,
+      canonical: 'https://zondscan.com/epochs',
+    },
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title: `Epochs - Page ${pageNumber} | ZondScan`,
+      description: `View epochs on the QRL Zond beacon chain. Page ${pageNumber} of the epochs list.`,
+      url: `https://zondscan.com/epochs/${pageNumber}`,
+      siteName: 'ZondScan',
+      type: 'website',
+    },
+    twitter: {
+      ...sharedMetadata.twitter,
+      title: `Epochs - Page ${pageNumber} | ZondScan`,
+      description: `View epochs on the QRL Zond beacon chain. Page ${pageNumber} of the epochs list.`,
+    },
+  };
+}
+
+export default async function EpochsPage({ params }: PageProps): Promise<JSX.Element> {
+  const resolvedParams = await params;
+  const pageNumber = resolvedParams.query || '1';
+  const data = await getEpochs(pageNumber);
+
+  return (
+    <main>
+      <EpochsClient initialData={data} initialPage={pageNumber} />
+    </main>
+  );
+}

--- a/ExplorerFrontend/app/home-client.tsx
+++ b/ExplorerFrontend/app/home-client.tsx
@@ -46,6 +46,7 @@ interface HomeData {
   epochInfo: EpochInfo | null;
   blocks: BlockResult[];
   totalStaked: string;
+  marketCap: number;
   loading: boolean;
   error: boolean;
   dataInitialized: boolean;
@@ -70,6 +71,16 @@ function parseHex(hex: string): number {
   if (!hex) return 0;
   if (hex.startsWith('0x')) return parseInt(hex, 16);
   return parseInt(hex, 10) || 0;
+}
+
+function formatStaked(gwei: string): string {
+  try {
+    const val = BigInt(gwei || '0');
+    const qrlBase = val / BigInt(1_000_000_000);
+    return formatNumberWithCommas(qrlBase.toString()) + ' QRL';
+  } catch {
+    return '0 QRL';
+  }
 }
 
 /** Derive recent epoch rows from epoch info */
@@ -134,6 +145,16 @@ const icons = {
       <path strokeLinecap="round" strokeLinejoin="round" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
     </svg>
   ),
+  staked: (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  ),
+  marketCap: (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+    </svg>
+  ),
 };
 
 // ── Stat Bar ─────────────────────────────────────────────────────────────────
@@ -144,12 +165,14 @@ function StatBar({ data }: { data: HomeData }) {
     { label: 'Slot', value: data.epochInfo ? formatNumberWithCommas(data.epochInfo.headSlot) : '—', icon: icons.slot },
     { label: 'Block Height', value: formatNumberWithCommas(data.blockHeight.toString()), icon: icons.block },
     { label: 'Validators', value: formatNumberWithCommas(data.validatorCount.toString()), icon: icons.validators },
+    { label: 'Staked QRL', value: data.totalStaked !== '0' ? formatStaked(data.totalStaked) : '—', icon: icons.staked },
     { label: 'Transactions', value: formatNumberWithCommas(data.totalTransactions.toString()), icon: icons.transactions },
+    { label: 'Market Cap', value: data.marketCap > 0 ? '$' + formatNumberWithCommas(data.marketCap.toString()) : '—', icon: icons.marketCap },
   ];
 
   return (
     <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden">
-      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5">
+      <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7">
         {stats.map((stat, i) => (
           <div
             key={stat.label}
@@ -366,6 +389,7 @@ export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.El
     epochInfo: null,
     blocks: [],
     totalStaked: '0',
+    marketCap: 0,
     loading: true,
     error: false,
     dataInitialized: false,
@@ -375,12 +399,13 @@ export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.El
     try {
       if (!config.handlerUrl) return;
 
-      const [overviewRes, latestBlockRes, txsRes, epochRes, blocksRes] = await Promise.allSettled([
+      const [overviewRes, latestBlockRes, txsRes, epochRes, blocksRes, epochsRes] = await Promise.allSettled([
         axios.get(config.handlerUrl + '/overview'),
         axios.get(config.handlerUrl + '/latestblock'),
         axios.get(config.handlerUrl + '/txs?page=1'),
         axios.get(config.handlerUrl + '/epoch'),
         axios.get(config.handlerUrl + '/blocks?page=1&limit=10'),
+        axios.get(config.handlerUrl + '/epochs?page=1&limit=1'),
       ]);
 
       setData((prev) => {
@@ -389,6 +414,7 @@ export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.El
         if (overviewRes.status === 'fulfilled') {
           next.validatorCount = overviewRes.value.data.validatorCount || 0;
           next.dataInitialized = overviewRes.value.data.status?.dataInitialized ?? false;
+          next.marketCap = overviewRes.value.data.marketcap || 0;
         }
         if (latestBlockRes.status === 'fulfilled') {
           next.blockHeight = latestBlockRes.value.data.blockNumber || 0;
@@ -401,6 +427,12 @@ export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.El
         }
         if (blocksRes.status === 'fulfilled') {
           next.blocks = blocksRes.value.data.blocks || [];
+        }
+        if (epochsRes.status === 'fulfilled') {
+          const latestEpoch = epochsRes.value.data.epochs?.[0];
+          if (latestEpoch?.totalStaked) {
+            next.totalStaked = latestEpoch.totalStaked;
+          }
         }
 
         return next;

--- a/ExplorerFrontend/app/home-client.tsx
+++ b/ExplorerFrontend/app/home-client.tsx
@@ -2,370 +2,449 @@
 
 import * as React from 'react';
 import dynamic from 'next/dynamic';
-import axios from "axios";
-import { formatNumberWithCommas, toFixed } from "./lib/helpers";
-import config from "../config.js"
-import SearchBar from "./components/SearchBar"
-import SeoTextSection from "./components/SeoTextSection";
+import Link from 'next/link';
+import axios from 'axios';
+import { formatNumberWithCommas, truncateHash, formatAddress } from './lib/helpers';
+import config from '../config.js';
+import SearchBar from './components/SearchBar';
 
-// Lazy load Charts component since it's below the fold and includes heavy TradingView widget
-const Charts = dynamic(() => import("./components/Charts"), {
+const Charts = dynamic(() => import('./components/Charts'), {
   loading: () => (
-    <div className="h-[400px] bg-[#1f1f1f] rounded-2xl border border-[#3d3d3d] animate-pulse flex items-center justify-center">
+    <div className="h-[400px] bg-[#1e1e1e] rounded-xl border border-[#2a2a2a] animate-pulse flex items-center justify-center">
       <span className="text-gray-500">Loading chart...</span>
     </div>
   ),
-  ssr: false // TradingView requires browser APIs
+  ssr: false,
 });
 
-interface StatsData {
-  value: string;
-  isLoading: boolean;
-  error: boolean;
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface EpochInfo {
+  headEpoch: string;
+  headSlot: string;
+  finalizedEpoch: string;
+  justifiedEpoch: string;
+  slotsPerEpoch: number;
+  secondsPerSlot: number;
+  slotInEpoch: number;
+  timeToNextEpoch: number;
+  updatedAt: number;
 }
 
-interface StatItem {
-  data: string;
-  title: string;
+interface BlockResult {
+  number: string;
+  timestamp: string;
+  hash: string;
+  miner: string;
+  transactions: any[];
+}
+
+interface HomeData {
+  blockHeight: number;
+  totalTransactions: number;
+  validatorCount: number;
+  epochInfo: EpochInfo | null;
+  blocks: BlockResult[];
+  totalStaked: string;
   loading: boolean;
   error: boolean;
-  icon: React.ReactNode;
-}
-
-const StatCard = ({ item }: { item: StatItem }): JSX.Element => (
-  <div className={`relative overflow-hidden rounded-2xl
-                 bg-gradient-to-br from-[#2d2d2d]/80 to-[#1f1f1f]/80
-                 border border-[#3d3d3d] shadow-xl
-                 hover:border-[#ffa729] transition-all duration-300
-                 group`}>
-    <div className="relative p-2 sm:p-6 text-center min-h-[90px] sm:min-h-[160px] flex flex-col justify-center">
-      {item.loading ? (
-        <div className="flex flex-col items-center justify-center space-y-2">
-          <div className="w-16 sm:w-32 h-4 sm:h-8 bg-gray-700/50 rounded animate-pulse"></div>
-          <div className="w-12 sm:w-24 h-2 sm:h-4 bg-gray-700/50 rounded animate-pulse"></div>
-        </div>
-      ) : item.error ? (
-        <div className="flex flex-col items-center justify-center text-red-400">
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 sm:h-8 w-4 sm:w-8 mb-1 sm:mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-          <span className="text-xs">Failed to load data</span>
-        </div>
-      ) : (
-        <>
-          <div className="flex justify-center items-center mb-1 sm:mb-2">
-            <div className="h-4 w-4 sm:h-6 sm:w-6 text-[#ffa729] [&>svg]:h-full [&>svg]:w-full">
-              {item.icon}
-            </div>
-          </div>
-          <p className="text-base sm:text-3xl font-bold mb-1 sm:mb-3 text-[#ffa729]
-                      group-hover:scale-110 transition-transform duration-300 break-words">
-            {item.data}
-          </p>
-          <p className="text-[10px] sm:text-sm text-gray-300 font-medium">
-            {item.title}
-          </p>
-        </>
-      )}
-    </div>
-  </div>
-);
-
-interface DashboardData {
-  walletCount: StatsData;
-  volume: StatsData;
-  blockHeight: StatsData;
-  totalTransactions: StatsData;
-  marketCap: StatsData;
-  currentPrice: StatsData;
-  validatorCount: StatsData;
-  contractCount: StatsData;
-  syncing: boolean;
   dataInitialized: boolean;
 }
 
-export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.Element {
-  const [data, setData] = React.useState<DashboardData>({
-    walletCount: { value: "0", isLoading: true, error: false },
-    volume: { value: "0", isLoading: true, error: false },
-    blockHeight: { value: "0", isLoading: true, error: false },
-    totalTransactions: { value: "0", isLoading: true, error: false },
-    marketCap: { value: "0", isLoading: true, error: false },
-    currentPrice: { value: "0", isLoading: true, error: false },
-    validatorCount: { value: "0", isLoading: true, error: false },
-    contractCount: { value: "0", isLoading: true, error: false },
-    syncing: true,
-    dataInitialized: false
-  });
+// ── Helpers ──────────────────────────────────────────────────────────────────
 
-  React.useEffect(() => {
-    async function fetchData(): Promise<void> {
-      try {
-        if (config.handlerUrl) {
-          const [overviewResponse, latestBlockResponse, txsResponse] = await Promise.allSettled([
-            axios.get(config.handlerUrl + "/overview"),
-            axios.get(config.handlerUrl + "/latestblock"),
-            axios.get(config.handlerUrl + "/txs?page=1")
-          ]);
+const SLOTS_PER_EPOCH = 128;
+const SECONDS_PER_SLOT = 60;
 
-          setData(prevData => {
-            const newData = { ...prevData };
+function timeAgo(unixSeconds: number): string {
+  const now = Math.floor(Date.now() / 1000);
+  const diff = now - unixSeconds;
+  if (diff < 0) return 'just now';
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
 
-            // Handle overview response
-            if (overviewResponse.status === 'fulfilled') {
-              newData.walletCount = { value: overviewResponse.value.data.countwallets.toString(), isLoading: false, error: false };
-              newData.volume = { value: overviewResponse.value.data.volume.toString(), isLoading: false, error: false };
-              newData.marketCap = { value: overviewResponse.value.data.marketcap.toString(), isLoading: false, error: false };
-              newData.currentPrice = { value: overviewResponse.value.data.currentPrice.toString(), isLoading: false, error: false };
-              newData.validatorCount = { value: overviewResponse.value.data.validatorCount.toString(), isLoading: false, error: false };
-              newData.contractCount = { value: overviewResponse.value.data.contractCount.toString(), isLoading: false, error: false };
-              newData.syncing = overviewResponse.value.data.status.syncing;
-              newData.dataInitialized = overviewResponse.value.data.status.dataInitialized;
-            } else {
-              newData.walletCount = { value: "0", isLoading: false, error: true };
-              newData.volume = { value: "0", isLoading: false, error: true };
-              newData.marketCap = { value: "0", isLoading: false, error: true };
-              newData.currentPrice = { value: "0", isLoading: false, error: true };
-              newData.validatorCount = { value: "0", isLoading: false, error: true };
-              newData.contractCount = { value: "0", isLoading: false, error: true };
-            }
+function parseHex(hex: string): number {
+  if (!hex) return 0;
+  if (hex.startsWith('0x')) return parseInt(hex, 16);
+  return parseInt(hex, 10) || 0;
+}
 
-            // Handle latest block response
-            if (latestBlockResponse.status === 'fulfilled') {
-              newData.blockHeight.value = latestBlockResponse.value.data.blockNumber?.toString() || "0";
-              newData.blockHeight.isLoading = false;
-              newData.blockHeight.error = false;
-            } else {
-              newData.blockHeight.error = true;
-            }
+/** Derive recent epoch rows from epoch info */
+function deriveEpochs(epochInfo: EpochInfo | null): EpochRow[] {
+  if (!epochInfo) return [];
+  const head = parseInt(epochInfo.headEpoch);
+  const finalized = parseInt(epochInfo.finalizedEpoch);
+  const justified = parseInt(epochInfo.justifiedEpoch);
+  const now = Math.floor(Date.now() / 1000);
+  const epochDuration = SLOTS_PER_EPOCH * SECONDS_PER_SLOT; // 7680s
 
-            // Handle transactions response
-            if (txsResponse.status === 'fulfilled') {
-              newData.totalTransactions.value = txsResponse.value.data.total?.toString() || "0";
-              newData.totalTransactions.isLoading = false;
-              newData.totalTransactions.error = false;
-            } else {
-              newData.totalTransactions.error = true;
-            }
+  // Current epoch start time estimate
+  const slotInEpoch = epochInfo.slotInEpoch || 0;
+  const currentEpochStartTime = now - slotInEpoch * SECONDS_PER_SLOT;
 
-            return newData;
-          });
-        }
-      } catch (error) {
-        console.error("Failed to fetch overview data:", error);
-      }
-    }
+  const rows: EpochRow[] = [];
+  const count = Math.min(head + 1, 10);
+  for (let i = 0; i < count; i++) {
+    const epoch = head - i;
+    if (epoch < 0) break;
+    const epochStartTime = currentEpochStartTime - i * epochDuration;
+    let status: 'finalized' | 'justified' | 'pending';
+    if (epoch <= finalized) status = 'finalized';
+    else if (epoch <= justified) status = 'justified';
+    else status = 'pending';
+    rows.push({ epoch, time: epochStartTime, status });
+  }
+  return rows;
+}
 
-    fetchData();
-  }, []);
+interface EpochRow {
+  epoch: number;
+  time: number;
+  status: 'finalized' | 'justified' | 'pending';
+}
 
-  const blockchainStats = [
-    {
-      data: formatNumberWithCommas(data.walletCount.value),
-      title: "Wallet Count",
-      loading: data.walletCount.isLoading,
-      error: data.walletCount.error,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mb-2 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z" />
-        </svg>
-      )
-    },
-    {
-      data: toFixed(parseFloat(data.volume.value)) + " QRL",
-      title: "Daily Transactions Volume",
-      loading: data.volume.isLoading,
-      error: data.volume.error,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mb-2 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-        </svg>
-      )
-    },
-    {
-      data: formatNumberWithCommas(data.blockHeight.value),
-      title: "Block Height",
-      loading: data.blockHeight.isLoading,
-      error: data.blockHeight.error,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mb-2 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-        </svg>
-      )
-    },
-    {
-      data: formatNumberWithCommas(data.totalTransactions.value),
-      title: "Total Transactions",
-      loading: data.totalTransactions.isLoading,
-      error: data.totalTransactions.error,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mb-2 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
-        </svg>
-      )
-    },
-    {
-      data: formatNumberWithCommas(data.validatorCount.value),
-      title: "Active Validators",
-      loading: data.validatorCount.isLoading,
-      error: data.validatorCount.error,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mb-2 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-      )
-    },
-    {
-      data: formatNumberWithCommas(data.contractCount.value),
-      title: "Smart Contracts",
-      loading: data.contractCount.isLoading,
-      error: data.contractCount.error,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mb-2 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
-        </svg>
-      )
-    }
+// ── Icons ────────────────────────────────────────────────────────────────────
+
+const icons = {
+  epoch: (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  ),
+  slot: (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+    </svg>
+  ),
+  block: (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+    </svg>
+  ),
+  validators: (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+    </svg>
+  ),
+  transactions: (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+    </svg>
+  ),
+};
+
+// ── Stat Bar ─────────────────────────────────────────────────────────────────
+
+function StatBar({ data }: { data: HomeData }) {
+  const stats = [
+    { label: 'Epoch', value: data.epochInfo ? data.epochInfo.headEpoch : '—', icon: icons.epoch },
+    { label: 'Slot', value: data.epochInfo ? formatNumberWithCommas(data.epochInfo.headSlot) : '—', icon: icons.slot },
+    { label: 'Block Height', value: formatNumberWithCommas(data.blockHeight.toString()), icon: icons.block },
+    { label: 'Validators', value: formatNumberWithCommas(data.validatorCount.toString()), icon: icons.validators },
+    { label: 'Transactions', value: formatNumberWithCommas(data.totalTransactions.toString()), icon: icons.transactions },
   ];
 
-  const financialStats = [
-    {
-      data: "$" + formatNumberWithCommas(data.marketCap.value),
-      title: "Market Cap",
-      loading: data.marketCap.isLoading,
-      error: data.marketCap.error,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mb-2 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-      )
-    },
-    {
-      data: "$" + parseFloat(data.currentPrice.value).toFixed(4),
-      title: "Current Price",
-      loading: data.currentPrice.isLoading,
-      error: data.currentPrice.error,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 mb-2 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-      )
-    }
-  ];
-
-  const videoContainerStyle: React.CSSProperties = {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    width: '100%',
-    height: '100%',
-    zIndex: -1,
-    overflow: 'hidden',
-  };
-
-  const videoStyle: React.CSSProperties = {
-    width: '100%',
-    height: '100%',
-    objectFit: 'cover',
-    opacity: 0.5, // Adjust this value to make the video more or less visible
-  };
-
-  const overlayStyle: React.CSSProperties = {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    width: '100%',
-    height: '100%',
-    backgroundColor: 'rgba(0, 0, 0, 0.5)', // Semi-transparent black overlay
-    zIndex: -1,
-  };
-
-  const seoTextItems = [
-    {
-      title: "What is ZondScan?",
-      text: "ZondScan is an independent blockchain explorer for QRL Zond, an EVM compatible blockchain secured by quantum resistant cryptography. Track blocks, transactions, smart contracts, and validators on a fast proof of stake network."
-    },
-    {
-      title: "What is QRL Zond?",
-      text: "QRL Zond is an EVM compatible blockchain built by the Quantum Resistant Ledger project with post quantum cryptography at its core. Most blockchains use cryptographic algorithms vulnerable to future quantum computers. QRL Zond uses SPHINCS+ instead, a NIST standardized signature scheme that provides security against both current and quantum era threats. Since it's EVM compatible, developers can deploy smart contracts using familiar Ethereum tools, libraries, and wallets. You get Ethereum compatibility plus quantum resistant security."
-    },
-    {
-      title: "Why Quantum Resistance Matters",
-      text: "Quantum computers will eventually break the cryptographic signatures that protect most blockchains today. When that happens, digital assets and identities on those chains become vulnerable. QRL Zond solves this with post quantum cryptography like SPHINCS+, ensuring your assets, contracts, and identity stay secure even when quantum computers arrive."
-    },
-    {
-      title: "Why SPHINCS+?",
-      text: "QRL Zond uses SPHINCS+, a stateless hash based signature scheme recently standardized by NIST. Unlike stateful schemes that require tracking signature usage, SPHINCS+ eliminates state management risks entirely. This makes development simpler and removes a major security headache for developers and enterprises. The tradeoff is slightly larger signatures and more computation, but that's manageable compared to the systemic risks of state tracking."
-    }
-  ];
   return (
-    <div className="relative">
-      {/* Video Background */}
-      <div style={videoContainerStyle}>
-        <video
-          autoPlay
-          loop
-          muted
-          playsInline
-          preload="metadata"
-          style={videoStyle}
-        >
-          <source src="/tree3.mp4" type="video/mp4" />
-          Your browser does not support the video tag.
-        </video>
-        <div style={overlayStyle}></div>
+    <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5">
+        {stats.map((stat, i) => (
+          <div
+            key={stat.label}
+            className={`px-4 py-4 sm:py-5 flex flex-col items-center justify-center text-center
+                        ${i < stats.length - 1 ? 'border-b lg:border-b-0 lg:border-r border-[#2a2a2a]' : ''}
+                        ${i % 2 === 0 && i < stats.length - 1 ? 'border-r sm:border-r border-[#2a2a2a]' : ''}
+                        `}
+          >
+            {data.loading ? (
+              <div className="h-7 w-20 bg-[#2a2a2a] rounded animate-pulse" />
+            ) : (
+              <span className="text-lg sm:text-xl font-semibold text-white tabular-nums">
+                {stat.value}
+              </span>
+            )}
+            <span className="flex items-center gap-1.5 text-[11px] text-gray-500 mt-1.5 uppercase tracking-wider">
+              <span className="text-gray-600">{stat.icon}</span>
+              {stat.label}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Status Badge ─────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: 'finalized' | 'justified' | 'pending' | 'proposed' }) {
+  const styles: Record<string, string> = {
+    finalized: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+    justified: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
+    pending: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/20',
+    proposed: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+  };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium border ${styles[status]}`}>
+      {status.charAt(0).toUpperCase() + status.slice(1)}
+    </span>
+  );
+}
+
+// ── Epoch Table ──────────────────────────────────────────────────────────────
+
+function EpochTable({ epochs, loading }: { epochs: EpochRow[]; loading: boolean }) {
+  return (
+    <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[#2a2a2a]">
+        <h2 className="flex items-center gap-2 text-[15px] font-semibold text-white">
+          <span className="text-[#ffa729]">{icons.epoch}</span>
+          Latest Epochs
+        </h2>
+        <Link href="/validators" className="text-xs text-[#ffa729] hover:text-[#ffb954] hover:underline transition-colors">
+          View all &rarr;
+        </Link>
       </div>
 
-      {/* Main Content */}
-      <div className="relative z-10 px-4 lg:px-8 pt-6.81 lg:pt-8">
+      {/* Table */}
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-[#2a2a2a]">
+              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Epoch</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Time</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              Array.from({ length: 8 }).map((_, i) => (
+                <tr key={i} className="border-b border-[#2a2a2a] last:border-b-0">
+                  <td className="px-4 py-2.5"><div className="h-4 w-12 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-2.5"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-2.5"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                </tr>
+              ))
+            ) : epochs.length === 0 ? (
+              <tr>
+                <td colSpan={3} className="px-4 py-8 text-center text-gray-500">No epoch data available</td>
+              </tr>
+            ) : (
+              epochs.map((epoch) => (
+                <tr
+                  key={epoch.epoch}
+                  className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
+                >
+                  <td className="px-4 py-2.5">
+                    <Link href="/validators" className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
+                      {formatNumberWithCommas(epoch.epoch.toString())}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-2.5 text-gray-400 tabular-nums">{timeAgo(epoch.time)}</td>
+                  <td className="px-4 py-2.5">
+                    <StatusBadge status={epoch.status} />
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ── Block Table ──────────────────────────────────────────────────────────────
+
+function BlockTable({ blocks, epochInfo, loading }: { blocks: BlockResult[]; epochInfo: EpochInfo | null; loading: boolean }) {
+  function getSlotFromBlock(blockNumber: string): number {
+    return parseHex(blockNumber);
+  }
+
+  function getEpochFromSlot(slot: number): number {
+    return Math.floor(slot / SLOTS_PER_EPOCH);
+  }
+
+  return (
+    <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[#2a2a2a]">
+        <h2 className="flex items-center gap-2 text-[15px] font-semibold text-white">
+          <span className="text-[#ffa729]">{icons.block}</span>
+          Latest Blocks
+        </h2>
+        <Link href="/blocks/1" className="text-xs text-[#ffa729] hover:text-[#ffb954] hover:underline transition-colors">
+          View all &rarr;
+        </Link>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-[#2a2a2a]">
+              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Block</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden sm:table-cell">Epoch</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Time</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Txns</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden md:table-cell">Proposer</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              Array.from({ length: 8 }).map((_, i) => (
+                <tr key={i} className="border-b border-[#2a2a2a] last:border-b-0">
+                  <td className="px-4 py-2.5"><div className="h-4 w-14 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-2.5 hidden sm:table-cell"><div className="h-4 w-10 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-2.5"><div className="h-4 w-14 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-2.5"><div className="h-4 w-6 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-2.5 hidden md:table-cell"><div className="h-4 w-24 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                </tr>
+              ))
+            ) : blocks.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-4 py-8 text-center text-gray-500">No blocks found</td>
+              </tr>
+            ) : (
+              blocks.map((block) => {
+                const blockNum = parseHex(block.number);
+                const slot = getSlotFromBlock(block.number);
+                const epoch = getEpochFromSlot(slot);
+                const timestamp = parseHex(block.timestamp);
+                const txCount = block.transactions?.length || 0;
+                const proposer = formatAddress(block.miner);
+
+                return (
+                  <tr
+                    key={block.hash}
+                    className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
+                  >
+                    <td className="px-4 py-2.5">
+                      <Link href={`/block/${blockNum}`} className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
+                        {formatNumberWithCommas(blockNum.toString())}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2.5 text-gray-400 tabular-nums hidden sm:table-cell">
+                      {formatNumberWithCommas(epoch.toString())}
+                    </td>
+                    <td className="px-4 py-2.5 text-gray-400 tabular-nums">{timeAgo(timestamp)}</td>
+                    <td className="px-4 py-2.5 text-gray-300 tabular-nums">{txCount}</td>
+                    <td className="px-4 py-2.5 hidden md:table-cell">
+                      <Link href={`/address/${proposer}`} className="text-gray-400 hover:text-[#ffa729] hover:underline font-mono text-xs transition-colors">
+                        {truncateHash(proposer, 8, 6)}
+                      </Link>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ── Main Component ───────────────────────────────────────────────────────────
+
+export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.Element {
+  const [data, setData] = React.useState<HomeData>({
+    blockHeight: 0,
+    totalTransactions: 0,
+    validatorCount: 0,
+    epochInfo: null,
+    blocks: [],
+    totalStaked: '0',
+    loading: true,
+    error: false,
+    dataInitialized: false,
+  });
+
+  const fetchData = React.useCallback(async () => {
+    try {
+      if (!config.handlerUrl) return;
+
+      const [overviewRes, latestBlockRes, txsRes, epochRes, blocksRes] = await Promise.allSettled([
+        axios.get(config.handlerUrl + '/overview'),
+        axios.get(config.handlerUrl + '/latestblock'),
+        axios.get(config.handlerUrl + '/txs?page=1'),
+        axios.get(config.handlerUrl + '/epoch'),
+        axios.get(config.handlerUrl + '/blocks?page=1&limit=10'),
+      ]);
+
+      setData((prev) => {
+        const next = { ...prev, loading: false };
+
+        if (overviewRes.status === 'fulfilled') {
+          next.validatorCount = overviewRes.value.data.validatorCount || 0;
+          next.dataInitialized = overviewRes.value.data.status?.dataInitialized ?? false;
+        }
+        if (latestBlockRes.status === 'fulfilled') {
+          next.blockHeight = latestBlockRes.value.data.blockNumber || 0;
+        }
+        if (txsRes.status === 'fulfilled') {
+          next.totalTransactions = txsRes.value.data.total || 0;
+        }
+        if (epochRes.status === 'fulfilled' && epochRes.value.data) {
+          next.epochInfo = epochRes.value.data;
+        }
+        if (blocksRes.status === 'fulfilled') {
+          next.blocks = blocksRes.value.data.blocks || [];
+        }
+
+        return next;
+      });
+    } catch (err) {
+      console.error('Failed to fetch homepage data:', err);
+      setData((prev) => ({ ...prev, loading: false, error: true }));
+    }
+  }, []);
+
+  React.useEffect(() => {
+    fetchData();
+    // Refresh every 30s (approx half a slot)
+    const interval = setInterval(fetchData, 30000);
+    return () => clearInterval(interval);
+  }, [fetchData]);
+
+  const epochs = React.useMemo(() => deriveEpochs(data.epochInfo), [data.epochInfo]);
+
+  return (
+    <div className="px-4 lg:px-8 pt-4 lg:pt-6">
+      <div className="max-w-6xl mx-auto">
         {/* Search Bar */}
-        <div className="max-w-6xl mx-auto mt-4">
-          <h1 className="text-base sm:text-xl font-bold mb-2 sm:mb-4 text-[#ffa729]">{pageTitle}</h1>
-          <div className="mb-4 sm:mb-10">
-            <SearchBar />
-          </div>
-
-          {!data.dataInitialized && (
-            <div className="mb-4 sm:mb-8 p-2 sm:p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-yellow-500">
-              <div className="flex items-center">
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 sm:h-5 w-4 sm:w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                <span className="text-xs sm:text-sm">Initializing explorer data... This may take a few minutes.</span>
-              </div>
-            </div>
-          )}
-
-          <div className="space-y-4 sm:space-y-8">
-            {/* Blockchain Stats */}
-            <div>
-              <h2 className="text-base sm:text-xl font-bold mb-2 sm:mb-4 text-[#ffa729]">Blockchain Statistics</h2>
-              <div className={`grid grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-4 ${!data.dataInitialized ? 'opacity-50' : ''}`}>
-                {blockchainStats.map((item, idx) => (
-                  <StatCard key={idx} item={item} />
-                ))}
-              </div>
-            </div>
-
-            {/* Financial Stats */}
-            <div>
-              <h2 className="text-base sm:text-xl font-bold mb-2 sm:mb-4 text-[#ffa729]">Financial Statistics</h2>
-              <div className={`grid grid-cols-2 gap-2 sm:gap-4 mb-4 ${!data.dataInitialized ? 'opacity-50' : ''}`}>
-                {financialStats.map((item, idx) => (
-                  <StatCard key={idx} item={item} />
-                ))}
-              </div>
-              <div className="max-w-6xl mx-auto">
-                <Charts />
-              </div>
-              
-            </div>
-          </div>
+        <h1 className="text-base sm:text-lg font-semibold mb-2 text-white">{pageTitle}</h1>
+        <div className="mb-6">
+          <SearchBar />
         </div>
-        <div className="max-w-6xl mx-auto px-4">
-        <SeoTextSection items={seoTextItems} />
+
+        {/* Init Warning */}
+        {!data.loading && !data.dataInitialized && (
+          <div className="mb-4 px-3 py-2.5 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-yellow-500 text-xs sm:text-sm flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            Initializing explorer data... This may take a few minutes.
+          </div>
+        )}
+
+        {/* Stats Bar */}
+        <div className="mb-6">
+          <StatBar data={data} />
         </div>
-        
+
+        {/* Side-by-Side Tables */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+          <EpochTable epochs={epochs} loading={data.loading} />
+          <BlockTable blocks={data.blocks} epochInfo={data.epochInfo} loading={data.loading} />
+        </div>
+
+        {/* TradingView Chart */}
+        <div className="mb-8">
+          <Charts />
+        </div>
       </div>
     </div>
   );

--- a/ExplorerFrontend/app/home-client.tsx
+++ b/ExplorerFrontend/app/home-client.tsx
@@ -199,8 +199,8 @@ function EpochTable({ epochs, loading }: { epochs: EpochRow[]; loading: boolean 
     <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-[#2a2a2a]">
-        <h2 className="flex items-center gap-2 text-[15px] font-semibold text-white">
-          <span className="text-[#ffa729]">{icons.epoch}</span>
+        <h2 className="flex items-center gap-2 text-[15px] font-semibold text-[#ffa729]">
+          {icons.epoch}
           Latest Epochs
         </h2>
         <Link href="/epochs/1" className="text-xs text-[#ffa729] hover:text-[#ffb954] hover:underline transition-colors">
@@ -238,7 +238,7 @@ function EpochTable({ epochs, loading }: { epochs: EpochRow[]; loading: boolean 
                   className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
                 >
                   <td className="px-4 py-2.5">
-                    <Link href="/epochs/1" className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
+                    <Link href={`/epoch/${epoch.epoch}`} className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
                       {formatNumberWithCommas(epoch.epoch.toString())}
                     </Link>
                   </td>
@@ -271,8 +271,8 @@ function BlockTable({ blocks, epochInfo, loading }: { blocks: BlockResult[]; epo
     <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-[#2a2a2a]">
-        <h2 className="flex items-center gap-2 text-[15px] font-semibold text-white">
-          <span className="text-[#ffa729]">{icons.block}</span>
+        <h2 className="flex items-center gap-2 text-[15px] font-semibold text-[#ffa729]">
+          {icons.block}
           Latest Blocks
         </h2>
         <Link href="/blocks/1" className="text-xs text-[#ffa729] hover:text-[#ffb954] hover:underline transition-colors">

--- a/ExplorerFrontend/app/home-client.tsx
+++ b/ExplorerFrontend/app/home-client.tsx
@@ -203,7 +203,7 @@ function EpochTable({ epochs, loading }: { epochs: EpochRow[]; loading: boolean 
           <span className="text-[#ffa729]">{icons.epoch}</span>
           Latest Epochs
         </h2>
-        <Link href="/validators" className="text-xs text-[#ffa729] hover:text-[#ffb954] hover:underline transition-colors">
+        <Link href="/epochs/1" className="text-xs text-[#ffa729] hover:text-[#ffb954] hover:underline transition-colors">
           View all &rarr;
         </Link>
       </div>
@@ -238,7 +238,7 @@ function EpochTable({ epochs, loading }: { epochs: EpochRow[]; loading: boolean 
                   className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
                 >
                   <td className="px-4 py-2.5">
-                    <Link href="/validators" className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
+                    <Link href="/epochs/1" className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
                       {formatNumberWithCommas(epoch.epoch.toString())}
                     </Link>
                   </td>

--- a/ExplorerFrontend/app/home-client.tsx
+++ b/ExplorerFrontend/app/home-client.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import axios from 'axios';
-import { formatNumberWithCommas, truncateHash, formatAddress } from './lib/helpers';
+import { formatNumberWithCommas } from './lib/helpers';
 import config from '../config.js';
 import SearchBar from './components/SearchBar';
 
@@ -194,9 +194,16 @@ function StatusBadge({ status }: { status: 'finalized' | 'justified' | 'pending'
 
 // ── Epoch Table ──────────────────────────────────────────────────────────────
 
+const TABLE_ROWS = 10;
+
+const ROW_CLASS = 'flex items-center px-4 h-[38px] border-b border-[#2a2a2a] last:border-b-0 text-sm';
+const HEAD_CLASS = 'flex items-center px-4 py-2 border-b border-[#2a2a2a] text-[11px] font-normal text-gray-600 uppercase tracking-wider';
+
 function EpochTable({ epochs, loading }: { epochs: EpochRow[]; loading: boolean }) {
+  const padCount = loading ? 0 : Math.max(0, TABLE_ROWS - epochs.length);
+
   return (
-    <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden flex flex-col">
+    <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-[#2a2a2a]">
         <h2 className="flex items-center gap-2 text-[15px] font-semibold text-[#ffa729]">
@@ -208,49 +215,58 @@ function EpochTable({ epochs, loading }: { epochs: EpochRow[]; loading: boolean 
         </Link>
       </div>
 
-      {/* Table */}
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-[#2a2a2a]">
-              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Epoch</th>
-              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Time</th>
-              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {loading ? (
-              Array.from({ length: 8 }).map((_, i) => (
-                <tr key={i} className="border-b border-[#2a2a2a] last:border-b-0">
-                  <td className="px-4 py-2.5"><div className="h-4 w-12 bg-[#2a2a2a] rounded animate-pulse" /></td>
-                  <td className="px-4 py-2.5"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></td>
-                  <td className="px-4 py-2.5"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></td>
-                </tr>
-              ))
-            ) : epochs.length === 0 ? (
-              <tr>
-                <td colSpan={3} className="px-4 py-8 text-center text-gray-500">No epoch data available</td>
-              </tr>
-            ) : (
-              epochs.map((epoch) => (
-                <tr
-                  key={epoch.epoch}
-                  className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
-                >
-                  <td className="px-4 py-2.5">
-                    <Link href={`/epoch/${epoch.epoch}`} className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
-                      {formatNumberWithCommas(epoch.epoch.toString())}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-2.5 text-gray-400 tabular-nums">{timeAgo(epoch.time)}</td>
-                  <td className="px-4 py-2.5">
-                    <StatusBadge status={epoch.status} />
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+      {/* Column headers */}
+      <div className={HEAD_CLASS}>
+        <span className="w-20">Epoch</span>
+        <span className="flex-1">Time</span>
+        <span className="w-24 text-right">Status</span>
+      </div>
+
+      {/* Rows */}
+      <div>
+        {loading ? (
+          Array.from({ length: TABLE_ROWS }).map((_, i) => (
+            <div key={i} className={ROW_CLASS}>
+              <span className="w-20"><div className="h-4 w-12 bg-[#2a2a2a] rounded animate-pulse" /></span>
+              <span className="flex-1"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></span>
+              <span className="w-24 flex justify-end"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></span>
+            </div>
+          ))
+        ) : epochs.length === 0 ? (
+          Array.from({ length: TABLE_ROWS }).map((_, i) => (
+            <div key={i} className={ROW_CLASS}>
+              <span className="w-20 text-transparent select-none">—</span>
+              <span className="flex-1" />
+              <span className="w-24" />
+            </div>
+          ))
+        ) : (
+          <>
+            {epochs.map((epoch) => (
+              <div
+                key={epoch.epoch}
+                className={`${ROW_CLASS} hover:bg-[#252525] transition-colors`}
+              >
+                <span className="w-20">
+                  <Link href={`/epoch/${epoch.epoch}`} className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
+                    {formatNumberWithCommas(epoch.epoch.toString())}
+                  </Link>
+                </span>
+                <span className="flex-1 text-gray-400 tabular-nums">{timeAgo(epoch.time)}</span>
+                <span className="w-24 flex justify-end">
+                  <StatusBadge status={epoch.status} />
+                </span>
+              </div>
+            ))}
+            {Array.from({ length: padCount }).map((_, i) => (
+              <div key={`pad-${i}`} className={ROW_CLASS}>
+                <span className="w-20 text-transparent select-none">—</span>
+                <span className="flex-1" />
+                <span className="w-24" />
+              </div>
+            ))}
+          </>
+        )}
       </div>
     </div>
   );
@@ -258,7 +274,7 @@ function EpochTable({ epochs, loading }: { epochs: EpochRow[]; loading: boolean 
 
 // ── Block Table ──────────────────────────────────────────────────────────────
 
-function BlockTable({ blocks, epochInfo, loading }: { blocks: BlockResult[]; epochInfo: EpochInfo | null; loading: boolean }) {
+function BlockTable({ blocks, loading }: { blocks: BlockResult[]; loading: boolean }) {
   function getSlotFromBlock(blockNumber: string): number {
     return parseHex(blockNumber);
   }
@@ -268,7 +284,7 @@ function BlockTable({ blocks, epochInfo, loading }: { blocks: BlockResult[]; epo
   }
 
   return (
-    <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden flex flex-col">
+    <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-[#2a2a2a]">
         <h2 className="flex items-center gap-2 text-[15px] font-semibold text-[#ffa729]">
@@ -280,68 +296,61 @@ function BlockTable({ blocks, epochInfo, loading }: { blocks: BlockResult[]; epo
         </Link>
       </div>
 
-      {/* Table */}
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-[#2a2a2a]">
-              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Block</th>
-              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden sm:table-cell">Epoch</th>
-              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Time</th>
-              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Txns</th>
-              <th className="text-left px-4 py-2.5 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden md:table-cell">Proposer</th>
-            </tr>
-          </thead>
-          <tbody>
-            {loading ? (
-              Array.from({ length: 8 }).map((_, i) => (
-                <tr key={i} className="border-b border-[#2a2a2a] last:border-b-0">
-                  <td className="px-4 py-2.5"><div className="h-4 w-14 bg-[#2a2a2a] rounded animate-pulse" /></td>
-                  <td className="px-4 py-2.5 hidden sm:table-cell"><div className="h-4 w-10 bg-[#2a2a2a] rounded animate-pulse" /></td>
-                  <td className="px-4 py-2.5"><div className="h-4 w-14 bg-[#2a2a2a] rounded animate-pulse" /></td>
-                  <td className="px-4 py-2.5"><div className="h-4 w-6 bg-[#2a2a2a] rounded animate-pulse" /></td>
-                  <td className="px-4 py-2.5 hidden md:table-cell"><div className="h-4 w-24 bg-[#2a2a2a] rounded animate-pulse" /></td>
-                </tr>
-              ))
-            ) : blocks.length === 0 ? (
-              <tr>
-                <td colSpan={5} className="px-4 py-8 text-center text-gray-500">No blocks found</td>
-              </tr>
-            ) : (
-              blocks.map((block) => {
-                const blockNum = parseHex(block.number);
-                const slot = getSlotFromBlock(block.number);
-                const epoch = getEpochFromSlot(slot);
-                const timestamp = parseHex(block.timestamp);
-                const txCount = block.transactions?.length || 0;
-                const proposer = formatAddress(block.miner);
+      {/* Column headers */}
+      <div className={HEAD_CLASS}>
+        <span className="w-20">Block</span>
+        <span className="w-16 hidden sm:block">Epoch</span>
+        <span className="flex-1">Time</span>
+        <span className="w-12 text-right">Txns</span>
+      </div>
 
-                return (
-                  <tr
-                    key={block.hash}
-                    className="border-b border-[#2a2a2a] last:border-b-0 hover:bg-[#252525] transition-colors"
-                  >
-                    <td className="px-4 py-2.5">
-                      <Link href={`/block/${blockNum}`} className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
-                        {formatNumberWithCommas(blockNum.toString())}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-2.5 text-gray-400 tabular-nums hidden sm:table-cell">
-                      {formatNumberWithCommas(epoch.toString())}
-                    </td>
-                    <td className="px-4 py-2.5 text-gray-400 tabular-nums">{timeAgo(timestamp)}</td>
-                    <td className="px-4 py-2.5 text-gray-300 tabular-nums">{txCount}</td>
-                    <td className="px-4 py-2.5 hidden md:table-cell">
-                      <Link href={`/address/${proposer}`} className="text-gray-400 hover:text-[#ffa729] hover:underline font-mono text-xs transition-colors">
-                        {truncateHash(proposer, 8, 6)}
-                      </Link>
-                    </td>
-                  </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
+      {/* Rows */}
+      <div>
+        {loading ? (
+          Array.from({ length: TABLE_ROWS }).map((_, i) => (
+            <div key={i} className={ROW_CLASS}>
+              <span className="w-20"><div className="h-4 w-14 bg-[#2a2a2a] rounded animate-pulse" /></span>
+              <span className="w-16 hidden sm:block"><div className="h-4 w-10 bg-[#2a2a2a] rounded animate-pulse" /></span>
+              <span className="flex-1"><div className="h-4 w-14 bg-[#2a2a2a] rounded animate-pulse" /></span>
+              <span className="w-12 flex justify-end"><div className="h-4 w-6 bg-[#2a2a2a] rounded animate-pulse" /></span>
+            </div>
+          ))
+        ) : blocks.length === 0 ? (
+          Array.from({ length: TABLE_ROWS }).map((_, i) => (
+            <div key={i} className={ROW_CLASS}>
+              <span className="w-20 text-transparent select-none">—</span>
+              <span className="w-16 hidden sm:block" />
+              <span className="flex-1" />
+              <span className="w-12" />
+            </div>
+          ))
+        ) : (
+          blocks.slice(0, TABLE_ROWS).map((block) => {
+            const blockNum = parseHex(block.number);
+            const slot = getSlotFromBlock(block.number);
+            const epoch = getEpochFromSlot(slot);
+            const timestamp = parseHex(block.timestamp);
+            const txCount = block.transactions?.length || 0;
+
+            return (
+              <div
+                key={block.hash}
+                className={`${ROW_CLASS} hover:bg-[#252525] transition-colors`}
+              >
+                <span className="w-20">
+                  <Link href={`/block/${blockNum}`} className="text-[#ffa729] hover:text-[#ffb954] hover:underline font-medium tabular-nums">
+                    {formatNumberWithCommas(blockNum.toString())}
+                  </Link>
+                </span>
+                <span className="w-16 text-gray-400 tabular-nums hidden sm:block">
+                  {formatNumberWithCommas(epoch.toString())}
+                </span>
+                <span className="flex-1 text-gray-400 tabular-nums">{timeAgo(timestamp)}</span>
+                <span className="w-12 text-right text-gray-300 tabular-nums">{txCount}</span>
+              </div>
+            );
+          })
+        )}
       </div>
     </div>
   );
@@ -438,11 +447,11 @@ export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.El
         {/* Side-by-Side Tables */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
           <EpochTable epochs={epochs} loading={data.loading} />
-          <BlockTable blocks={data.blocks} epochInfo={data.epochInfo} loading={data.loading} />
+          <BlockTable blocks={data.blocks} loading={data.loading} />
         </div>
 
         {/* TradingView Chart */}
-        <div className="mb-8">
+        <div className="mb-2">
           <Charts />
         </div>
       </div>

--- a/ExplorerFrontend/app/layout.tsx
+++ b/ExplorerFrontend/app/layout.tsx
@@ -8,19 +8,19 @@ import Footer from './components/Footer';
 
 export const metadata: Metadata = {
   ...sharedMetadata,
-  title: 'QRL Zond Blockchain Explorer',
+  title: 'ZondScan - QRL v2 Explorer',
   description:
     'Blockchain explorer for QRL Zond, an EVM-compatible blockchain secured with post-quantum cryptography. Track transactions, smart contracts, blocks, and validators.',
   openGraph: {
     ...sharedMetadata.openGraph,
-    title: 'QRL Zond Blockchain Explorer',
+    title: 'ZondScan - QRL v2 Explorer',
     description:
       'Blockchain explorer for QRL Zond. Track smart contracts, blocks, and transactions on a quantum-resistant EVM-compatible chain.',
     url: 'https://zondscan.com',
   },
   twitter: {
     ...sharedMetadata.twitter,
-    title: 'QRL Zond Blockchain Explorer',
+    title: 'ZondScan - QRL v2 Explorer',
     description:
       'Blockchain explorer for QRL Zond. Track transactions, blocks, smart contracts, and validators on a post-quantum EVM chain.',
   },

--- a/ExplorerFrontend/app/lib/seo/metaData.ts
+++ b/ExplorerFrontend/app/lib/seo/metaData.ts
@@ -4,7 +4,7 @@ import { Metadata } from 'next';
 export const sharedMetadata: Partial<Metadata> = {
   metadataBase: new URL('https://zondscan.com'),
   keywords:
-    'QRL, Proof of Stake, ZOND, blockchain explorer, Web3, EVM, quantum resistant, cryptocurrency, blockchain, smart contracts, validators, transactions, blocks',
+    'QRL, Proof of Stake, Zond, QRL v2 blockchain explorer, Web3, EVM, quantum resistant, cryptocurrency, blockchain, smart contracts, validators, transactions, blocks',
   alternates: {
     languages: {
       'en-US': 'https://zondscan.com',

--- a/ExplorerFrontend/app/types/jsx.d.ts
+++ b/ExplorerFrontend/app/types/jsx.d.ts
@@ -9,4 +9,7 @@ declare global {
   }
 }
 
+// Allow CSS imports
+declare module '*.css' {}
+
 export {};

--- a/ExplorerFrontend/tsconfig.json
+++ b/ExplorerFrontend/tsconfig.json
@@ -27,7 +27,7 @@
       "node",
       "jest"
     ],
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
     "skipDefaultLibCheck": true,
     "target": "ES2017",
     "baseUrl": ".",

--- a/Zond2mongoDB/services/validator_service.go
+++ b/Zond2mongoDB/services/validator_service.go
@@ -142,19 +142,20 @@ func storeValidatorHistoryFromDB(epoch string, currentEpochInt int64) error {
 		}
 	}
 
-	record := &models.ValidatorHistoryRecord{
-		Epoch:           epoch,
-		Timestamp:       time.Now().Unix(),
-		ValidatorsCount: int(totalCount),
-		ActiveCount:     activeCount,
-		PendingCount:    pendingCount,
-		ExitedCount:     exitedCount,
-		SlashedCount:    slashedCount,
-		TotalStaked:     totalStaked.String(),
+	record := bson.M{
+		"epoch":           epoch,
+		"epochInt":        currentEpochInt,
+		"timestamp":       time.Now().Unix(),
+		"validatorsCount": int(totalCount),
+		"activeCount":     activeCount,
+		"pendingCount":    pendingCount,
+		"exitedCount":     exitedCount,
+		"slashedCount":    slashedCount,
+		"totalStaked":     totalStaked.String(),
 	}
 
 	opts := options.Update().SetUpsert(true)
-	filter := bson.M{"epoch": record.Epoch}
+	filter := bson.M{"epoch": epoch}
 	update := bson.M{"$set": record}
 
 	_, err = configs.ValidatorHistoryCollections.UpdateOne(ctx, filter, update, opts)
@@ -163,8 +164,8 @@ func storeValidatorHistoryFromDB(epoch string, currentEpochInt int64) error {
 	}
 
 	configs.Logger.Debug("Stored validator history",
-		zap.String("epoch", record.Epoch),
-		zap.Int("validatorsCount", record.ValidatorsCount))
+		zap.String("epoch", epoch),
+		zap.Int("validatorsCount", int(totalCount)))
 	return nil
 }
 
@@ -270,6 +271,145 @@ func StoreEpochInfo(chainHead *models.BeaconChainHeadResponse) error {
 	configs.Logger.Debug("Stored epoch info",
 		zap.String("headEpoch", epochInfo.HeadEpoch),
 		zap.String("headSlot", epochInfo.HeadSlot))
+	return nil
+}
+
+// BackfillValidatorHistory fills in missing epoch records in validator_history.
+// currentEpoch is the current epoch number derived from the latest block.
+// Since all validators on this chain have been active since genesis with unchanged
+// balances, we use the current validator state for all past epochs and compute
+// timestamps from genesis time + epoch duration.
+func BackfillValidatorHistory(currentEpoch int64) error {
+	if currentEpoch <= 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const slotsPerEpoch = 128
+	const secondsPerSlot = 60
+	const epochDuration = int64(slotsPerEpoch * secondsPerSlot) // 7680s
+
+	// Find which epochs already have records
+	cursor, err := configs.ValidatorHistoryCollections.Find(ctx, bson.M{},
+		options.Find().SetProjection(bson.M{"epoch": 1}))
+	if err != nil {
+		return fmt.Errorf("query existing history: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	existingEpochs := make(map[string]bool)
+	for cursor.Next(ctx) {
+		var rec struct {
+			Epoch string `bson:"epoch"`
+		}
+		if err := cursor.Decode(&rec); err == nil {
+			existingEpochs[rec.Epoch] = true
+		}
+	}
+
+	// If all epochs exist, nothing to do
+	if int64(len(existingEpochs)) >= currentEpoch {
+		configs.Logger.Debug("Validator history is complete, no backfill needed",
+			zap.Int64("currentEpoch", currentEpoch),
+			zap.Int("existingRecords", len(existingEpochs)))
+		return nil
+	}
+
+	// Get current validator data
+	totalCount, err := configs.ValidatorsCollections.CountDocuments(ctx, bson.M{})
+	if err != nil || totalCount == 0 {
+		return fmt.Errorf("no validators to backfill from: %w", err)
+	}
+
+	valCursor, err := configs.ValidatorsCollections.Find(ctx, bson.M{},
+		options.Find().SetProjection(bson.M{
+			"slashed": 1, "activationEpoch": 1, "exitEpoch": 1, "effectiveBalance": 1,
+		}))
+	if err != nil {
+		return fmt.Errorf("find validators for backfill: %w", err)
+	}
+	defer valCursor.Close(ctx)
+
+	var docs []models.ValidatorDocument
+	if err := valCursor.All(ctx, &docs); err != nil {
+		return fmt.Errorf("decode validators for backfill: %w", err)
+	}
+
+	// Get genesis time from block 0
+	var block0 struct {
+		Result struct {
+			Timestamp string `bson:"timestamp"`
+		} `bson:"result"`
+	}
+	err = configs.BlocksCollections.FindOne(ctx, bson.M{"blockNumberInt": int64(0)}).Decode(&block0)
+	genesisTime := int64(0)
+	if err == nil && block0.Result.Timestamp != "" {
+		genesisTime, _ = strconv.ParseInt(block0.Result.Timestamp, 0, 64)
+	}
+	if genesisTime == 0 {
+		genesisTime = time.Now().Unix() - currentEpoch*epochDuration
+	}
+
+	// Build batch of missing epoch records
+	writeModels := make([]mongo.WriteModel, 0)
+	for epoch := int64(0); epoch < currentEpoch; epoch++ {
+		epochStr := strconv.FormatInt(epoch, 10)
+		if existingEpochs[epochStr] {
+			continue
+		}
+
+		var activeCount, pendingCount, exitedCount, slashedCount int
+		totalStaked := big.NewInt(0)
+		for _, d := range docs {
+			status := models.GetValidatorStatus(d.ActivationEpoch, d.ExitEpoch, d.Slashed, epoch)
+			switch status {
+			case "active":
+				activeCount++
+			case "pending":
+				pendingCount++
+			case "exited":
+				exitedCount++
+			case "slashed":
+				slashedCount++
+			}
+			if balance, ok := new(big.Int).SetString(d.EffectiveBalance, 10); ok {
+				totalStaked.Add(totalStaked, balance)
+			}
+		}
+
+		doc := bson.M{
+			"epoch":           epochStr,
+			"epochInt":        epoch,
+			"timestamp":       genesisTime + epoch*epochDuration,
+			"validatorsCount": int(totalCount),
+			"activeCount":     activeCount,
+			"pendingCount":    pendingCount,
+			"exitedCount":     exitedCount,
+			"slashedCount":    slashedCount,
+			"totalStaked":     totalStaked.String(),
+		}
+
+		filter := bson.M{"epoch": epochStr}
+		update := bson.M{"$set": doc}
+		writeModels = append(writeModels, mongo.NewUpdateOneModel().
+			SetFilter(filter).SetUpdate(update).SetUpsert(true))
+	}
+
+	if len(writeModels) == 0 {
+		return nil
+	}
+
+	result, err := configs.ValidatorHistoryCollections.BulkWrite(ctx, writeModels, options.BulkWrite().SetOrdered(false))
+	if err != nil {
+		return fmt.Errorf("bulk write backfill: %w", err)
+	}
+
+	configs.Logger.Info("Backfilled validator history",
+		zap.Int64("upserted", result.UpsertedCount),
+		zap.Int64("modified", result.ModifiedCount),
+		zap.Int64("currentEpoch", currentEpoch))
 	return nil
 }
 

--- a/Zond2mongoDB/services/validator_service.go
+++ b/Zond2mongoDB/services/validator_service.go
@@ -349,7 +349,28 @@ func BackfillValidatorHistory(currentEpoch int64) error {
 		genesisTime, _ = strconv.ParseInt(block0.Result.Timestamp, 0, 64)
 	}
 	if genesisTime == 0 {
-		genesisTime = time.Now().Unix() - currentEpoch*epochDuration
+		return fmt.Errorf("cannot backfill: block 0 not yet synced, genesis timestamp unavailable")
+	}
+
+	// Pre-parse validator balances to avoid repeated string→BigInt parsing in the loop
+	type parsedValidator struct {
+		ActivationEpoch string
+		ExitEpoch       string
+		Slashed         bool
+		Balance         *big.Int
+	}
+	parsed := make([]parsedValidator, 0, len(docs))
+	for _, d := range docs {
+		bal := big.NewInt(0)
+		if b, ok := new(big.Int).SetString(d.EffectiveBalance, 10); ok {
+			bal = b
+		}
+		parsed = append(parsed, parsedValidator{
+			ActivationEpoch: d.ActivationEpoch,
+			ExitEpoch:       d.ExitEpoch,
+			Slashed:         d.Slashed,
+			Balance:         bal,
+		})
 	}
 
 	// Build batch of missing epoch records
@@ -362,8 +383,8 @@ func BackfillValidatorHistory(currentEpoch int64) error {
 
 		var activeCount, pendingCount, exitedCount, slashedCount int
 		totalStaked := big.NewInt(0)
-		for _, d := range docs {
-			status := models.GetValidatorStatus(d.ActivationEpoch, d.ExitEpoch, d.Slashed, epoch)
+		for _, v := range parsed {
+			status := models.GetValidatorStatus(v.ActivationEpoch, v.ExitEpoch, v.Slashed, epoch)
 			switch status {
 			case "active":
 				activeCount++
@@ -374,9 +395,7 @@ func BackfillValidatorHistory(currentEpoch int64) error {
 			case "slashed":
 				slashedCount++
 			}
-			if balance, ok := new(big.Int).SetString(d.EffectiveBalance, 10); ok {
-				totalStaked.Add(totalStaked, balance)
-			}
+			totalStaked.Add(totalStaked, v.Balance)
 		}
 
 		doc := bson.M{

--- a/Zond2mongoDB/synchroniser/periodic_tasks.go
+++ b/Zond2mongoDB/synchroniser/periodic_tasks.go
@@ -388,6 +388,12 @@ func syncValidators() error {
 		return err
 	}
 
+	// Backfill any missing epoch history records
+	currentEpochInt, _ := strconv.ParseInt(currentEpoch, 10, 64)
+	if err := services.BackfillValidatorHistory(currentEpochInt); err != nil {
+		configs.Logger.Warn("Failed to backfill validator history", zap.Error(err))
+	}
+
 	configs.Logger.Info("Successfully synced validators", zap.String("epoch", currentEpoch))
 	return nil
 }

--- a/backendAPI/db/validator.go
+++ b/backendAPI/db/validator.go
@@ -246,6 +246,75 @@ func GetValidatorByID(id string) (*models.ValidatorDetailResponse, error) {
 	}, nil
 }
 
+// GetEpochs returns a paginated list of epochs from validator_history,
+// augmented with finalized/justified status from epoch_info.
+func GetEpochs(page, limit int) (*models.EpochsResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Get current epoch state for finalized/justified status
+	var epochInfo models.EpochInfo
+	err := configs.EpochInfoCollection.FindOne(ctx, bson.M{"_id": "current"}).Decode(&epochInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get epoch info: %v", err)
+	}
+	finalizedEpoch := parseEpoch(epochInfo.FinalizedEpoch)
+	justifiedEpoch := parseEpoch(epochInfo.JustifiedEpoch)
+
+	// Count total epoch records
+	total, err := configs.ValidatorHistoryCollection.CountDocuments(ctx, bson.M{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to count epochs: %v", err)
+	}
+
+	// Query with pagination, sorted newest first
+	skip := int64((page - 1) * limit)
+	findOpts := options.Find().
+		SetSort(bson.D{{Key: "epoch", Value: -1}}).
+		SetSkip(skip).
+		SetLimit(int64(limit))
+
+	cursor, err := configs.ValidatorHistoryCollection.Find(ctx, bson.M{}, findOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query epochs: %v", err)
+	}
+	defer cursor.Close(ctx)
+
+	var records []models.ValidatorHistoryRecord
+	if err := cursor.All(ctx, &records); err != nil {
+		return nil, fmt.Errorf("failed to decode epochs: %v", err)
+	}
+
+	epochs := make([]models.EpochListItem, 0, len(records))
+	for _, r := range records {
+		epochNum := parseEpoch(r.Epoch)
+		var status string
+		if epochNum <= finalizedEpoch {
+			status = "finalized"
+		} else if epochNum <= justifiedEpoch {
+			status = "justified"
+		} else {
+			status = "pending"
+		}
+
+		epochs = append(epochs, models.EpochListItem{
+			Epoch:           r.Epoch,
+			Timestamp:       r.Timestamp,
+			Status:          status,
+			ValidatorsCount: r.ValidatorsCount,
+			ActiveCount:     r.ActiveCount,
+			TotalStaked:     r.TotalStaked,
+		})
+	}
+
+	return &models.EpochsResponse{
+		Epochs:         epochs,
+		Total:          total,
+		FinalizedEpoch: epochInfo.FinalizedEpoch,
+		JustifiedEpoch: epochInfo.JustifiedEpoch,
+	}, nil
+}
+
 // GetValidatorStats returns aggregated validator statistics using a MongoDB aggregation
 // pipeline instead of loading all validators into Go memory.
 func GetValidatorStats() (*models.ValidatorStatsResponse, error) {

--- a/backendAPI/db/validator.go
+++ b/backendAPI/db/validator.go
@@ -267,10 +267,10 @@ func GetEpochs(page, limit int) (*models.EpochsResponse, error) {
 		return nil, fmt.Errorf("failed to count epochs: %v", err)
 	}
 
-	// Query with pagination, sorted newest first
+	// Query with pagination, sorted newest first by numeric epoch
 	skip := int64((page - 1) * limit)
 	findOpts := options.Find().
-		SetSort(bson.D{{Key: "epoch", Value: -1}}).
+		SetSort(bson.D{{Key: "epochInt", Value: -1}}).
 		SetSkip(skip).
 		SetLimit(int64(limit))
 

--- a/backendAPI/db/validator.go
+++ b/backendAPI/db/validator.go
@@ -315,6 +315,128 @@ func GetEpochs(page, limit int) (*models.EpochsResponse, error) {
 	}, nil
 }
 
+// GetEpochDetail returns full epoch information including all slots (proposed/missed).
+func GetEpochDetail(epochId string) (*models.EpochDetailResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	epochNum, err := strconv.ParseInt(epochId, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid epoch number: %v", err)
+	}
+
+	startSlot := epochNum * SlotsPerEpoch
+	endSlot := (epochNum + 1) * SlotsPerEpoch
+
+	// Get epoch_info for chain head status
+	var epochInfo models.EpochInfo
+	err = configs.EpochInfoCollection.FindOne(ctx, bson.M{"_id": "current"}).Decode(&epochInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get epoch info: %v", err)
+	}
+
+	headEpoch := parseEpoch(epochInfo.HeadEpoch)
+	if epochNum > headEpoch {
+		return nil, fmt.Errorf("epoch %d has not yet occurred (head: %d)", epochNum, headEpoch)
+	}
+
+	finalizedEpoch := parseEpoch(epochInfo.FinalizedEpoch)
+	justifiedEpoch := parseEpoch(epochInfo.JustifiedEpoch)
+
+	var status string
+	if epochNum <= finalizedEpoch {
+		status = "finalized"
+	} else if epochNum <= justifiedEpoch {
+		status = "justified"
+	} else {
+		status = "pending"
+	}
+
+	// Get validator_history record (may not exist for very recent epochs)
+	var historyRecord models.ValidatorHistoryRecord
+	_ = configs.ValidatorHistoryCollection.FindOne(ctx, bson.M{"epoch": epochId}).Decode(&historyRecord)
+
+	// Get blocks in this epoch's slot range
+	blockFilter := bson.M{
+		"blockNumberInt": bson.M{"$gte": startSlot, "$lt": endSlot},
+	}
+	projection := bson.D{
+		{Key: "blockNumberInt", Value: 1},
+		{Key: "result.number", Value: 1},
+		{Key: "result.timestamp", Value: 1},
+		{Key: "result.miner", Value: 1},
+		{Key: "result.transactions", Value: 1},
+		{Key: "result.gasUsed", Value: 1},
+		{Key: "result.hash", Value: 1},
+	}
+	findOpts := options.Find().
+		SetProjection(projection).
+		SetSort(bson.D{{Key: "blockNumberInt", Value: 1}})
+
+	cursor, err := configs.BlocksCollection.Find(ctx, blockFilter, findOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query blocks: %v", err)
+	}
+	defer cursor.Close(ctx)
+
+	blockMap := make(map[int64]models.EpochDetailBlock)
+	for cursor.Next(ctx) {
+		var doc struct {
+			BlockNumberInt int64        `bson:"blockNumberInt"`
+			Result         models.Result `bson:"result"`
+		}
+		if err := cursor.Decode(&doc); err != nil {
+			continue
+		}
+		blockMap[doc.BlockNumberInt] = models.EpochDetailBlock{
+			Slot:         doc.BlockNumberInt,
+			Status:       "proposed",
+			Timestamp:    doc.Result.Timestamp,
+			Proposer:     doc.Result.Miner,
+			Transactions: len(doc.Result.Transactions),
+			GasUsed:      doc.Result.GasUsed,
+			BlockHash:    doc.Result.Hash,
+		}
+	}
+
+	// Build full 128-slot list
+	blocks := make([]models.EpochDetailBlock, 0, SlotsPerEpoch)
+	proposedCount := 0
+	missedCount := 0
+	for slot := startSlot; slot < endSlot; slot++ {
+		if b, ok := blockMap[slot]; ok {
+			blocks = append(blocks, b)
+			proposedCount++
+		} else {
+			blocks = append(blocks, models.EpochDetailBlock{
+				Slot:   slot,
+				Status: "missed",
+			})
+			missedCount++
+		}
+	}
+
+	return &models.EpochDetailResponse{
+		Epoch:           epochId,
+		Timestamp:       historyRecord.Timestamp,
+		Status:          status,
+		ValidatorsCount: historyRecord.ValidatorsCount,
+		ActiveCount:     historyRecord.ActiveCount,
+		PendingCount:    historyRecord.PendingCount,
+		ExitedCount:     historyRecord.ExitedCount,
+		SlashedCount:    historyRecord.SlashedCount,
+		TotalStaked:     historyRecord.TotalStaked,
+		StartSlot:       startSlot,
+		EndSlot:         endSlot,
+		Blocks:          blocks,
+		FinalizedEpoch:  epochInfo.FinalizedEpoch,
+		JustifiedEpoch:  epochInfo.JustifiedEpoch,
+		HeadEpoch:       epochInfo.HeadEpoch,
+		ProposedCount:   proposedCount,
+		MissedCount:     missedCount,
+	}, nil
+}
+
 // GetValidatorStats returns aggregated validator statistics using a MongoDB aggregation
 // pipeline instead of loading all validators into Go memory.
 func GetValidatorStats() (*models.ValidatorStatsResponse, error) {

--- a/backendAPI/models/validator.go
+++ b/backendAPI/models/validator.go
@@ -130,3 +130,21 @@ type ValidatorStatsResponse struct {
 	TotalStaked     string `json:"totalStaked"`
 	CurrentEpoch    string `json:"currentEpoch"`
 }
+
+// EpochListItem represents a single epoch in the paginated listing
+type EpochListItem struct {
+	Epoch           string `json:"epoch"`
+	Timestamp       int64  `json:"timestamp"`
+	Status          string `json:"status"` // finalized, justified, pending
+	ValidatorsCount int    `json:"validatorsCount"`
+	ActiveCount     int    `json:"activeCount"`
+	TotalStaked     string `json:"totalStaked"`
+}
+
+// EpochsResponse represents the paginated epochs API response
+type EpochsResponse struct {
+	Epochs         []EpochListItem `json:"epochs"`
+	Total          int64           `json:"total"`
+	FinalizedEpoch string          `json:"finalizedEpoch"`
+	JustifiedEpoch string          `json:"justifiedEpoch"`
+}

--- a/backendAPI/models/validator.go
+++ b/backendAPI/models/validator.go
@@ -131,6 +131,38 @@ type ValidatorStatsResponse struct {
 	CurrentEpoch    string `json:"currentEpoch"`
 }
 
+// EpochDetailBlock represents a single slot within an epoch detail view
+type EpochDetailBlock struct {
+	Slot         int64  `json:"slot"`
+	Status       string `json:"status"` // proposed or missed
+	Timestamp    string `json:"timestamp,omitempty"`
+	Proposer     string `json:"proposer,omitempty"`
+	Transactions int    `json:"transactions"`
+	GasUsed      string `json:"gasUsed,omitempty"`
+	BlockHash    string `json:"blockHash,omitempty"`
+}
+
+// EpochDetailResponse represents the full epoch detail API response
+type EpochDetailResponse struct {
+	Epoch           string             `json:"epoch"`
+	Timestamp       int64              `json:"timestamp"`
+	Status          string             `json:"status"`
+	ValidatorsCount int                `json:"validatorsCount"`
+	ActiveCount     int                `json:"activeCount"`
+	PendingCount    int                `json:"pendingCount"`
+	ExitedCount     int                `json:"exitedCount"`
+	SlashedCount    int                `json:"slashedCount"`
+	TotalStaked     string             `json:"totalStaked"`
+	StartSlot       int64              `json:"startSlot"`
+	EndSlot         int64              `json:"endSlot"`
+	Blocks          []EpochDetailBlock `json:"blocks"`
+	FinalizedEpoch  string             `json:"finalizedEpoch"`
+	JustifiedEpoch  string             `json:"justifiedEpoch"`
+	HeadEpoch       string             `json:"headEpoch"`
+	ProposedCount   int                `json:"proposedCount"`
+	MissedCount     int                `json:"missedCount"`
+}
+
 // EpochListItem represents a single epoch in the paginated listing
 type EpochListItem struct {
 	Epoch           string `json:"epoch"`

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -538,6 +538,23 @@ func UserRoute(router *gin.Engine) {
 		c.JSON(http.StatusOK, validatorResponse)
 	})
 
+	// Get epoch detail by ID
+	router.GET("/epoch/:id", func(c *gin.Context) {
+		epochId := c.Param("id")
+		epochDetail, err := db.GetEpochDetail(epochId)
+		if err != nil {
+			if strings.Contains(err.Error(), "not yet occurred") || strings.Contains(err.Error(), "invalid epoch") {
+				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": fmt.Sprintf("Failed to fetch epoch detail: %v", err),
+			})
+			return
+		}
+		c.JSON(http.StatusOK, epochDetail)
+	})
+
 	// Get current epoch information
 	router.GET("/epoch", func(c *gin.Context) {
 		epochInfo, err := db.GetEpochInfo()

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -506,6 +506,25 @@ func UserRoute(router *gin.Engine) {
 		c.JSON(http.StatusOK, gin.H{"response": query})
 	})
 
+	// Paginated epochs listing
+	router.GET("/epochs", func(c *gin.Context) {
+		page, limit := getPaginationParams(c, 1, 15)
+
+		result, err := db.GetEpochs(page, limit)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": fmt.Sprintf("Failed to fetch epochs: %v", err),
+			})
+			return
+		}
+
+		if result.Epochs == nil {
+			result.Epochs = make([]models.EpochListItem, 0)
+		}
+
+		c.JSON(http.StatusOK, result)
+	})
+
 	router.GET("/validators", func(c *gin.Context) {
 		pageToken := c.Query("page_token")
 		validatorResponse, err := db.ReturnValidators(pageToken)


### PR DESCRIPTION
## Summary
- **Homepage redesign**: Replaces stat cards with horizontal stats bar (block height, epoch, validators, staked QRL, txns, market cap) and side-by-side Latest Epochs / Latest Blocks tables inspired by beaconcha.in
- **Epoch pages**: New `/epochs/[query]` paginated listing and `/epoch/[id]` detail pages showing all 128 slots per epoch with proposed/missed status, proposer links, and navigation
- **Validator history backfill**: Syncer now backfills `validatorHistory` for all past epochs during initial sync so epoch data is immediately available
- **Backend endpoints**: `GET /epochs?page=N&limit=N` for paginated epoch listing, `GET /epoch/:id` for epoch detail with full slot breakdown
- **UI polish**: Fixed table height alignment via fixed row counts (10 rows with padding), updated SEO titles, consistent orange accent theme

## New files
- `ExplorerFrontend/app/epoch/[id]/page.tsx` + `epoch-detail-client.tsx` — Epoch detail page
- `ExplorerFrontend/app/epochs/[query]/page.tsx` + `epochs-client.tsx` — Epochs listing page
- `backendAPI/db/validator.go` — Epoch queries (GetEpochDetail, GetEpochs)
- `backendAPI/models/validator.go` — Epoch response types

## Test plan
- [x] Homepage loads with stats bar and both tables at equal height
- [x] Epoch table links navigate to `/epoch/{id}` detail pages
- [x] Epoch detail shows all 128 slots with correct proposed/missed status
- [x] `/epochs/1` paginated listing works with Previous/Next navigation
- [x] Syncer backfills validator history on startup for all past epochs
- [x] Backend `/epoch/:id` returns 404 for future epochs
- [x] Responsive layout works on mobile (columns hidden appropriately)