### PR TITLE
fix(pending): consistent 404 + unify tombstone shape (Gemini #57 follow-up)

### DIFF
--- a/QRL2MongoDB/synchroniser/pending_sync.go
+++ b/QRL2MongoDB/synchroniser/pending_sync.go
@@ -82,17 +82,15 @@ func UpdatePendingTransactionsInBlock(block *models.ZondDatabaseBlock) error {
 	// back to "pending". Since status is excluded from $set in the upsert,
 	// an existing tombstone is preserved across re-polls.
 	// CleanupOldPendingTransactions sweeps these rows once they age out.
+	//
+	// Only status + lastSeen change here — match the shape that
+	// verifyPendingTransactions/UpdatePendingTransactionStatus writes, so
+	// both tombstone paths produce identical rows. blockNumber lives in
+	// the blocks/transactions collections.
 	for _, tx := range pendingTxs {
 		if blockTxs[tx.Hash] {
-			update := bson.M{
-				"$set": bson.M{
-					"status":      "mined",
-					"lastSeen":    time.Now(),
-					"blockNumber": block.Result.Number,
-				},
-			}
-			if _, err := collection.UpdateOne(ctx, bson.M{"_id": tx.Hash}, update); err != nil {
-				configs.Logger.Error("Failed to update mined transaction status",
+			if err := db.UpdatePendingTransactionStatus(tx.Hash, "mined"); err != nil {
+				configs.Logger.Error("Failed to tombstone mined transaction",
 					zap.String("hash", tx.Hash),
 					zap.Error(err))
 				continue

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -79,22 +78,22 @@ func UserRoute(router *gin.Engine) {
 
 		// If not found in pending, check if it's in the transactions collection
 		if transaction == nil {
-			// Check if transaction exists in the transactions collection
 			tx, err := db.GetTransactionByHash(hash)
 			if err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 				return
 			}
 
+			// Mined tx whose tombstone was already swept — return 404 in the
+			// same shape as the tombstone branch below. The frontend treats
+			// any non-200 from this endpoint as "not pending" and fetches
+			// /tx/:hash for the mined payload, so returning the mined details
+			// here just duplicates work and creates a state-dependent API.
 			if tx != nil {
-				// Transaction is mined - return formatted response
-				c.JSON(http.StatusOK, gin.H{
-					"transaction": gin.H{
-						"hash":        tx.Hash, // Already has 0x prefix
-						"status":      "mined",
-						"blockNumber": tx.BlockNumber,
-						"timestamp":   time.Now().Unix(),
-					},
+				c.JSON(http.StatusNotFound, gin.H{
+					"error":   "Transaction has been mined",
+					"status":  "mined",
+					"details": "This transaction has been confirmed. Please view it as a confirmed transaction.",
 				})
 				return
 			}


### PR DESCRIPTION
## Summary

Both fixes from Gemini's review of #57.

### A. Consistent 404 from `/pending-transaction/:hash`

Before: the handler returned 200 with mined details when no pending row existed but the tx was in the `transactions` collection, while the tombstone branch returned 404. Same logical state ("this tx is mined") — different response, depending on whether the cleanup sweep had run yet. After 24h+ that becomes a state-dependent API surface.

After: 404 in both cases. The frontend already treats any non-200 from this endpoint as "not pending" and falls back to `/tx/:hash` for the mined payload, so the duplicate-mined response was dead weight.

### B. Unified tombstone shape

Before: `UpdatePendingTransactionsInBlock` wrote `{status, lastSeen, blockNumber}` via a raw `$set`, but `blockNumber` isn't on the syncer's `models.PendingTransaction` struct (so it was silently dropped on decode), and `verifyPendingTransactions` → `UpdatePendingTransactionStatus` only wrote `{status, lastSeen}`. Two tombstone paths, differently-shaped rows.

After: `UpdatePendingTransactionsInBlock` calls the same `UpdatePendingTransactionStatus` helper. Both paths now write exactly `{status:"mined", lastSeen:now}`. Block number is canonically in `blocks`/`transactions` anyway.

## Test plan

- [ ] `go build` + `go vet` on both QRL2MongoDB and backendAPI — done locally.
- [ ] After deploy: visit `/tx/<freshly-mined-hash>` → renders Confirmed with positive confirmations.
- [ ] After 24h+: `/pending-transaction/<old-hash>` returns 404 regardless of whether the tombstone is still in `pending_transactions` or has been swept.
- [ ] `db.pending_transactions.findOne({status:"mined"})` rows have only `{_id, status:"mined", lastSeen, ...mempool fields, createdAt}` — no leftover `blockNumber` on newly tombstoned rows (legacy ones from before this PR are fine).