### PR TITLE
chore(pending): remove unused DeleteMinedTransaction helper

### DIFF
--- a/backendAPI/db/pending.go
+++ b/backendAPI/db/pending.go
@@ -90,13 +90,3 @@ func GetPendingTransactionByHash(hash string) (*models.PendingTransaction, error
 
 	return &transaction, nil
 }
-
-// DeleteMinedTransaction removes a transaction from the pending_transactions collection once it's mined
-func DeleteMinedTransaction(hash string) error {
-    collection := configs.GetCollection(configs.DB, PENDING_COLLECTION)
-    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-    defer cancel()
-
-    _, err := collection.DeleteOne(ctx, bson.M{"_id": hash})
-    return err
-}


### PR DESCRIPTION
## Summary

After #57, `db.DeleteMinedTransaction` has zero callers in the repo — the `/pending-transaction/:hash` handler now returns 404 in the mined branch without touching the row, so the tombstone is preserved across mempool re-polls.

Verified dead before deleting:

```
$ grep -rn "DeleteMinedTransaction" --include='*.go' .   # only the def
$ go build ./...                                          # passes after removal
```

## Test plan

- [ ] `go build -o backendAPI main.go` in `backendAPI/` succeeds (already verified locally).