### PR TITLE
perf(scalability/sprint-2b): in-process route cache + address pagination

### DIFF
--- a/backendAPI/cache/cache.go
+++ b/backendAPI/cache/cache.go
@@ -87,11 +87,30 @@ func (c *TTLCache) StartJanitor(interval time.Duration) {
 	}()
 }
 
+// evictExpired uses a two-phase lock so a large cache doesn't stall reads
+// while the janitor scans: a read lock to collect candidate keys, then a
+// brief write lock to delete them (re-checking expiry to avoid a TOCTOU
+// race where a concurrent GetOrCompute refreshed the entry between
+// passes).
 func (c *TTLCache) evictExpired() {
 	now := time.Now()
-	c.mu.Lock()
+
+	c.mu.RLock()
+	var expiredKeys []string
 	for k, e := range c.store {
 		if now.After(e.expires) {
+			expiredKeys = append(expiredKeys, k)
+		}
+	}
+	c.mu.RUnlock()
+
+	if len(expiredKeys) == 0 {
+		return
+	}
+
+	c.mu.Lock()
+	for _, k := range expiredKeys {
+		if e, ok := c.store[k]; ok && now.After(e.expires) {
 			delete(c.store, k)
 		}
 	}

--- a/backendAPI/cache/cache.go
+++ b/backendAPI/cache/cache.go
@@ -1,0 +1,99 @@
+// Package cache provides a tiny in-process TTL cache with singleflight
+// deduplication, used to absorb concurrent traffic on hot read endpoints
+// (/overview, /blocks, /txs, /pending-transactions, /latestblock,
+// /address/aggregate).
+//
+// Without this layer, every page-view fans out into 1-8 MongoDB queries,
+// and the homepage polls every 30 s — so at modest concurrency the same
+// queries are run hundreds of times per second. With the cache, identical
+// requests within the TTL window are served from memory, and the
+// singleflight Group ensures only ONE goroutine recomputes a key when it
+// expires (no "thundering herd" against MongoDB).
+//
+// Bounded by design: only a small set of route+params keys exist, so we
+// don't need LRU eviction. A periodic janitor purges expired entries to
+// keep the map from leaking memory under unusual key churn.
+package cache
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+type entry struct {
+	val     interface{}
+	expires time.Time
+}
+
+// TTLCache is concurrent-safe. Zero value is not usable — call New().
+type TTLCache struct {
+	mu    sync.RWMutex
+	store map[string]entry
+	sf    singleflight.Group
+}
+
+func New() *TTLCache {
+	return &TTLCache{store: make(map[string]entry)}
+}
+
+// GetOrCompute returns the cached value for key if it's still fresh.
+// Otherwise it calls fn (deduped across concurrent callers for the same
+// key via singleflight), caches the result with the given TTL, and
+// returns it. If fn returns an error nothing is cached.
+func (c *TTLCache) GetOrCompute(key string, ttl time.Duration, fn func() (interface{}, error)) (interface{}, error) {
+	if v, ok := c.get(key); ok {
+		return v, nil
+	}
+	v, err, _ := c.sf.Do(key, func() (interface{}, error) {
+		// Re-check under singleflight in case another caller just populated
+		// the entry while we were queued.
+		if v, ok := c.get(key); ok {
+			return v, nil
+		}
+		val, err := fn()
+		if err != nil {
+			return nil, err
+		}
+		c.mu.Lock()
+		c.store[key] = entry{val: val, expires: time.Now().Add(ttl)}
+		c.mu.Unlock()
+		return val, nil
+	})
+	return v, err
+}
+
+func (c *TTLCache) get(key string) (interface{}, bool) {
+	c.mu.RLock()
+	e, ok := c.store[key]
+	c.mu.RUnlock()
+	if !ok || time.Now().After(e.expires) {
+		return nil, false
+	}
+	return e.val, true
+}
+
+// StartJanitor spawns a goroutine that walks the store every `interval`
+// and deletes expired entries. Returns immediately; the goroutine runs
+// for the process lifetime.
+func (c *TTLCache) StartJanitor(interval time.Duration) {
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for range t.C {
+			c.evictExpired()
+		}
+	}()
+}
+
+func (c *TTLCache) evictExpired() {
+	now := time.Now()
+	c.mu.Lock()
+	for k, e := range c.store {
+		if now.After(e.expires) {
+			delete(c.store, k)
+		}
+	}
+	c.mu.Unlock()
+}

