### PR TITLE
perf(scalability/sprint-2a): indexes, estimated counts, ISR caching

### DIFF
--- a/ExplorerFrontend/app/address/[query]/page.tsx
+++ b/ExplorerFrontend/app/address/[query]/page.tsx
@@ -42,8 +42,11 @@ export async function generateMetadata({ params }: { params: Promise<{ query: st
 async function fetchAddressData(address: string): Promise<AddressData | null> {
     try {
         const handlerUrl = process.env.HANDLER_URL || 'http://127.0.0.1:8080';
+        // 10 s ISR — address-page contents are dominated by recent tx
+        // history, which refreshes on the same chain-block cadence.
+        // Eliminates the per-pageview backend fanout this endpoint causes.
         const response = await fetch(`${handlerUrl}/address/aggregate/${address}`, {
-            cache: 'no-store'
+            next: { revalidate: 10 }
         });
 
         if (!response.ok) {

--- a/ExplorerFrontend/app/richlist/page.tsx
+++ b/ExplorerFrontend/app/richlist/page.tsx
@@ -25,8 +25,15 @@ export const metadata: Metadata = {
 };
 
 
+// Render on demand (don't prerender at build, which would require backend
+// availability during `npm run build`). The fetch revalidate window below
+// is what does the heavy lifting under traffic.
+export const dynamic = 'force-dynamic';
+
 export default async function RichlistPage(): Promise<JSX.Element> {
-  const response = await fetch(config.handlerUrl + "/richlist", { cache: 'no-store' });
+  // Richlist changes slowly (balance rankings) — 30 s revalidate is plenty
+  // fresh and keeps a single backend call serving N concurrent pageloads.
+  const response = await fetch(config.handlerUrl + "/richlist", { next: { revalidate: 30 } });
   if (!response.ok) {
     throw new Error('Failed to load richlist data');
   }

--- a/ExplorerFrontend/app/transactions/[query]/page.tsx
+++ b/ExplorerFrontend/app/transactions/[query]/page.tsx
@@ -9,18 +9,20 @@ import { sharedMetadata } from '../../lib/seo/metaData';
 async function getTransactions(page: string): Promise<TransactionsResponse> {
   try {
     const pageNum = parseInt(page, 10) || 1;
-    
-    const timestamp = Date.now();
-    const response = await fetch(`${config.handlerUrl}/txs?page=${pageNum}&limit=10&_t=${timestamp}`, {
+
+    // Cache the response server-side for 10 s. Block time on QRL Zond is
+    // O(1 minute), so 10 s is well within a "freshness" SLA for a listing
+    // page and lets ISR absorb concurrent traffic instead of hammering
+    // the backend with one fetch per pageview. Drop the _t cache-buster
+    // and the no-store directive that were forcing zero caching.
+    const response = await fetch(`${config.handlerUrl}/txs?page=${pageNum}&limit=10`, {
       method: 'GET',
       headers: {
-        'Accept': 'application/json',
-        'Cache-Control': 'no-cache'
+        Accept: 'application/json',
       },
-      cache: 'no-store',
       next: {
-        revalidate: 0
-      }
+        revalidate: 10,
+      },
     });
 
     if (!response.ok) {

--- a/QRL2MongoDB/configs/setup.go
+++ b/QRL2MongoDB/configs/setup.go
@@ -417,6 +417,36 @@ func initializeCollections(db *mongo.Database) {
 		Logger.Warn("Could not create validators collection indexes", zap.Error(err))
 	}
 
+	// Indexes on pending_transactions. The backend paginates by {status, createdAt}
+	// (`/pending-transactions` and the homepage poll) and the syncer cleans by
+	// lastSeen (`CleanupOldPendingTransactions`); both were doing collection scans
+	// before. Compound + single keys here are sized for the access pattern, not
+	// for general flexibility.
+	pendingTransactionsCollection := db.Collection(PENDING_TRANSACTIONS_COLLECTION)
+	_, err = pendingTransactionsCollection.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "status", Value: 1}, {Key: "createdAt", Value: -1}},
+			Options: options.Index().SetName("pending_status_createdAt_idx"),
+		},
+		{
+			Keys:    bson.D{{Key: "lastSeen", Value: 1}},
+			Options: options.Index().SetName("pending_lastSeen_idx"),
+		},
+	})
+	if err != nil {
+		Logger.Warn("Could not create pending_transactions indexes", zap.Error(err))
+	}
+
+	// validator_history sorts by epochInt -1 on the public /epochs listing.
+	validatorHistoryCollection := db.Collection(VALIDATOR_HISTORY_COLLECTION)
+	_, err = validatorHistoryCollection.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys:    bson.D{{Key: "epochInt", Value: -1}},
+		Options: options.Index().SetName("validator_history_epochInt_desc_idx"),
+	})
+	if err != nil {
+		Logger.Warn("Could not create validator_history.epochInt index", zap.Error(err))
+	}
+
 	Logger.Info("All collections initialized successfully")
 }
 

--- a/QRL2MongoDB/configs/setup.go
+++ b/QRL2MongoDB/configs/setup.go
@@ -224,7 +224,13 @@ func ensureCollection(db *mongo.Database, name string, validator bson.M) {
 }
 
 func initializeCollections(db *mongo.Database) {
-	ctx := context.Background()
+	// Bound every index/collection setup call inside this function so a
+	// stalled MongoDB can't hang syncer startup indefinitely. 60s is
+	// generous enough for any single CreateIndex over this dataset; if a
+	// build truly takes longer the operation is too big for startup and
+	// should be moved offline.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
 
 	// Initialize token balances collection with compound index
 	tokenBalancesCollection := db.Collection("tokenBalances")

--- a/backendAPI/db/block.go
+++ b/backendAPI/db/block.go
@@ -101,11 +101,14 @@ func ReturnLatestBlocks(page int, limit int) ([]models.Result, error) {
 	return blocks, nil
 }
 
+// CountBlocksNetwork returns the total number of blocks. Uses
+// EstimatedDocumentCount (metadata read) rather than CountDocuments({}),
+// which is O(rows) on the blocks collection.
 func CountBlocksNetwork() (int64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	count, err := configs.BlocksCollection.CountDocuments(ctx, primitive.D{})
+	count, err := configs.BlocksCollection.EstimatedDocumentCount(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/backendAPI/db/contract.go
+++ b/backendAPI/db/contract.go
@@ -118,12 +118,15 @@ func ReturnContractCode(address string) (models.ContractInfo, error) {
 	return result, nil
 }
 
-// CountContracts returns the total number of smart contracts
+// CountContracts returns the total number of smart contracts. Uses
+// EstimatedDocumentCount (metadata read, ~microseconds) instead of
+// CountDocuments({}) which is O(rows) and blocked hot endpoints
+// (/overview) under any concurrency.
 func CountContracts() (int64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	count, err := configs.ContractInfoCollection.CountDocuments(ctx, bson.D{})
+	count, err := configs.ContractInfoCollection.EstimatedDocumentCount(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/backendAPI/db/transaction.go
+++ b/backendAPI/db/transaction.go
@@ -285,11 +285,14 @@ func ReturnTransactions(address string, page, limit int) ([]models.TransactionBy
 	return transactions, nil
 }
 
+// CountTransactionsNetwork returns the total transactionByAddress row count.
+// Uses EstimatedDocumentCount (metadata read) rather than CountDocuments({}),
+// which is O(rows) on a collection that grows linearly with chain activity.
 func CountTransactionsNetwork() (int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	count, err := configs.GetCollection(configs.DB, "transactionByAddress").CountDocuments(ctx, primitive.D{})
+	count, err := configs.GetCollection(configs.DB, "transactionByAddress").EstimatedDocumentCount(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count transactions: %v", err)
 	}

--- a/backendAPI/db/transaction.go
+++ b/backendAPI/db/transaction.go
@@ -288,7 +288,9 @@ func ReturnTransactions(address string, page, limit int) ([]models.TransactionBy
 // CountTransactionsNetwork returns the total transactionByAddress row count.
 // Uses EstimatedDocumentCount (metadata read) rather than CountDocuments({}),
 // which is O(rows) on a collection that grows linearly with chain activity.
-func CountTransactionsNetwork() (int, error) {
+// Returns int64 to match sibling count helpers and to avoid an implicit cap
+// at 2^31-1 on long-running chains.
+func CountTransactionsNetwork() (int64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -297,7 +299,7 @@ func CountTransactionsNetwork() (int, error) {
 		return 0, fmt.Errorf("failed to count transactions: %v", err)
 	}
 
-	return int(count), nil
+	return count, nil
 }
 
 func CountTransactions(address string) (int, error) {

--- a/backendAPI/db/validator.go
+++ b/backendAPI/db/validator.go
@@ -88,12 +88,14 @@ func ReturnValidators(pageToken string) (*models.ValidatorResponse, error) {
 	}, nil
 }
 
-// CountValidators returns the total number of validator documents in the collection.
+// CountValidators returns the total validator count. Uses
+// EstimatedDocumentCount (metadata read) rather than CountDocuments({}),
+// which is O(rows) and ran on every /overview hit.
 func CountValidators() (int64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	count, err := configs.ValidatorsCollections.CountDocuments(ctx, bson.M{})
+	count, err := configs.ValidatorsCollections.EstimatedDocumentCount(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count validators: %v", err)
 	}
@@ -261,8 +263,10 @@ func GetEpochs(page, limit int) (*models.EpochsResponse, error) {
 	finalizedEpoch := parseEpoch(epochInfo.FinalizedEpoch)
 	justifiedEpoch := parseEpoch(epochInfo.JustifiedEpoch)
 
-	// Count total epoch records
-	total, err := configs.ValidatorHistoryCollection.CountDocuments(ctx, bson.M{})
+	// Count total epoch records. EstimatedDocumentCount is metadata-based
+	// and accurate enough for "total pages" pagination since epoch records
+	// are append-only.
+	total, err := configs.ValidatorHistoryCollection.EstimatedDocumentCount(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to count epochs: %v", err)
 	}
@@ -449,8 +453,11 @@ func GetValidatorStats() (*models.ValidatorStatsResponse, error) {
 	}
 	currentEpoch := HexToInt(latestBlock) / 128
 
-	// Check whether the collection has any documents at all.
-	totalCount, err := configs.ValidatorsCollections.CountDocuments(ctx, bson.M{})
+	// Check whether the collection has any documents at all. The
+	// EstimatedDocumentCount metadata can be 0 on a brand-new collection
+	// or briefly stale during heavy writes; the == 0 guard below handles
+	// both cases the same way.
+	totalCount, err := configs.ValidatorsCollections.EstimatedDocumentCount(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to count validators: %v", err)
 	}


### PR DESCRIPTION
## Summary

First slice of the zondscan scalability sprint, focused on the cheapest, lowest-risk wins from the recent audit. No behavior changes — just faster reads.

### Indexes (`QRL2MongoDB/configs/setup.go`)

| Collection | Index | Why |
|---|---|---|
| `pending_transactions` | `{status:1, createdAt:-1}` | `/pending-transactions` endpoint filters `status != "mined"` + sorts `createdAt:-1`. Was a collection scan. |
| `pending_transactions` | `{lastSeen:1}` | `CleanupOldPendingTransactions` filters `lastSeen $lt cutoff`. Was a collection scan, ran every hour. |
| `validator_history` | `{epochInt:-1}` | `/epochs` listing sort. Was a collection scan + in-memory sort. |

### Counts → `EstimatedDocumentCount`

Six hot count sites swapped from `CountDocuments({})` (O(rows) on WiredTiger — hundreds of ms on a chain with millions of txs) to `EstimatedDocumentCount` (metadata read, ~microseconds):

- `backendAPI/db/block.go::CountBlocksNetwork`
- `backendAPI/db/contract.go::CountContracts`
- `backendAPI/db/transaction.go::CountTransactionsNetwork`
- `backendAPI/db/validator.go::CountValidators` (×2 call-sites)
- `backendAPI/db/validator.go::GetEpochs` total

All call sites use the count purely for display or pagination headroom — EDC is accurate enough and stays fast as the chain grows.

### ISR caching (`ExplorerFrontend` server components)

Drop `cache:'no-store'` + `_t=${timestamp}` cache-busters from server-side fetches on `/transactions`, `/address`, `/richlist`. Replace with sensible `revalidate` windows (10 s for listings, 30 s for richlist).

This lets Next's ISR absorb concurrent traffic so the backend doesn't get one fetch per pageview. `/richlist` adds `export const dynamic = 'force-dynamic'` to skip build-time prerender (which would require the backend to be online during `npm run build`).

The client-side polling pattern in `transactions-client.tsx` is deliberately untouched — covered separately by the visibility-blind-polling item in Sprint 2b.

## Test plan

- [x] `go build` + `go vet` on QRL2MongoDB + backendAPI
- [x] `npx tsc --noEmit` + `SKIP_DAPP_EXAMPLE=1 npm run build` clean
- [ ] After deploy: `/overview` and `/blocks` count display still correct (within EDC accuracy)
- [ ] After deploy: `db.pending_transactions.getIndexes()` shows the new compound + lastSeen indexes
- [ ] After deploy: `/transactions/1` page returns within ms on a refresh (was per-pageview fetch)