### PR TITLE
fix(pending): tombstone mined rows instead of deleting; unblock legacy sync_state

### DIFF
--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -233,11 +233,20 @@ func StoreLastKnownBlockNumber(blockNumber string) error {
 	// Use the integer field for the $lt guard so the comparison is numeric,
 	// not the lexicographic hex string comparison that would produce wrong
 	// ordering (e.g. "0x9" sorts after "0x10" lexicographically).
+	//
+	// Also accept docs that don't yet have block_number_int — legacy rows
+	// written by an older syncer were missing the field, which made the
+	// $lt match nothing and silently froze sync_state. The early-return
+	// guard above (existing.BlockNumber >= new) already prevents
+	// going-backwards for those rows.
 	result, err := syncColl.UpdateOne(
 		ctx,
 		bson.M{
-			"_id":              LastSyncedBlockID,
-			"block_number_int": bson.M{"$lt": blockNumberIntVal},
+			"_id": LastSyncedBlockID,
+			"$or": []bson.M{
+				{"block_number_int": bson.M{"$lt": blockNumberIntVal}},
+				{"block_number_int": bson.M{"$exists": false}},
+			},
 		},
 		bson.M{"$set": bson.M{
 			"block_number":     blockNumber,

--- a/QRL2MongoDB/db/pending.go
+++ b/QRL2MongoDB/db/pending.go
@@ -82,7 +82,12 @@ func UpdatePendingTransactionStatus(hash string, status string) error {
 	return nil
 }
 
-// CleanupOldPendingTransactions removes transactions that haven't been seen recently
+// CleanupOldPendingTransactions removes rows that haven't been seen recently —
+// both genuinely-pending rows the node has forgotten about, and "mined"
+// tombstones that have aged out. The tombstones must be cleaned here too;
+// the per-status helpers (UpdatePendingTransactionsInBlock,
+// verifyPendingTransactions) intentionally leave them in place to block
+// stale mempool re-inserts.
 func CleanupOldPendingTransactions(maxAge time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -90,7 +95,6 @@ func CleanupOldPendingTransactions(maxAge time.Duration) error {
 	cutoff := time.Now().Add(-maxAge)
 	filter := bson.M{
 		"lastSeen": bson.M{"$lt": cutoff},
-		"status":   "pending",
 	}
 
 	_, err := configs.PendingTransactionsCollections.DeleteMany(ctx, filter)

--- a/QRL2MongoDB/synchroniser/pending_sync.go
+++ b/QRL2MongoDB/synchroniser/pending_sync.go
@@ -76,19 +76,28 @@ func UpdatePendingTransactionsInBlock(block *models.ZondDatabaseBlock) error {
 		return err
 	}
 
-	// Check each pending transaction
+	// Tombstone: keep the row with status="mined" rather than deleting it.
+	// Deletion would let a subsequent mempool poll re-insert the same hash
+	// via UpsertPendingTransaction's $setOnInsert path, flipping the status
+	// back to "pending". Since status is excluded from $set in the upsert,
+	// an existing tombstone is preserved across re-polls.
+	// CleanupOldPendingTransactions sweeps these rows once they age out.
 	for _, tx := range pendingTxs {
 		if blockTxs[tx.Hash] {
-			// Delete (don't $set status="mined") — a stale mempool entry can
-			// otherwise clobber status back to "pending" via UpsertPendingTransaction
-			// before the verification sweep catches it.
-			if err := db.DeletePendingTransaction(tx.Hash); err != nil {
-				configs.Logger.Error("Failed to delete mined pending transaction",
+			update := bson.M{
+				"$set": bson.M{
+					"status":      "mined",
+					"lastSeen":    time.Now(),
+					"blockNumber": block.Result.Number,
+				},
+			}
+			if _, err := collection.UpdateOne(ctx, bson.M{"_id": tx.Hash}, update); err != nil {
+				configs.Logger.Error("Failed to update mined transaction status",
 					zap.String("hash", tx.Hash),
 					zap.Error(err))
 				continue
 			}
-			configs.Logger.Info("Transaction mined and removed from pending",
+			configs.Logger.Info("Transaction mined",
 				zap.String("hash", tx.Hash),
 				zap.String("block", block.Result.Number))
 		}
@@ -168,7 +177,9 @@ func syncMempool() error {
 }
 
 // verifyPendingTransactions checks pending transactions against the node
-// and removes any that have been mined (have a receipt)
+// and tombstones any that have been mined (have a receipt). Tombstone instead
+// of delete to match UpdatePendingTransactionsInBlock — a delete here could
+// also race with mempool re-poll re-inserting the row as "pending".
 func verifyPendingTransactions() error {
 	hashes, err := db.GetAllPendingTransactionHashes()
 	if err != nil {
@@ -182,7 +193,7 @@ func verifyPendingTransactions() error {
 	configs.Logger.Info("Verifying pending transactions against node",
 		zap.Int("count", len(hashes)))
 
-	removedCount := 0
+	tombstonedCount := 0
 	for _, hash := range hashes {
 		// Check if transaction has a receipt (meaning it's mined)
 		receipt, err := rpc.GetTransactionReceipt(hash)
@@ -193,24 +204,24 @@ func verifyPendingTransactions() error {
 			continue
 		}
 
-		// If receipt exists with status, transaction is mined - remove from pending
+		// If receipt exists with status, the tx is mined — tombstone the row.
 		if receipt != nil && receipt.Result.Status != "" {
-			if err := db.DeletePendingTransaction(hash); err != nil {
-				configs.Logger.Error("Failed to delete mined pending transaction",
+			if err := db.UpdatePendingTransactionStatus(hash, "mined"); err != nil {
+				configs.Logger.Error("Failed to tombstone mined pending transaction",
 					zap.String("hash", hash),
 					zap.Error(err))
 			} else {
-				removedCount++
-				configs.Logger.Info("Removed mined transaction from pending",
+				tombstonedCount++
+				configs.Logger.Info("Tombstoned mined transaction in pending",
 					zap.String("hash", hash),
 					zap.String("blockNumber", receipt.Result.BlockNumber))
 			}
 		}
 	}
 
-	if removedCount > 0 {
+	if tombstonedCount > 0 {
 		configs.Logger.Info("Pending transaction verification complete",
-			zap.Int("removed", removedCount),
+			zap.Int("tombstoned", tombstonedCount),
 			zap.Int("total", len(hashes)))
 	}
 

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -107,13 +107,11 @@ func UserRoute(router *gin.Engine) {
 			return
 		}
 
-		// If transaction is mined, delete it from pending collection and redirect to mined tx
+		// If the row is a tombstone for a mined tx, return 404 — let the
+		// frontend fall back to /tx/<hash>. Don't delete here: the tombstone
+		// protects against a stale mempool poll re-inserting the row as
+		// "pending". CleanupOldPendingTransactions sweeps it after maxAge.
 		if transaction.Status == "mined" {
-			if err := db.DeleteMinedTransaction(hash); err != nil {
-				// Log error but don't fail the request
-				log.Printf("Error deleting mined transaction %s: %v\n", hash, err)
-			}
-			// Don't return the pending transaction - let frontend fetch from /tx endpoint
 			c.JSON(http.StatusNotFound, gin.H{
 				"error":   "Transaction has been mined",
 				"status":  "mined",


### PR DESCRIPTION
## Summary

Two fixes prompted by Gemini's review of #56 and a live repro on prod.

### 1. Gemini's race-condition catch (PR #56 regression)

In #56 I switched `UpdatePendingTransactionsInBlock` from `\$set status:\"mined\"` to `db.DeletePendingTransaction(hash)`. Gemini correctly flagged that this re-opens the race we were trying to close: when the QRL node still has the tx in \`txpool_content\` for ~1 s after a block is sealed, the next mempool poll falls into the upsert's **insert** path and `\$setOnInsert` writes `status:\"pending\"` again. The flicker is back.

Fix: tombstone in all three places that conclude a tx is mined.

- **`QRL2MongoDB/synchroniser/pending_sync.go::UpdatePendingTransactionsInBlock`** — revert to `UpdateOne(\$set status:\"mined\", lastSeen, blockNumber)`. With `status` excluded from `\$set` in `UpsertPendingTransaction` (from #56), the tombstone is preserved across re-polls.
- **`QRL2MongoDB/synchroniser/verifyPendingTransactions`** — was already calling `DeletePendingTransaction`. Same race, smaller window (runs every 5 min). Switch to `UpdatePendingTransactionStatus(hash, \"mined\")`.
- **`backendAPI/routes/routes.go::/pending-transaction/:hash`** — was calling `DeleteMinedTransaction` whenever a row had `status==\"mined\"`. Triggered on every API hit for a recently-mined tx — exactly the worst window. Drop the delete; return 404 only.

### 2. Cleanup path for tombstones

Tombstones can't grow unbounded. `CleanupOldPendingTransactions` filtered to `status:\"pending\"` only — useless for tombstones. Drop the status filter so it sweeps anything older than `maxAge` (24 h default). Mined tombstones get GC'd by the same hourly cleanup that drains forgotten-pending rows.

### 3. \`StoreLastKnownBlockNumber\` resilience (separate live bug we hit)

While deploying #56 we hit a live symptom that wasn't from #56 itself: confirmed txs showed \"Pending - -24 Confirmations\". Trace: the backend's \`latestBlock\` was 30 blocks behind the node, so frontend got a negative confirmation count and fell into the \"not > 0\" branch.

Cause: the legacy \`sync_state\` doc on prod only had \`block_number\` (the hex string), not \`block_number_int\`. The update path's guard:

\`\`\`go
bson.M{
    \"_id\": LastSyncedBlockID,
    \"block_number_int\": bson.M{\"\$lt\": blockNumberIntVal},
}
\`\`\`

…matches nothing when the field is missing, so every \`StoreLastKnownBlockNumber\` call silently failed. New blocks were being inserted into the \`blocks\` and \`transactions\` collections, but \`sync_state\` never moved.

Fix: \`\$or\` the filter with \`\{block_number_int: \{\$exists: false\}\}\`. The hex-string early-return guard above (existing.BlockNumber >= new → return) already prevents going backwards, so this stays safe.

Production was unblocked separately by a one-shot mongo update to backfill the int field. Once this PR ships, the bug can't recur on legacy databases.

## Why NOT parse blockNumber to uint64

Gemini also suggested converting block number to uint64 via \`HexToInt\`. Skipped: per `zondscan/CLAUDE.md`, the repo convention is \"Numeric values stored as hex strings with '0x' prefix in blocks/transactions\". Changing this one site would diverge from how every other handler reads the field.

## Test plan

- [ ] \`go build -o syncer\` in QRL2MongoDB, \`go build -o backendAPI\` in backendAPI, \`go vet ./...\` clean on both.
- [ ] Submit a fresh tx → \`/tx/<hash>\` redirects to \`/pending/tx/<hash>\` while pending; on inclusion, \`/pending/tx/<hash>\` redirects back to \`/tx/<hash>\` showing \"Confirmed\".
- [ ] Race check (manual): right after a block is sealed, query \`db.pending_transactions.find({_id: <hash>})\` — row exists with \`status:\"mined\"\` (tombstone), not absent. Wait through 2–3 mempool sync intervals — status stays \"mined\".
- [ ] After 24 h: \`db.pending_transactions.countDocuments({status:\"mined\", lastSeen: <24h ago>})\` is 0 (cleanup swept them).
- [ ] sync_state advances normally: \`db.sync_state.findOne()\` updates as new blocks arrive (both \`block_number\` and \`block_number_int\` move).