--- a/backendAPI/db/transaction.go
+++ b/backendAPI/db/transaction.go
@@ -61,7 +61,23 @@ func ReturnLatestTransactions() ([]models.TransactionByAddress, error) {
 	return transactions, nil
 }
 
-func ReturnAllInternalTransactionsByAddress(address string) ([]models.TraceResult, error) {
+// ReturnAllInternalTransactionsByAddress returns one page (default 10, max
+// 50) of internal transactions for the given address, sorted by
+// blockTimestamp desc. Pagination was added to keep the worst-case
+// $or+sort cost from blowing past the 10 s context budget on high-volume
+// addresses (validators, contracts) where the unpaginated 200-row hit
+// would routinely time out.
+func ReturnAllInternalTransactionsByAddress(address string, page, limit int) ([]models.TraceResult, error) {
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 {
+		limit = 10
+	}
+	if limit > 50 {
+		limit = 50
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -95,7 +111,8 @@ func ReturnAllInternalTransactionsByAddress(address string) ([]models.TraceResul
 	opts := options.Find().
 		SetProjection(projection).
 		SetSort(primitive.D{{Key: "blockTimestamp", Value: -1}}).
-		SetLimit(200)
+		SetSkip(int64((page - 1) * limit)).
+		SetLimit(int64(limit))
 
 	results, err := configs.InternalTransactionByAddressCollection.Find(ctx, filter, opts)
 	if err != nil {
@@ -122,7 +139,21 @@ func ReturnAllInternalTransactionsByAddress(address string) ([]models.TraceResul
 	return transactions, nil
 }
 
-func ReturnAllTransactionsByAddress(address string) ([]models.TransactionByAddress, error) {
+// ReturnAllTransactionsByAddress returns one page (default 10, max 50) of
+// transactions involving the address, sorted by timeStamp desc. Paginated
+// to bound the $or+sort cost: high-volume addresses (validators,
+// contracts) routinely timed out under the unpaginated 200-row hit.
+func ReturnAllTransactionsByAddress(address string, page, limit int) ([]models.TransactionByAddress, error) {
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 {
+		limit = 10
+	}
+	if limit > 50 {
+		limit = 50
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -150,7 +181,8 @@ func ReturnAllTransactionsByAddress(address string) ([]models.TransactionByAddre
 	opts := options.Find().
 		SetProjection(projection).
 		SetSort(primitive.D{{Key: "timeStamp", Value: -1}}).
-		SetLimit(200)
+		SetSkip(int64((page - 1) * limit)).
+		SetLimit(int64(limit))
 
 	results, err := configs.TransactionByAddressCollection.Find(ctx, filter, opts)
 	if err != nil {

--- a/backendAPI/db/transaction.go
+++ b/backendAPI/db/transaction.go
@@ -111,7 +111,7 @@ func ReturnAllInternalTransactionsByAddress(address string, page, limit int) ([]
 	opts := options.Find().
 		SetProjection(projection).
 		SetSort(primitive.D{{Key: "blockTimestamp", Value: -1}}).
-		SetSkip(int64((page - 1) * limit)).
+		SetSkip(int64(page-1) * int64(limit)).
 		SetLimit(int64(limit))
 
 	results, err := configs.InternalTransactionByAddressCollection.Find(ctx, filter, opts)
@@ -181,7 +181,7 @@ func ReturnAllTransactionsByAddress(address string, page, limit int) ([]models.T
 	opts := options.Find().
 		SetProjection(projection).
 		SetSort(primitive.D{{Key: "timeStamp", Value: -1}}).
-		SetSkip(int64((page - 1) * limit)).
+		SetSkip(int64(page-1) * int64(limit)).
 		SetLimit(int64(limit))
 
 	results, err := configs.TransactionByAddressCollection.Find(ctx, filter, opts)

--- a/backendAPI/go.mod
+++ b/backendAPI/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-playground/validator/v10 v10.19.0
 	github.com/joho/godotenv v1.5.1
 	go.mongodb.org/mongo-driver v1.8.4
+	golang.org/x/sync v0.19.0
 )
 
 require (
@@ -42,7 +43,6 @@ require (
 	golang.org/x/arch v0.7.0 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"backendAPI/cache"
 	"backendAPI/db"
 	"backendAPI/models"
 	"fmt"
@@ -8,10 +9,21 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo"
 )
+
+// routeCache absorbs concurrent traffic on read endpoints with a small TTL
+// (5–30 s depending on freshness needs). Singleflight inside the cache
+// guarantees only one goroutine recomputes a key when it expires, so
+// MongoDB never sees a "thundering herd" on cache miss.
+var routeCache = cache.New()
+
+func init() {
+	routeCache.StartJanitor(time.Minute)
+}
 
 // parseHexBlockNumber parses a "0x"-prefixed hex string into a uint64.
 func parseHexBlockNumber(hexStr string) (uint64, error) {
@@ -46,25 +58,25 @@ func UserRoute(router *gin.Engine) {
 	// Add pending transactions endpoint with pagination
 	router.GET("/pending-transactions", func(c *gin.Context) {
 		page, limit := getPaginationParams(c, 1, 10)
-
-		result, err := db.GetPendingTransactions(page, limit)
+		key := fmt.Sprintf("pending-tx:%d:%d", page, limit)
+		// Frontend polls this every 30 s × every user. 5 s TTL absorbs the
+		// herd; mempool freshness only suffers by at most 5 s.
+		v, err := routeCache.GetOrCompute(key, 5*time.Second, func() (interface{}, error) {
+			result, err := db.GetPendingTransactions(page, limit)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch pending transactions: %w", err)
+			}
+			if result.Transactions == nil {
+				result.Transactions = make([]models.PendingTransaction, 0)
+			}
+			return result, nil
+		})
 		if err != nil {
 			log.Printf("Error fetching pending transactions: %v", err)
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch pending transactions: %v", err),
-			})
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
-
-		// Log the result for debugging
-		log.Printf("Found %d pending transactions", len(result.Transactions))
-
-		// Return empty array instead of null for transactions
-		if result.Transactions == nil {
-			result.Transactions = make([]models.PendingTransaction, 0)
-		}
-
-		c.JSON(http.StatusOK, result)
+		c.JSON(http.StatusOK, v)
 	})
 
 	// Add endpoint for fetching a specific pending transaction
@@ -123,55 +135,49 @@ func UserRoute(router *gin.Engine) {
 	})
 
 	router.GET("/overview", func(c *gin.Context) {
-		// Get market cap with default value
-		marketCap := db.GetMarketCap()
+		// /overview is the homepage hero data — 8 separate Mongo round-trips
+		// per request. Cache the assembled payload for 10 s so N concurrent
+		// pageviews fan into 1 backend computation.
+		v, _ := routeCache.GetOrCompute("overview", 10*time.Second, func() (interface{}, error) {
+			marketCap := db.GetMarketCap()
+			currentPrice := db.GetCurrentPrice()
+			walletCount := db.GetWalletCount()
 
-		// Get current price with default value
-		currentPrice := db.GetCurrentPrice()
+			circulating := db.ReturnTotalCirculatingSupply()
+			if circulating == "" {
+				circulating = "65000000" // default when no data is available
+			}
 
-		// Get wallet count with default value
-		walletCount := db.GetWalletCount()
+			volume := db.ReturnDailyTransactionsVolume()
 
-		// Get circulating supply with default value
-		circulating := db.ReturnTotalCirculatingSupply()
-		if circulating == "" {
-			circulating = "65000000" // Default value when no data is available
-		}
+			validatorCount, err := db.CountValidators()
+			if err != nil {
+				validatorCount = 0
+			}
 
-		// Get daily transaction volume with default value
-		volume := db.ReturnDailyTransactionsVolume()
+			contractCount, err := db.CountContracts()
+			if err != nil {
+				contractCount = 0
+			}
 
-		// Get validator count
-		validatorCount, err := db.CountValidators()
-		if err != nil {
-			validatorCount = 0
-		}
+			tradingVolume := db.GetCurrentVolume()
 
-		// Get contract count
-		contractCount, err := db.CountContracts()
-		if err != nil {
-			contractCount = 0
-		}
-
-		// Get 24h trading volume
-		tradingVolume := db.GetCurrentVolume()
-
-		// Return response with default values if data isn't available
-
-		c.JSON(http.StatusOK, gin.H{
-			"marketcap":      marketCap,      // Returns 0 if not available
-			"currentPrice":   currentPrice,   // Returns 0 if not available
-			"countwallets":   walletCount,    // Returns 0 if not available
-			"circulating":    circulating,    // Returns "0" if not available
-			"volume":         volume,         // Returns 0 if not available
-			"tradingVolume":  tradingVolume,  // 24h trading volume from CoinGecko
-			"validatorCount": validatorCount, // Returns 0 if not available
-			"contractCount":  contractCount,  // Returns 0 if not available
-			"status": gin.H{
-				"syncing":         true, // Indicate that data is still being synced
-				"dataInitialized": marketCap > 0 || currentPrice > 0 || walletCount > 0 || circulating != "0" || volume > 0,
-			},
+			return gin.H{
+				"marketcap":      marketCap,
+				"currentPrice":   currentPrice,
+				"countwallets":   walletCount,
+				"circulating":    circulating,
+				"volume":         volume,
+				"tradingVolume":  tradingVolume,
+				"validatorCount": validatorCount,
+				"contractCount":  contractCount,
+				"status": gin.H{
+					"syncing":         true,
+					"dataInitialized": marketCap > 0 || currentPrice > 0 || walletCount > 0 || circulating != "0" || volume > 0,
+				},
+			}, nil
 		})
+		c.JSON(http.StatusOK, v)
 	})
 
 	// Price history endpoint for wallet apps and charts
@@ -230,7 +236,6 @@ func UserRoute(router *gin.Engine) {
 
 	router.GET("/txs", func(c *gin.Context) {
 		pageStr := c.Query("page")
-
 		page, err := strconv.Atoi(pageStr)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
@@ -239,49 +244,38 @@ func UserRoute(router *gin.Engine) {
 			return
 		}
 
-		txs, err := db.ReturnTransactionsNetwork(page)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch transactions: %v", err),
-			})
-			return
-		}
-
-		// Transaction count for the address
-		countTransactions, err := db.CountTransactionsNetwork()
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to count transactions: %v", err),
-			})
-			return
-		}
-
-		latestBlockNumber, err := db.GetLatestBlockFromSyncState()
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to get latest block: %v", err),
-			})
-			return
-		}
-
-		latestBlockNum, err := parseHexBlockNumber(latestBlockNumber)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to parse block number: %v", err),
-			})
-			return
-		}
-
-		// Return empty array instead of null if no transactions
-		if txs == nil {
-			txs = make([]models.TransactionByAddress, 0)
-		}
-
-		c.JSON(http.StatusOK, gin.H{
-			"txs":         txs,
-			"total":       countTransactions,
-			"latestBlock": latestBlockNum,
+		key := fmt.Sprintf("txs:%d", page)
+		v, err := routeCache.GetOrCompute(key, 10*time.Second, func() (interface{}, error) {
+			txs, err := db.ReturnTransactionsNetwork(page)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch transactions: %w", err)
+			}
+			countTransactions, err := db.CountTransactionsNetwork()
+			if err != nil {
+				return nil, fmt.Errorf("failed to count transactions: %w", err)
+			}
+			latestBlockNumber, err := db.GetLatestBlockFromSyncState()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get latest block: %w", err)
+			}
+			latestBlockNum, err := parseHexBlockNumber(latestBlockNumber)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse block number: %w", err)
+			}
+			if txs == nil {
+				txs = make([]models.TransactionByAddress, 0)
+			}
+			return gin.H{
+				"txs":         txs,
+				"total":       countTransactions,
+				"latestBlock": latestBlockNum,
+			}, nil
 		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, v)
 	})
 
 	router.GET("/walletdistribution/:query", func(c *gin.Context) {
@@ -301,70 +295,69 @@ func UserRoute(router *gin.Engine) {
 		param := c.Param("query")
 		// db functions normalize the address to canonical q-prefix internally.
 
-		// Single Address data
-		addressData, err := db.ReturnSingleAddress(param)
-		if err != nil && err != mongo.ErrNoDocuments {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Error querying address: %v", err)})
-			return
-		}
+		// Pagination for the tx-list aggregations. Defaults match the old
+		// implicit page-1 view; cap at 50 (the same cap the DB layer
+		// enforces) so a hostile caller can't push limit=10000.
+		page, limit := getPaginationParams(c, 1, 10)
 
-		// Transaction count for the address
-		countTransactions, err := db.CountTransactions(param)
-		if err != nil {
-			log.Printf("error counting transactions: %v", err)
-		}
+		key := fmt.Sprintf("addr:%s:%d:%d", strings.ToLower(param), page, limit)
+		v, err := routeCache.GetOrCompute(key, 10*time.Second, func() (interface{}, error) {
+			addressData, err := db.ReturnSingleAddress(param)
+			if err != nil && err != mongo.ErrNoDocuments {
+				return nil, fmt.Errorf("error querying address: %w", err)
+			}
 
-		// Rank of the address
-		rank, err := db.ReturnRankAddress(param)
-		if err != nil {
-			log.Printf("error getting rank: %v", err)
-		}
+			countTransactions, err := db.CountTransactions(param)
+			if err != nil {
+				log.Printf("error counting transactions: %v", err)
+			}
 
-		// Get all transactions by the address
-		transactionsByAddress, err := db.ReturnAllTransactionsByAddress(param)
-		if err != nil {
-			log.Printf("error getting transactions: %v", err)
-		}
+			rank, err := db.ReturnRankAddress(param)
+			if err != nil {
+				log.Printf("error getting rank: %v", err)
+			}
 
-		// Get all internal transactions by the address
-		internalTransactionsByAddress, err := db.ReturnAllInternalTransactionsByAddress(param)
-		if err != nil {
-			log.Printf("error getting internal transactions: %v", err)
-		}
+			transactionsByAddress, err := db.ReturnAllTransactionsByAddress(param, page, limit)
+			if err != nil {
+				log.Printf("error getting transactions: %v", err)
+			}
 
-		// Get contract code data
-		contractCodeData, err := db.ReturnContractCode(param)
-		if err != nil {
-			log.Printf("error getting contract code: %v", err)
-		}
+			internalTransactionsByAddress, err := db.ReturnAllInternalTransactionsByAddress(param, page, limit)
+			if err != nil {
+				log.Printf("error getting internal transactions: %v", err)
+			}
 
-		// Get latest block number
-		latestBlockNumber, err := db.GetLatestBlockFromSyncState()
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to get latest block: %v", err),
-			})
-			return
-		}
+			contractCodeData, err := db.ReturnContractCode(param)
+			if err != nil {
+				log.Printf("error getting contract code: %v", err)
+			}
 
-		latestBlockNum, err := parseHexBlockNumber(latestBlockNumber)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to parse block number: %v", err),
-			})
-			return
-		}
+			latestBlockNumber, err := db.GetLatestBlockFromSyncState()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get latest block: %w", err)
+			}
+			latestBlockNum, err := parseHexBlockNumber(latestBlockNumber)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse block number: %w", err)
+			}
 
