### PR TITLE
fix(rollback): validate hex input to prevent chain-wipe on malformed call

### DIFF
--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -5,6 +5,7 @@ import (
 	"QRL2MongoDB/models"
 	"QRL2MongoDB/utils"
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -535,11 +536,25 @@ func InsertManyBlockDocuments(blocks []interface{}) {
 // which would leave stale blocks above the rollback point during chain reorgs and
 // silently corrupt the chain view.
 func Rollback(blockNumber string) error {
+	// Validate the input BEFORE building the filter. HexToInt64 returns 0
+	// on any parse failure (empty string, missing 0x, non-hex chars). With
+	// a $gt: 0 filter, a malformed blockNumber would delete every block
+	// except genesis — strictly worse than the original lex-sort bug we
+	// were fixing. Refuse to proceed unless the input is a real hex value.
+	s := strings.TrimPrefix(blockNumber, "0x")
+	if s == "" {
+		return fmt.Errorf("rollback: empty block number")
+	}
+	rollbackTo, err := strconv.ParseInt(s, 16, 64)
+	if err != nil {
+		return fmt.Errorf("rollback: invalid hex block number %q: %w", blockNumber, err)
+	}
+
 	ctx := context.Background()
 
 	filter := bson.M{
 		"blockNumberInt": bson.M{
-			"$gt": HexToInt64(blockNumber),
+			"$gt": rollbackTo,
 		},
 	}
 

--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -536,11 +536,13 @@ func InsertManyBlockDocuments(blocks []interface{}) {
 // which would leave stale blocks above the rollback point during chain reorgs and
 // silently corrupt the chain view.
 func Rollback(blockNumber string) error {
-	// Validate the input BEFORE building the filter. HexToInt64 returns 0
-	// on any parse failure (empty string, missing 0x, non-hex chars). With
-	// a $gt: 0 filter, a malformed blockNumber would delete every block
-	// except genesis — strictly worse than the original lex-sort bug we
-	// were fixing. Refuse to proceed unless the input is a real hex value.
+	// Validate the input BEFORE building the filter. HexToInt64 / HexToInt
+	// both silently return 0 on parse failure (empty string, missing 0x,
+	// non-hex chars). With a $gt: 0 filter, a malformed blockNumber would
+	// delete every block except genesis — strictly worse than the original
+	// lex-sort bug we were fixing. Parse explicitly so we get an error path,
+	// and reject negative values defensively (e.g. "0x-10" → -16 via
+	// strconv) which would also widen the filter dangerously.
 	s := strings.TrimPrefix(blockNumber, "0x")
 	if s == "" {
 		return fmt.Errorf("rollback: empty block number")
@@ -548,6 +550,9 @@ func Rollback(blockNumber string) error {
 	rollbackTo, err := strconv.ParseInt(s, 16, 64)
 	if err != nil {
 		return fmt.Errorf("rollback: invalid hex block number %q: %w", blockNumber, err)
+	}
+	if rollbackTo < 0 {
+		return fmt.Errorf("rollback: block number cannot be negative: %d", rollbackTo)
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Follow-up to Gemini's HIGH on #63. My switch from `result.number $gt` (lex) to `blockNumberInt $gt` (numeric) calls `HexToInt64(blockNumber)`, which returns `0` on any parse failure. With `{blockNumberInt: {\$gt: 0}}`, a malformed input (`""`, `"0x"`, non-hex chars) would `DeleteMany` every block above genesis — strictly worse than the original lex-sort bug we were fixing.

Validate the input in `Rollback` before constructing the filter:
- Strip `0x` prefix, require non-empty hex string
- Parse via `strconv.ParseInt(..., 16, 64)` and surface the error
- Return `fmt.Errorf` to the only caller (`sync.go:394` on parent-hash mismatch) instead of silently deleting the chain

Defense-in-depth — the caller still shouldn't pass empty input, but the blast radius of accidentally doing so should not be "wipe the chain".

## Test plan

- [ ] `go build` + `go vet` on QRL2MongoDB — done.
- [ ] Manual: confirm `Rollback("")`, `Rollback("0x")`, `Rollback("garbage")` now return a non-nil error and do not touch the blocks collection.
- [ ] `Rollback("0x10")` still works (numeric parse succeeds, deletes blocks above 16).

## Workflow note

Filing this as a separate PR because #63 was already merged. Per a workflow correction from this session, future PRs will wait for Gemini's auto-review (3-10 min) before being merged.