### PR TITLE
fix(sync): hoist type assertion above ProcessTransactions in batch consumer

### DIFF
--- a/QRL2MongoDB/synchroniser/producer_consumer.go
+++ b/QRL2MongoDB/synchroniser/producer_consumer.go
@@ -65,23 +65,25 @@ func consumer(ch <-chan (<-chan Data)) {
 					configs.Logger.Info("Inserted block batch",
 						zap.Int("count", len(data.blockData)))
 
+					// blockData is []interface{} (see Data struct). Assert before
+					// calling ProcessTransactions: that function does its own
+					// unchecked .(models.ZondDatabaseBlock) and would panic the
+					// consumer goroutine on a bad entry, which would render any
+					// subsequent safety check unreachable.
 					for x := 0; x < len(data.blockNumbers); x++ {
-						db.ProcessTransactions(data.blockData[x])
+						blk, ok := data.blockData[x].(models.ZondDatabaseBlock)
+						if !ok {
+							configs.Logger.Warn("Unexpected blockData type in batch consumer, skipping block",
+								zap.Int("blockNumber", data.blockNumbers[x]))
+							continue
+						}
+						db.ProcessTransactions(blk)
 						// Tombstone any pending rows whose hashes are in this
 						// block. The single-block path (sync.go) calls this
 						// inline; without it here, batch-sync (first-sync /
 						// behind-the-tip catch-up) leaves rows as "pending"
 						// until verifyPendingTransactions sweeps them — up to
 						// 5 minutes after the tx is confirmed on-chain.
-						// blockData is []interface{} (see Data struct); use
-						// comma-ok so a bad type doesn't panic the whole
-						// consumer.
-						blk, ok := data.blockData[x].(models.ZondDatabaseBlock)
-						if !ok {
-							configs.Logger.Warn("Unexpected blockData type in batch consumer, skipping tombstone",
-								zap.Int("blockNumber", data.blockNumbers[x]))
-							continue
-						}
 						if err := UpdatePendingTransactionsInBlock(&blk); err != nil {
 							configs.Logger.Error("Failed to update pending transactions in batch block",
 								zap.String("block", blk.Result.Number),


### PR DESCRIPTION
## Summary

Gemini's HIGH-severity catch on #60: my added comma-ok safety check at `producer_consumer.go:79` was unreachable for the case it was supposed to defend against. `db.ProcessTransactions` (called on the previous line) does its own unchecked `.(models.ZondDatabaseBlock)` assertion, so a bad entry panics the consumer goroutine first — before my safety check ever runs.

Fix: hoist the comma-ok assertion above `ProcessTransactions`. Both `ProcessTransactions` and `UpdatePendingTransactionsInBlock` now receive the asserted concrete value; the consumer can't panic on a mistyped `blockData` entry.

## Test plan

- [ ] `go build` + `go vet` — done locally.
- [ ] After deploy: normal block processing continues unchanged (the assertion succeeds for legitimate entries — same path as before).