-		// Response aggregation
-		c.JSON(http.StatusOK, gin.H{
-			"address":                          addressData,
-			"transactions_count":               countTransactions,
-			"rank":                             rank,
-			"transactions_by_address":          transactionsByAddress,
-			"internal_transactions_by_address": internalTransactionsByAddress,
-			"contract_code":                    contractCodeData,
-			"latestBlock":                      latestBlockNum,
+			return gin.H{
+				"address":                          addressData,
+				"transactions_count":               countTransactions,
+				"rank":                             rank,
+				"transactions_by_address":          transactionsByAddress,
+				"internal_transactions_by_address": internalTransactionsByAddress,
+				"contract_code":                    contractCodeData,
+				"latestBlock":                      latestBlockNum,
+				"page":                             page,
+				"limit":                            limit,
+			}, nil
 		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, v)
 	})
 
 	router.GET("/tx/:query", func(c *gin.Context) {
@@ -433,25 +426,25 @@ func UserRoute(router *gin.Engine) {
 	})
 
 	router.GET("/latestblock", func(c *gin.Context) {
-		blockNumber, err := db.GetLatestBlockFromSyncState()
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch latest block: %v", err),
-			})
-			return
-		}
-
-		num, err := parseHexBlockNumber(blockNumber)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Invalid block number format in sync state",
-			})
-			return
-		}
-
-		c.JSON(http.StatusOK, gin.H{
-			"blockNumber": num,
+		// Several frontend pages and external pollers hit this very often;
+		// a 5 s cache trims the load by orders of magnitude with no
+		// visible staleness (chain block time is much longer).
+		v, err := routeCache.GetOrCompute("latestblock", 5*time.Second, func() (interface{}, error) {
+			blockNumber, err := db.GetLatestBlockFromSyncState()
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch latest block: %w", err)
+			}
+			num, err := parseHexBlockNumber(blockNumber)
+			if err != nil {
+				return nil, fmt.Errorf("invalid block number format in sync state: %w", err)
+			}
+			return gin.H{"blockNumber": num}, nil
 		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, v)
 	})
 
 	router.GET("/coinbase/:query", func(c *gin.Context) {
@@ -464,43 +457,51 @@ func UserRoute(router *gin.Engine) {
 	})
 
 	router.GET("/richlist", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"richlist": db.ReturnRichlist()})
