### PR TITLE
Replace floating-point math with string-based conversion in currency converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ zond-contract-example*
 backendAPI/backendAPI.log
 *.cert
 *.key
-
+*.tsbuildinfo

--- a/ExplorerFrontend/app/converter/converter-client.tsx
+++ b/ExplorerFrontend/app/converter/converter-client.tsx
@@ -1,35 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-
-const SHOR_DECIMALS = 18;
-
-// Convert Shor (integer string) to Quanta (decimal string) without floating-point math
-function shorToQuanta(shorStr: string): string {
-  if (!shorStr || shorStr === '0') return '0';
-  // Remove any leading zeros
-  shorStr = shorStr.replace(/^0+/, '') || '0';
-  if (shorStr === '0') return '0';
-
-  // Pad with leading zeros so we have at least SHOR_DECIMALS + 1 characters
-  const padded = shorStr.padStart(SHOR_DECIMALS + 1, '0');
-  const intPart = padded.slice(0, padded.length - SHOR_DECIMALS);
-  const fracPart = padded.slice(padded.length - SHOR_DECIMALS).replace(/0+$/, '');
-
-  return fracPart ? `${intPart}.${fracPart}` : intPart;
-}
-
-// Convert Quanta (decimal string) to Shor (integer string) without floating-point math
-function quantaToShor(quantaStr: string): string {
-  if (!quantaStr || quantaStr === '0') return '0';
-
-  const parts = quantaStr.split('.');
-  const intPart = parts[0] || '0';
-  const fracPart = (parts[1] || '').slice(0, SHOR_DECIMALS).padEnd(SHOR_DECIMALS, '0');
-
-  const result = (intPart + fracPart).replace(/^0+/, '') || '0';
-  return result;
-}
+import { smallestUnitToDecimal, decimalToSmallestUnit } from '../lib/helpers';
 
 function Converter(): JSX.Element {
   const [quanta, setQuanta] = useState("");
@@ -49,7 +21,7 @@ function Converter(): JSX.Element {
     } else {
       setError('');
       setShor(value);
-      setQuanta(shorToQuanta(value));
+      setQuanta(smallestUnitToDecimal(value, 18));
     }
   };
 
@@ -66,7 +38,7 @@ function Converter(): JSX.Element {
     } else {
       setError('');
       setQuanta(value);
-      setShor(quantaToShor(value));
+      setShor(decimalToSmallestUnit(value, 18));
     }
   };
 

--- a/ExplorerFrontend/app/converter/converter-client.tsx
+++ b/ExplorerFrontend/app/converter/converter-client.tsx
@@ -1,34 +1,72 @@
 'use client';
 
 import React, { useState } from 'react';
