### PR TITLE
fix(pending): drop mined row, freeze status on upsert, auto-redirect /tx

### DIFF
--- a/ExplorerFrontend/app/tx/[query]/page.tsx
+++ b/ExplorerFrontend/app/tx/[query]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import TransactionView from './transaction-view';
 import type { TransactionDetails } from '@/app/types';
 import config from '../../../config';
@@ -69,57 +69,44 @@ async function getTransaction(txHash: string): Promise<TransactionDetails> {
   return transaction;
 }
 
-export default async function TransactionPage({ params }: PageProps): Promise<JSX.Element> {
-  let resolvedParams;
-  let txHash = '';
-  
+async function isPendingTransaction(txHash: string): Promise<boolean> {
   try {
-    resolvedParams = await params;
-    txHash = resolvedParams.query;
-
-    // Validate transaction hash format
-    const hashRegex = /^0x[0-9a-fA-F]{64}$/;
-    if (!hashRegex.test(txHash)) {
-      return (
-        <div className="container mx-auto px-4">
-          <div className="bg-red-900/20 border border-red-500/50 rounded-xl p-6 shadow-lg mt-6">
-            <h2 className="text-red-500 font-semibold mb-2">Invalid Transaction Hash</h2>
-            <p className="text-gray-300">
-              The provided transaction hash is not in the correct format. 
-              Transaction hashes should start with &apos;0x&apos; followed by 64 hexadecimal characters.
-            </p>
-          </div>
-        </div>
-      );
-    }
-
-    // Check if transaction is in mempool (only show pending if status is actually "pending")
     const pendingResponse = await fetch(`${config.handlerUrl}/pending-transaction/${txHash}`);
-    if (pendingResponse.ok && pendingResponse.status === 200) {
-      const pendingData = await pendingResponse.json();
-      // Only show pending view if transaction exists AND status is "pending" (not "mined")
-      if (pendingData?.transaction && pendingData.transaction.status === 'pending') {
-        // If found in mempool with pending status, show pending message with link
-        return (
-          <div className="container mx-auto px-4">
-            <div className="bg-yellow-900/20 border border-yellow-500/50 rounded-xl p-6 shadow-lg mt-6">
-              <h2 className="text-yellow-500 font-semibold mb-2">Transaction Pending</h2>
-              <p className="text-gray-300 mb-4">
-                This transaction is still pending and has not been mined yet.
-              </p>
-              <a
-                href={`/pending/tx/${txHash}`}
-                className="inline-block bg-yellow-500/20 text-yellow-500 px-4 py-2 rounded-lg hover:bg-yellow-500/30 transition-colors"
-              >
-                View Pending Transaction →
-              </a>
-            </div>
-          </div>
-        );
-      }
-    }
+    if (!pendingResponse.ok || pendingResponse.status !== 200) return false;
+    const pendingData = await pendingResponse.json();
+    return Boolean(pendingData?.transaction && pendingData.transaction.status === 'pending');
+  } catch (error) {
+    console.error('Error checking pending transaction:', error);
+    return false;
+  }
+}
 
-    // Not in mempool, try to get mined transaction
+export default async function TransactionPage({ params }: PageProps): Promise<JSX.Element> {
+  const resolvedParams = await params;
+  const txHash = resolvedParams.query;
+
+  const hashRegex = /^0x[0-9a-fA-F]{64}$/;
+  if (!hashRegex.test(txHash)) {
+    return (
+      <div className="container mx-auto px-4">
+        <div className="bg-red-900/20 border border-red-500/50 rounded-xl p-6 shadow-lg mt-6">
+          <h2 className="text-red-500 font-semibold mb-2">Invalid Transaction Hash</h2>
+          <p className="text-gray-300">
+            The provided transaction hash is not in the correct format.
+            Transaction hashes should start with &apos;0x&apos; followed by 64 hexadecimal characters.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // redirect() throws a NEXT_REDIRECT sentinel that the framework must
+  // receive uncaught — keep this call outside any try/catch.
+  if (await isPendingTransaction(txHash)) {
+    redirect(`/pending/tx/${txHash}`);
+  }
+
+  try {
     const transaction = await getTransaction(txHash);
     return <TransactionView transaction={transaction} />;
   } catch (error) {

--- a/ExplorerFrontend/app/types/transaction.ts
+++ b/ExplorerFrontend/app/types/transaction.ts
@@ -158,17 +158,9 @@ export function getTransactionStatus(confirmations?: number | null): {
   text: string;
   color: string;
 } {
-  if (confirmations === null) {
-    return { text: 'Pending', color: 'bg-yellow-500' };
-  }
-
   if (confirmations && confirmations > 0) {
-    if (confirmations >= 1) {
-      return { text: 'Confirmed', color: 'bg-green-500' };
-    }
-    return { text: 'Processing', color: 'bg-blue-500' };
+    return { text: 'Confirmed', color: 'bg-green-500' };
   }
-
   return { text: 'Pending', color: 'bg-yellow-500' };
 }
 

--- a/QRL2MongoDB/db/pending.go
+++ b/QRL2MongoDB/db/pending.go
@@ -32,13 +32,20 @@ func UpsertPendingTransaction(tx *models.PendingTransaction) error {
 		configs.Logger.Error("Failed to unmarshal pending transaction", zap.Error(err))
 		return err
 	}
+	// status must only be written on initial insert — otherwise a stale
+	// mempool entry can revert a row that was already marked mined back to
+	// "pending". Explicit transitions go through UpdatePendingTransactionStatus.
 	delete(setFields, "createdAt")
+	delete(setFields, "status")
 
 	opts := options.Update().SetUpsert(true)
 	filter := bson.M{"_id": tx.Hash}
 	update := bson.M{
-		"$set":         setFields,
-		"$setOnInsert": bson.M{"createdAt": now},
+		"$set": setFields,
+		"$setOnInsert": bson.M{
+			"createdAt": now,
+			"status":    "pending",
+		},
 	}
 
 	_, err = configs.PendingTransactionsCollections.UpdateOne(ctx, filter, update, opts)

--- a/QRL2MongoDB/synchroniser/pending_sync.go
+++ b/QRL2MongoDB/synchroniser/pending_sync.go
@@ -79,22 +79,16 @@ func UpdatePendingTransactionsInBlock(block *models.ZondDatabaseBlock) error {
 	// Check each pending transaction
 	for _, tx := range pendingTxs {
 		if blockTxs[tx.Hash] {
-			// Transaction is in the block, update its status
-			update := bson.M{
-				"$set": bson.M{
-					"status":      "mined",
-					"lastSeen":    time.Now(),
-					"blockNumber": block.Result.Number,
-				},
-			}
-			_, err := collection.UpdateOne(ctx, bson.M{"_id": tx.Hash}, update)
-			if err != nil {
-				configs.Logger.Error("Failed to update mined transaction status",
+			// Delete (don't $set status="mined") — a stale mempool entry can
+			// otherwise clobber status back to "pending" via UpsertPendingTransaction
+			// before the verification sweep catches it.
+			if err := db.DeletePendingTransaction(tx.Hash); err != nil {
+				configs.Logger.Error("Failed to delete mined pending transaction",
 					zap.String("hash", tx.Hash),
 					zap.Error(err))
 				continue
 			}
-			configs.Logger.Info("Transaction mined",
+			configs.Logger.Info("Transaction mined and removed from pending",
 				zap.String("hash", tx.Hash),
 				zap.String("block", block.Result.Number))
 		}


### PR DESCRIPTION
## Summary

Two related defects were causing wallets and end-users to see incorrect pending-tx UX:

1. **Confirmed txs displaying as "pending"** — root cause is in the syncer's mempool upsert: every 1 s poll unconditionally writes `status: "pending"` via a `$set`, which can clobber a row that `UpdatePendingTransactionsInBlock` just marked `"mined"` if the QRL node briefly still lists the tx in `txpool_content`. The 5-min verification sweep was the only safety net, so users saw stale "pending" for up to that window.
2. **Manual "View Pending Transaction →" click on `/tx/<hash>`** — when a wallet emits `https://zondscan.com/tx/<hash>` for a pending tx, the explorer rendered a yellow card with a manual link instead of redirecting to `/pending/tx/<hash>`.

## Changes

- **`QRL2MongoDB/synchroniser/pending_sync.go`** — `UpdatePendingTransactionsInBlock` now calls `db.DeletePendingTransaction(hash)` instead of `$set status:"mined"`. Mined txs leave the `pending_transactions` collection immediately; the row can no longer be reverted to pending by a stale mempool entry.
- **`QRL2MongoDB/db/pending.go`** — `UpsertPendingTransaction` moves `status` from `$set` to `$setOnInsert` so subsequent mempool polls refresh `lastSeen`/`from`/`nonce` but can never overwrite status. Explicit transitions still flow through `UpdatePendingTransactionStatus`.
- **`ExplorerFrontend/app/tx/[query]/page.tsx`** — pending check extracted into `isPendingTransaction()` helper so its fetch errors stay isolated, then `redirect('/pending/tx/<hash>')` is called outside any try/catch (Next's `redirect()` throws a `NEXT_REDIRECT` sentinel that must reach the framework uncaught). The yellow card is gone.
- **`ExplorerFrontend/app/types/transaction.ts`** — drop unreachable "Processing" branch in `getTransactionStatus`. For integer confirmations, the inner `>= 1` check was equivalent to the outer `> 0`.

## Test plan

- [ ] **Build gates green**: `go build` on `QRL2MongoDB` (→ `syncer`) and `backendAPI` (→ `backendAPI`); `go vet ./...` clean on both; `npx tsc --noEmit` clean; `SKIP_DAPP_EXAMPLE=1 npm run build` succeeds.
- [ ] **Fresh tx end-to-end**: submit a tx, open `/tx/<hash>` — verify auto-redirect to `/pending/tx/<hash>` (no click). After inclusion, refresh and verify auto-redirect back to `/tx/<hash>` showing "Confirmed".
- [ ] **DB sanity** after a tx is mined: `db.pending_transactions.findOne({_id: "<hash>"})` returns null; `db.pending_transactions.find({status: "mined"})` is empty.
- [ ] **No regressions**: `/pending/tx/<hash>` for a still-pending tx renders normally; `/pending-transactions` listing still populated when real pending txs exist; invalid hash on `/tx/<hash>` still renders the validation card.

## Notes

- Pre-existing: `npm run lint` is broken (eslint config references `import/no-anonymous-default-export` but `eslint-plugin-import` isn't registered — leftover from the ESLint 8→9 upgrade in `dd73142`). Not touched here.