### PR TITLE
feat: host QRL Connect dApp example at /dapp-example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ Zond2mongoDB/syncer
 Zond2mongoDB/backendAPI
 backendAPI/handler/main
 ExplorerFrontend/tsconfig.tsbuildinfo
+ExplorerFrontend/.dapp-example-cache
+ExplorerFrontend/public/dapp-example

--- a/ExplorerFrontend/app/components/Sidebar.tsx
+++ b/ExplorerFrontend/app/components/Sidebar.tsx
@@ -327,6 +327,24 @@ export default function Sidebar(): JSX.Element {
               <span className="truncate">QRL Zond Wallet</span>
               <ArrowTopRightOnSquareIcon className="w-3.5 h-3.5 text-gray-500 ml-auto flex-shrink-0" />
             </a>
+            <a
+              href="/dapp-example/"
+              className="flex w-full items-center gap-2 px-3 py-2.5 text-sm text-gray-300
+                         hover:bg-[#2d2d2d] rounded-md transition-all duration-200
+                         hover:text-[#ffa729] group whitespace-nowrap"
+            >
+              <div className="w-5 h-5 relative flex-shrink-0">
+                <Image
+                  src={PartnerHandshakeIcon}
+                  alt=""
+                  fill
+                  sizes="20px"
+                  style={{ objectFit: 'contain' }}
+                  className={`${ICON_FILTER} ${ICON_FILTER_HOVER} transition-[filter]`}
+                />
+              </div>
+              <span className="truncate">dApp Example</span>
+            </a>
             <Link
               href="/api-explorer"
               aria-current={isActive(pathname, '/api-explorer') ? 'page' : undefined}

--- a/ExplorerFrontend/next.config.js
+++ b/ExplorerFrontend/next.config.js
@@ -38,6 +38,14 @@ const nextConfig = {
         source: '/api/:path*',
         destination: `${process.env.HANDLER_URL || 'http://127.0.0.1:8081'}/:path*`,
       },
+      {
+        source: '/dapp-example',
+        destination: '/dapp-example/index.html',
+      },
+      {
+        source: '/dapp-example/',
+        destination: '/dapp-example/index.html',
+      },
     ];
   },
 }

