### PR TITLE
fix(scalability/sprint-1): eliminate hex-string sort/range traps on blocks

### DIFF
--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -63,10 +63,11 @@ func GetLatestBlockFromDB() *models.ZondDatabaseBlock {
 	ctx, cancel := context.WithTimeout(context.Background(), DBTimeout)
 	defer cancel()
 
-	// Query for the latest block by sorting on timestamp (more reliable than hex string sorting)
+	// Sort by blockNumberInt (numeric) — hex strings on result.number /
+	// result.timestamp lex-sort wrong at width boundaries.
 	findOptions := options.FindOne().
 		SetProjection(bson.M{"result.number": 1, "result.timestamp": 1}).
-		SetSort(bson.M{"result.timestamp": -1})
+		SetSort(bson.M{"blockNumberInt": -1})
 
 	var block models.ZondDatabaseBlock
 	err := configs.BlocksCollections.FindOne(ctx, bson.D{}, findOptions).Decode(&block)
@@ -294,9 +295,11 @@ func GetLastKnownBlockNumberFromInitialSync() string {
 		return result.BlockNumber
 	}
 
-	// If no record exists, find the oldest block in the DB
+	// If no record exists, find the oldest block in the DB. Sort ascending by
+	// blockNumberInt — sorting by result.number (hex string) would lex-sort
+	// "0x10" before "0x9" and return the wrong "oldest" block.
 	var block models.ZondDatabaseBlock
-	findOptions := options.FindOne().SetProjection(bson.M{"result.number": 1}).SetSort(bson.M{"result.number": 1})
+	findOptions := options.FindOne().SetProjection(bson.M{"result.number": 1}).SetSort(bson.M{"blockNumberInt": 1})
 	err = configs.BlocksCollections.FindOne(ctx, bson.M{}, findOptions).Decode(&block)
 
 	if err == nil && block.Result.Number != "" {
@@ -526,14 +529,17 @@ func InsertManyBlockDocuments(blocks []interface{}) {
 	}
 }
 
-// Rollback removes all blocks after the given block number and updates the sync state
+// Rollback removes all blocks after the given block number and updates the sync state.
+// Filter on blockNumberInt (numeric), NOT result.number (hex string) — lex comparison
+// on hex strings produces wrong results (e.g. "0xa" > "0x100" lexicographically),
+// which would leave stale blocks above the rollback point during chain reorgs and
+// silently corrupt the chain view.
 func Rollback(blockNumber string) error {
 	ctx := context.Background()
 
-	// Find all blocks after the given block number
 	filter := bson.M{
-		"result.number": bson.M{
-			"$gt": blockNumber,
+		"blockNumberInt": bson.M{
+			"$gt": HexToInt64(blockNumber),
 		},
 	}
 

--- a/backendAPI/db/block.go
+++ b/backendAPI/db/block.go
@@ -69,9 +69,14 @@ func ReturnLatestBlocks(page int, limit int) ([]models.Result, error) {
 		{Key: "result.transactions", Value: 1},
 	}
 
+	// Sort by blockNumberInt (numeric), NOT result.timestamp (hex string).
+	// Hex-string sort goes wrong at width boundaries (e.g. "0x6a019244" vs
+	// "0x70000000"), which would reorder the public Latest Blocks list and
+	// cause pagination to duplicate/drop rows. Block number monotonically
+	// tracks chain order; the blockNumberInt_desc_idx covers this sort.
 	opts := options.Find().
 		SetProjection(projection).
-		SetSort(primitive.D{{Key: "result.timestamp", Value: -1}})
+		SetSort(primitive.D{{Key: "blockNumberInt", Value: -1}})
 
 	if page == 0 {
 		page = 1


### PR DESCRIPTION
## Summary

First slice of the scalability work — Sprint 1 (safety). Closes the highest-severity item from the zondscan scalability audit (Rollback can silently corrupt the chain on reorgs) plus three sibling hex-sort traps on hot block-listing paths.

### Why hex-string ordering is broken

MongoDB sorts strings lexicographically. `"0xa"` > `"0x100"` lex, `"0x10"` < `"0x9"` lex. The blocks collection has carried a numeric `blockNumberInt` field with a `blockNumberInt_desc_idx` for a while now; the four sites here were the remaining hot paths still using the hex string.

### Changes

| File:line | Before | After |
|---|---|---|
| `QRL2MongoDB/db/blocks.go::Rollback` | `result.number $gt <hex>` | `blockNumberInt $gt HexToInt64(hex)` |
| `QRL2MongoDB/db/blocks.go::GetLatestBlockFromDB` | sort `result.timestamp -1` | sort `blockNumberInt -1` |
| `QRL2MongoDB/db/blocks.go` (oldest-block initial-sync) | sort `result.number 1` | sort `blockNumberInt 1` |
| `backendAPI/db/block.go::ReturnLatestBlocks` | sort `result.timestamp -1` | sort `blockNumberInt -1` |

Rollback is the data-corruption risk (rolling back to `"0x9"` would leave `"0x10"`, `"0x100"`, etc. in place). The others would have started misordering recent blocks once Unix-timestamp hex width crosses (~`0x6fffffff` → `0x70000000` boundary).

### Deferred to a follow-up

Same bug class on different fields, needs a schema migration to add `blockTimestampInt`:
- `QRL2MongoDB/db/volume.go::GetDailyTransactionVolume` — hex-string range on `blockTimestamp`
- `backendAPI/db/transaction.go::ReturnInternalTransactionsByAddress` — hex-string sort on `blockTimestamp`

## Test plan

- [ ] `go build` + `go vet` on both projects — done.
- [ ] After deploy: `/blocks` Latest Blocks list ordered correctly (highest block first); pagination doesn't duplicate or drop rows near hex boundaries.
- [ ] sync_state-driven flows unchanged (we already sorted blockNumberInt in sync_state).