+		// Richlist (top wallets by balance) changes slowly — 30 s TTL.
+		v, _ := routeCache.GetOrCompute("richlist", 30*time.Second, func() (interface{}, error) {
+			return gin.H{"richlist": db.ReturnRichlist()}, nil
+		})
+		c.JSON(http.StatusOK, v)
 	})
 
 	router.GET("/blocks", func(c *gin.Context) {
 		page, limit := getPaginationParams(c, 1, 5)
-
-		blocks, err := db.ReturnLatestBlocks(page, limit)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch blocks"})
-			return
-		}
-
-		countBlocks, err := db.CountBlocksNetwork()
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to count blocks"})
-			return
-		}
-
-		// Limit total pages to 300
-		maxPages := int64(300)
-		maxBlocks := maxPages * int64(limit)
-		if countBlocks > maxBlocks {
-			countBlocks = maxBlocks
-		}
-
-		c.JSON(http.StatusOK, gin.H{
-			"blocks": blocks,
-			"total":  countBlocks,
+		key := fmt.Sprintf("blocks:%d:%d", page, limit)
+		v, err := routeCache.GetOrCompute(key, 10*time.Second, func() (interface{}, error) {
+			blocks, err := db.ReturnLatestBlocks(page, limit)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch blocks: %w", err)
+			}
+			countBlocks, err := db.CountBlocksNetwork()
+			if err != nil {
+				return nil, fmt.Errorf("failed to count blocks: %w", err)
+			}
+			// Limit total pages to 300
+			maxPages := int64(300)
+			maxBlocks := maxPages * int64(limit)
+			if countBlocks > maxBlocks {
+				countBlocks = maxBlocks
+			}
+			return gin.H{"blocks": blocks, "total": countBlocks}, nil
 		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, v)
 	})
 
 	router.GET("/blocksizes", func(c *gin.Context) {
-		query, err := db.ReturnBlockSizes()
-		if err != nil {
-			log.Printf("error fetching block sizes: %v", err)
-		}
-		c.JSON(http.StatusOK, gin.H{"response": query})
+		// Block-size aggregate is a precomputed collection refreshed by the
+		// syncer's periodic task — safe to cache for longer.
+		v, _ := routeCache.GetOrCompute("blocksizes", 30*time.Second, func() (interface{}, error) {
+			query, err := db.ReturnBlockSizes()
+			if err != nil {
+				log.Printf("error fetching block sizes: %v", err)
+			}
+			return gin.H{"response": query}, nil
+		})
+		c.JSON(http.StatusOK, v)
 	})
 
 	// Paginated epochs listing

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -138,7 +138,7 @@ func UserRoute(router *gin.Engine) {
 		// /overview is the homepage hero data — 8 separate Mongo round-trips
 		// per request. Cache the assembled payload for 10 s so N concurrent
 		// pageviews fan into 1 backend computation.
-		v, _ := routeCache.GetOrCompute("overview", 10*time.Second, func() (interface{}, error) {
+		v, err := routeCache.GetOrCompute("overview", 10*time.Second, func() (interface{}, error) {
 			marketCap := db.GetMarketCap()
 			currentPrice := db.GetCurrentPrice()
 			walletCount := db.GetWalletCount()
@@ -177,6 +177,10 @@ func UserRoute(router *gin.Engine) {
 				},
 			}, nil
 		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusOK, v)
 	})
 
@@ -458,9 +462,13 @@ func UserRoute(router *gin.Engine) {
 
 	router.GET("/richlist", func(c *gin.Context) {
 		// Richlist (top wallets by balance) changes slowly — 30 s TTL.
-		v, _ := routeCache.GetOrCompute("richlist", 30*time.Second, func() (interface{}, error) {
+		v, err := routeCache.GetOrCompute("richlist", 30*time.Second, func() (interface{}, error) {
 			return gin.H{"richlist": db.ReturnRichlist()}, nil
 		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusOK, v)
 	})
 
@@ -494,13 +502,17 @@ func UserRoute(router *gin.Engine) {
 	router.GET("/blocksizes", func(c *gin.Context) {
 		// Block-size aggregate is a precomputed collection refreshed by the
 		// syncer's periodic task — safe to cache for longer.
-		v, _ := routeCache.GetOrCompute("blocksizes", 30*time.Second, func() (interface{}, error) {
+		v, err := routeCache.GetOrCompute("blocksizes", 30*time.Second, func() (interface{}, error) {
 			query, err := db.ReturnBlockSizes()
 			if err != nil {
 				log.Printf("error fetching block sizes: %v", err)
 			}
 			return gin.H{"response": query}, nil
 		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusOK, v)
 	})
 

--- a/nginx.conf.example
+++ b/nginx.conf.example
@@ -2,6 +2,15 @@
 # Copy this file to /etc/nginx/sites-available/your-domain.com
 # Then create a symlink: ln -s /etc/nginx/sites-available/your-domain.com /etc/nginx/sites-enabled/
 
+# Per-IP rate-limit zone. Keep this in the http {} context (it usually lives
+# in /etc/nginx/nginx.conf, NOT inside a server {} block). The zone here is
+# 10 MB which fits roughly 160k tracked IPs; the rate cap is 20 req/s per
+# IP, with a small burst bucket so genuine page-load fanouts (multiple
+# API calls during a single page render) don't get rejected. Tune `rate`
+# and `burst` upward if legitimate clients hit them.
+#
+# limit_req_zone $binary_remote_addr zone=zondscan_api:10m rate=20r/s;
+
 # HTTP redirect to HTTPS
 server {
     listen 80;
@@ -40,6 +49,14 @@ server {
 
     # Backend API proxy (Go handler)
     location /api/ {
+        # Per-IP rate limit. Uncomment after defining `zondscan_api` in
+        # the http {} context (see the top of this file). `burst=40
+        # nodelay` lets a burst of 40 requests through immediately, then
+        # falls back to the steady 20 req/s cap. Returns 503 when
+        # exceeded — adjust to 429 with `limit_req_status 429;` if you
+        # want a clearer signal to abusers.
+        # limit_req zone=zondscan_api burst=40 nodelay;
+
         proxy_pass http://127.0.0.1:8080/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
## Summary

Second slice of the zondscan scalability sprint. Adds a small TTL cache with singleflight in front of the hot read endpoints, paginates the biggest unbounded address query, and ships an nginx rate-limit template. Together this addresses H1 (no caching), H7 (address aggregate no pagination), and H8 (no rate limiting) from the audit.

### Cache layer (`backendAPI/cache/cache.go`)

New `TTLCache`: ~80 lines, just a map + singleflight from `golang.org/x/sync`. Singleflight ensures a cache miss for a popular key triggers exactly one MongoDB computation across N concurrent callers, eliminating the thundering-herd risk on cache expiry. A janitor goroutine evicts expired entries every minute; no LRU needed because the key set is bounded by route shape × small param ranges.

| Endpoint | Cache key | TTL |
|---|---|---|
| `/overview` | `overview` | 10 s (was 8 mongo ops/req) |
| `/latestblock` | `latestblock` | 5 s |
| `/blocks?page=N&limit=L` | `blocks:N:L` | 10 s |
| `/txs?page=N` | `txs:N` | 10 s |
| `/pending-transactions?page=N&limit=L` | `pending-tx:N:L` | 5 s (homepage polls this) |
| `/blocksizes` | `blocksizes` | 30 s |
| `/richlist` | `richlist` | 30 s |
| `/address/aggregate/:q?page=N&limit=L` | `addr:<lc-q>:N:L` | 10 s |

Errors propagate; nothing is cached on failure.

### Address pagination

`ReturnAllTransactionsByAddress` + `ReturnAllInternalTransactionsByAddress` now take `(page, limit)` (default 10, max 50). The `/address/aggregate/:q` route reads `page`/`limit` via the existing `getPaginationParams` helper. High-volume addresses (validators, mixers, contracts) were routinely timing out under the unpaginated 200-row `\$or+sort` hit; capped to a 50-row Skip+Limit now.

### nginx rate limit

`nginx.conf.example` documents the per-IP `limit_req_zone` + `limit_req` directives. Shipped commented-out so the file still parses in environments that don't define the zone in `http {}`. 20 req/s steady, burst 40, per IP, on `/api/`. Ops uncomments after copying the zone into the global `nginx.conf`.

## Test plan

- [x] `go build` + `go vet` on backendAPI + QRL2MongoDB
- [ ] After deploy: hit `/overview` twice in quick succession; the first should run the 8 mongo queries, the second should be ~ms (cache hit).
- [ ] Hit `/address/aggregate/<high-vol-address>?page=2&limit=20` — returns a 20-row slice without timeout.
- [ ] `/pending-transactions` polling load on Mongo is visibly lower in `mongostat`.
- [ ] No regression on dynamic endpoints (`/tx/:hash`, `/block/:query`, `/pending-transaction/:hash`) — those are intentionally NOT cached.