--- a/ExplorerFrontend/package.json
+++ b/ExplorerFrontend/package.json
@@ -40,6 +40,7 @@
     },
     "scripts": {
         "dev": "next dev --webpack",
+        "prebuild": "bash scripts/build-dapp-example.sh",
         "build": "next build",
         "start": "next start",
         "lint": "eslint ."

--- a/ExplorerFrontend/scripts/README.md
+++ b/ExplorerFrontend/scripts/README.md
@@ -1,0 +1,60 @@
+# ExplorerFrontend build scripts
+
+## `build-dapp-example.sh`
+
+Stages the [QRL Connect](https://github.com/DigitalGuards/myqrlwallet-connect) test dApp into `public/dapp-example/` so ZondScan serves it as a static SPA at [`/dapp-example`](https://zondscan.com/dapp-example). Invoked automatically via the `prebuild` npm hook, so every `npm run build` (and by extension every `update-frontend.sh` / PM2 restart) refreshes the hosted example against the latest connect repo.
+
+### What @qrlwallet/connect is
+
+`@qrlwallet/connect` is the self-hosted, end-to-end encrypted protocol MyQRLWallet uses to pair a dApp with the mobile wallet — the QRL equivalent of WalletConnect, but tailored to Q-addresses and designed for an eventual post-quantum transport migration.
+
+```
+┌─────────────────────┐                  ┌──────────────────────────┐
+│  External dApp      │    Socket.IO     │  MyQRLWallet App         │
+│  @qrlwallet/connect │  (E2E encrypted) │  (WebView handles ECIES  │
+│  → QR / deep link   │ <=============> │   + approval UI)          │
+└─────────┬───────────┘                  └──────────────────────────┘
+          │
+   ┌──────▼──────┐
+   │ Relay Server │  stateless Socket.IO router (qrlwallet.com)
+   └──────────────┘
+```
+
+The hosted `/dapp-example` is a live demo of that protocol: a dApp that generates a QR code, walks through the SYN/SYNACK/ACK handshake, and exercises `qrl_sendTransaction` / `personal_sign` / read-only RPC calls — all while streaming every event to an on-page log so developers can see the wire format. Deep architecture lives in the connect repo's [`CLAUDE.md`](https://github.com/DigitalGuards/myqrlwallet-connect/blob/dev/CLAUDE.md) and [`example/README.md`](https://github.com/DigitalGuards/myqrlwallet-connect/blob/dev/example/README.md).
+
+### What the script does
+
+1. Clones (or fetches) `DigitalGuards/myqrlwallet-connect` into `.dapp-example-cache/` (gitignored).
+2. `npm install && npm run build` in the SDK root — tsup emits the `dist/` that `example/` consumes via `file:..`.
+3. `npm install && npx vite build --base=/dapp-example/` in `example/` — rewrites asset paths so `/dapp-example/assets/*.js` resolves correctly when mounted under ZondScan.
+4. Copies `example/dist/*` into `ExplorerFrontend/public/dapp-example/`.
+
+A Next.js rewrite in `next.config.js` maps `/dapp-example` (no trailing slash) to `/dapp-example/index.html` so the directory request doesn't 404.
+
+### Env overrides
+
+| Variable              | Default                                                       | Purpose                                    |
+| --------------------- | ------------------------------------------------------------- | ------------------------------------------ |
+| `QRL_CONNECT_REPO`    | `https://github.com/DigitalGuards/myqrlwallet-connect.git`    | Alternate remote.                          |
+| `QRL_CONNECT_REF`     | `dev`                                                         | Branch or tag to clone. Pin to a tag for stable deploys. |
+| `QRL_CONNECT_LOCAL`   | _(unset)_                                                     | Absolute path to a local connect checkout. Rsyncs instead of cloning — useful when developing against uncommitted SDK changes. |
+| `SKIP_DAPP_EXAMPLE`   | `0`                                                           | Set to `1` to bypass entirely (fast local builds). |
+
+### Examples
+
+```bash
+# Pin to a specific SDK release tag
+QRL_CONNECT_REF=v0.2.0 npm run build
+
+# Build against a local connect checkout (no git required)
+QRL_CONNECT_LOCAL=/home/you/myqrlwallet-connect npm run build
+
+# Skip during a fast iteration loop
+SKIP_DAPP_EXAMPLE=1 npm run build
+```
+
+### Troubleshooting
+
+- **Vite build fails with `Rollup failed to resolve "vite-plugin-node-polyfills/shims/buffer"`** — you're on an old connect revision predating [connect#5](https://github.com/DigitalGuards/myqrlwallet-connect/pull/5). Bump `QRL_CONNECT_REF` or update the local checkout.
+- **`/dapp-example` returns 404 in dev** — `next dev` doesn't re-run `prebuild`. Either run `npm run build` once first, or bounce PM2 against a fresh production build.
+- **Stale bundle after connect changes** — the cache dir is retained between runs. `rm -rf .dapp-example-cache` to force a clean clone.

--- a/ExplorerFrontend/scripts/build-dapp-example.sh
+++ b/ExplorerFrontend/scripts/build-dapp-example.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds the QRL Connect dApp example and stages it into public/dapp-example/
+# so Next.js serves it at /dapp-example. Runs as a prebuild step.
+#
+# Override the source with QRL_CONNECT_REPO / QRL_CONNECT_REF env vars if needed.
+# Set SKIP_DAPP_EXAMPLE=1 to bypass entirely (useful for fast local builds).
+
+if [[ "${SKIP_DAPP_EXAMPLE:-0}" == "1" ]]; then
+  echo "[dapp-example] SKIP_DAPP_EXAMPLE=1 — skipping build"
+  exit 0
+fi
+
+REPO_URL="${QRL_CONNECT_REPO:-https://github.com/DigitalGuards/myqrlwallet-connect.git}"
+REF="${QRL_CONNECT_REF:-dev}"
+LOCAL_SRC="${QRL_CONNECT_LOCAL:-}"
+
+FRONTEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CACHE_DIR="$FRONTEND_DIR/.dapp-example-cache"
+OUT_DIR="$FRONTEND_DIR/public/dapp-example"
+
+echo "[dapp-example] cache=$CACHE_DIR out=$OUT_DIR"
+
+if [[ -n "$LOCAL_SRC" ]]; then
+  echo "[dapp-example] using local source: $LOCAL_SRC"
+  rm -rf "$CACHE_DIR"
+  mkdir -p "$CACHE_DIR"
+  rsync -a --delete \
+    --exclude node_modules --exclude dist --exclude .git \
+    --exclude example/node_modules --exclude example/dist \
+    "$LOCAL_SRC/" "$CACHE_DIR/"
+else
+  echo "[dapp-example] repo=$REPO_URL ref=$REF"
+  if [[ ! -d "$CACHE_DIR/.git" ]]; then
+    rm -rf "$CACHE_DIR"
+    git clone --depth 1 --branch "$REF" "$REPO_URL" "$CACHE_DIR"
+  else
+    git -C "$CACHE_DIR" fetch --depth 1 origin "$REF"
+    git -C "$CACHE_DIR" checkout -B "$REF" "origin/$REF"
+  fi
+fi
+
+echo "[dapp-example] building SDK"
+( cd "$CACHE_DIR" && npm install --no-audit --no-fund && npm run build )
+
+echo "[dapp-example] building example with base=/dapp-example/"
+(
+  cd "$CACHE_DIR/example"
+  npm install --no-audit --no-fund
+  npx vite build --base=/dapp-example/
+)
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+cp -r "$CACHE_DIR/example/dist/." "$OUT_DIR/"
+
+echo "[dapp-example] staged at $OUT_DIR"

--- a/ExplorerFrontend/scripts/build-dapp-example.sh
+++ b/ExplorerFrontend/scripts/build-dapp-example.sh
@@ -36,8 +36,9 @@ else
     rm -rf "$CACHE_DIR"
     git clone --depth 1 --branch "$REF" "$REPO_URL" "$CACHE_DIR"
   else
+    # FETCH_HEAD works for both branches and tags; origin/$REF would not resolve for tags.
     git -C "$CACHE_DIR" fetch --depth 1 origin "$REF"
-    git -C "$CACHE_DIR" checkout -B "$REF" "origin/$REF"
+    git -C "$CACHE_DIR" checkout --detach FETCH_HEAD
   fi
 fi
 


### PR DESCRIPTION
## Summary
Bakes the `@qrlwallet/connect` test dApp into `public/dapp-example/` at build time so ZondScan can host it as a live demo of the wallet-dApp pairing protocol. Auto-refreshes on every deploy: the prebuild script clones the latest connect repo, builds the example with `--base=/dapp-example/`, and copies the static output into the Next.js public directory.

- `scripts/build-dapp-example.sh`: clones `DigitalGuards/myqrlwallet-connect`, builds SDK + example, stages `dist/` into `public/dapp-example/`. Env overrides for ref (`QRL_CONNECT_REF`, default `dev`), remote, local path, and `SKIP_DAPP_EXAMPLE=1` bypass for fast local builds.
- `package.json`: `prebuild` hook wires the script into every `npm run build`.
- `next.config.js`: rewrite `/dapp-example` to `/dapp-example/index.html` so the directory request resolves without a trailing-slash 308.
- `Sidebar.tsx`: plain-anchor link under the external-items section (hard nav, since the target is a static asset outside the App Router).
- `.gitignore`: generated `public/dapp-example` and the `.dapp-example-cache` clone directory.
- `scripts/README.md`: documents the pipeline, env overrides, and common troubleshooting.

Depends on [connect#5](https://github.com/DigitalGuards/myqrlwallet-connect/pull/5) (already merged) for a buildable example, and pairs nicely with [connect#6](https://github.com/DigitalGuards/myqrlwallet-connect/pull/6) which adds the hosted intro + palette match.

## Test plan
- [x] `npm run build` triggers prebuild, example stages into `public/dapp-example/`
- [x] `curl -sI localhost:3000/dapp-example` returns 200
- [x] PM2 `frontend` restart serves the hosted example
- [x] Sidebar link navigates to the hosted dApp
- [ ] Verify on production domain after deploy