-import { toFixed } from '../lib/helpers';
+
+const SHOR_DECIMALS = 18;
+
+// Convert Shor (integer string) to Quanta (decimal string) without floating-point math
+function shorToQuanta(shorStr: string): string {
+  if (!shorStr || shorStr === '0') return '0';
+  // Remove any leading zeros
+  shorStr = shorStr.replace(/^0+/, '') || '0';
+  if (shorStr === '0') return '0';
+
+  // Pad with leading zeros so we have at least SHOR_DECIMALS + 1 characters
+  const padded = shorStr.padStart(SHOR_DECIMALS + 1, '0');
+  const intPart = padded.slice(0, padded.length - SHOR_DECIMALS);
+  const fracPart = padded.slice(padded.length - SHOR_DECIMALS).replace(/0+$/, '');
+
+  return fracPart ? `${intPart}.${fracPart}` : intPart;
+}
+
+// Convert Quanta (decimal string) to Shor (integer string) without floating-point math
+function quantaToShor(quantaStr: string): string {
+  if (!quantaStr || quantaStr === '0') return '0';
+
+  const parts = quantaStr.split('.');
+  const intPart = parts[0] || '0';
+  const fracPart = (parts[1] || '').slice(0, SHOR_DECIMALS).padEnd(SHOR_DECIMALS, '0');
+
+  const result = (intPart + fracPart).replace(/^0+/, '') || '0';
+  return result;
+}
 
 function Converter(): JSX.Element {
   const [quanta, setQuanta] = useState("");
   const [shor, setShor] = useState("");
   const [error, setError] = useState("");
 
-  const DECIMALS = 1e18; // QRL heeft 18 decimalen zoals Ethereum
-
   const handleChangeShors = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const value = e.target.value;
-    if (isNaN(Number(value))) {
-      setError("Invalid Input: Enter a number");
+    if (value === '') {
+      setError('');
+      setShor('');
+      setQuanta('');
+      return;
+    }
+    if (!/^\d+$/.test(value)) {
+      setError("Invalid Input: Enter a whole number (Shor is indivisible)");
     } else {
       setError('');
-      setQuanta(toFixed(Number(value) / DECIMALS).toString());
       setShor(value);
+      setQuanta(shorToQuanta(value));
     }
   };
 
   const handleChangeQuanta = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const value = e.target.value;
-    if (isNaN(Number(value))) {
-      setError("Invalid Input: Enter a number");
+    if (value === '') {
+      setError('');
+      setShor('');
+      setQuanta('');
+      return;
+    }
+    if (!/^\d*\.?\d*$/.test(value) || value === '.') {
+      setError("Invalid Input: Enter a valid number");
     } else {
       setError('');
-      setShor(toFixed(Number(value) * DECIMALS).toString());
       setQuanta(value);
+      setShor(quantaToShor(value));
     }
   };
 

--- a/ExplorerFrontend/app/lib/helpers.ts
+++ b/ExplorerFrontend/app/lib/helpers.ts
@@ -336,6 +336,37 @@ export function decodeTokenTransferInput(inputData: string | undefined | null): 
 }
 
 /**
+ * Converts a smallest-unit integer string to a decimal string using BigInt (no floating-point).
+ * E.g. smallestUnitToDecimal("200000000000", 18) => "0.0000002"
+ */
+export function smallestUnitToDecimal(amount: string, decimals: number = 18): string {
+  if (!amount || amount === '0') return '0';
+  try {
+    const raw = BigInt(amount);
+    if (raw === BigInt(0)) return '0';
+    const divisor = BigInt(10) ** BigInt(decimals);
+    const wholePart = raw / divisor;
+    const fractionalPart = raw % divisor;
+    let fracStr = fractionalPart.toString().padStart(decimals, '0').replace(/0+$/, '');
+    return fracStr ? `${wholePart}.${fracStr}` : wholePart.toString();
+  } catch {
+    return '0';
+  }
+}
+
+/**
+ * Converts a decimal string to a smallest-unit integer string using string manipulation (no floating-point).
+ * E.g. decimalToSmallestUnit("0.0000002", 18) => "200000000000"
+ */
+export function decimalToSmallestUnit(value: string, decimals: number = 18): string {
+  if (!value || value === '0') return '0';
+  const parts = value.split('.');
+  const intPart = parts[0] || '0';
+  const fracPart = (parts[1] || '').slice(0, decimals).padEnd(decimals, '0');
+  return (intPart + fracPart).replace(/^0+/, '') || '0';
+}
+
+/**
  * Formats a token amount with proper decimals
  * @param amount - The raw token amount (as string)
  * @param decimals - The number of decimals for the token


### PR DESCRIPTION
## Summary
Refactored the currency converter to use string-based arithmetic instead of floating-point operations, eliminating precision errors when converting between Shor (integer) and Quanta (decimal) units.

## Key Changes
- Removed dependency on `toFixed` helper and floating-point math (`Number` operations)
- Implemented `shorToQuanta()` function that converts Shor integers to Quanta decimals using string manipulation and padding
- Implemented `quantaToShor()` function that converts Quanta decimals back to Shor integers without precision loss
- Updated input validation:
  - Shor input now only accepts whole numbers (regex: `^\d+$`)
  - Quanta input accepts decimal numbers (regex: `^\d*\.?\d*$`)
  - Added proper error messages for invalid input types
- Improved empty input handling to clear both fields and errors when input is cleared
- Added `*.tsbuildinfo` to `.gitignore`

## Implementation Details
- Uses `SHOR_DECIMALS = 18` constant to define the decimal places
- String padding and slicing ensure accurate conversion without floating-point rounding errors
- Handles edge cases like leading zeros, missing integer/fractional parts, and trailing zeros
- Validation now prevents invalid input before conversion attempts

https://claude.ai/code/session_018pqyW9Upy6QdKBY5ZET9WU