### PR TITLE
feat(explorer): auto-refresh pending tx + /gas page + home gas tile

### DIFF
--- a/ExplorerFrontend/app/components/Sidebar.tsx
+++ b/ExplorerFrontend/app/components/Sidebar.tsx
@@ -35,6 +35,7 @@ const navGroups: NavGroup[] = [
       { name: 'Latest Blocks', description: 'View all Blocks', href: '/blocks/1', imgSrc: BlockchainIcon },
       { name: 'Epochs', description: 'View all Epochs', href: '/epochs/1', imgSrc: BlockchainIcon },
       { name: 'Validators', description: 'Network Validators', href: '/validators', imgSrc: ContractIcon },
+      { name: 'Gas', description: 'Network gas metrics', href: '/gas', imgSrc: BlockchainIcon },
     ],
   },
   {

--- a/ExplorerFrontend/app/gas/gas-client.tsx
+++ b/ExplorerFrontend/app/gas/gas-client.tsx
@@ -42,7 +42,15 @@ function StatCard({ label, value, sub }: { label: string; value: string; sub?: s
   );
 }
 
-function GasUsedChart({ rows }: { rows: GasHistoryRow[] }): JSX.Element {
+function formatAxisTick(unixSec: number, range: '24h' | '7d'): string {
+  const d = new Date(unixSec * 1000);
+  if (range === '7d') {
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+  }
+  return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', timeZone: 'UTC', hour12: false });
+}
+
+function GasUsedChart({ rows, range }: { rows: GasHistoryRow[]; range: '24h' | '7d' }): JSX.Element {
   // Inline SVG line+area chart. Self-contained so we don't fight with
   // AreaChart's block-shape coupling.
   const points = useMemo(() => {
@@ -105,7 +113,7 @@ function GasUsedChart({ rows }: { rows: GasHistoryRow[] }): JSX.Element {
         {/* X labels */}
         {xTicks.map((t, i) => (
           <text key={i} x={sx(t)} y={h - 8} textAnchor="middle" fontSize="10" fill="#9ca3af">
-            {new Date(t * 1000).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', timeZone: 'UTC', hour12: false })}
+            {formatAxisTick(t, range)}
           </text>
         ))}
       </svg>
@@ -275,7 +283,7 @@ export default function GasClient(): JSX.Element {
           <h3 className="text-sm font-semibold text-[#ffa729]">Gas Used per Block</h3>
           <Badge variant="neutral">{range}</Badge>
         </div>
-        <GasUsedChart rows={history} />
+        <GasUsedChart rows={history} range={range} />
       </div>
 
       <div className="rounded-xl bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f] border border-[#3d3d3d] shadow-lg p-4 sm:p-6">

--- a/ExplorerFrontend/app/gas/gas-client.tsx
+++ b/ExplorerFrontend/app/gas/gas-client.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import axios from 'axios';
+import config from '../../config';
+import Badge from '../components/Badge';
+import { formatGasPrice } from '../lib/helpers';
+
+interface GasSummary {
+  avgGasPriceHex: string;
+  avgGasUsedHex: string;
+  avgGasLimitHex: string;
+  avgBlockTimeSec: number;
+  pendingCount: number;
+  lastBlockNumberHex: string;
+  lastGasUsedHex: string;
+  lastGasLimitHex: string;
+  gasPriceHistogram: { gweiLow: number; gweiHigh: number; count: number }[];
+}
+
+interface GasHistoryRow {
+  blockNumber: number;
+  timestamp: number;
+  gasUsed: string;
+  gasLimit: string;
+  baseFeePerGas: string;
+  txCount: number;
+}
+
+interface GasHistoryResp {
+  range: '24h' | '7d';
+  data: GasHistoryRow[];
+}
+
+function hexBig(s: string | undefined | null): bigint {
+  if (!s) return BigInt(0);
+  try {
+    return BigInt(s.startsWith('0x') ? s : '0x' + s);
+  } catch {
+    return BigInt(0);
+  }
+}
+
+function hexToNumber(s: string | undefined | null): number {
+  if (!s) return 0;
+  try {
+    return Number(BigInt(s.startsWith('0x') ? s : '0x' + s));
+  } catch {
+    return 0;
+  }
+}
+
+function formatBigGas(s: string | undefined | null): string {
+  if (!s) return '—';
+  const v = hexBig(s);
+  if (v === BigInt(0)) return '0';
+  return v.toLocaleString();
+}
+
+function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }): JSX.Element {
+  return (
+    <div className="rounded-xl bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f] border border-[#3d3d3d] shadow-lg p-4">
+      <p className="text-xs uppercase tracking-wider text-gray-400 mb-1">{label}</p>
+      <p className="text-xl font-semibold text-[#ffa729] truncate">{value}</p>
+      {sub && <p className="text-xs text-gray-500 mt-1">{sub}</p>}
+    </div>
+  );
+}
+
+function GasUsedChart({ rows }: { rows: GasHistoryRow[] }): JSX.Element {
+  // Inline SVG line+area chart. Self-contained so we don't fight with
+  // AreaChart's block-shape coupling.
+  const points = useMemo(() => {
+    return rows
+      .map((r) => ({ x: r.timestamp, y: hexToNumber(r.gasUsed) }))
+      .filter((p) => p.x > 0);
+  }, [rows]);
+
+  if (points.length < 2) {
+    return (
+      <div className="text-center text-gray-500 text-sm py-12">
+        Not enough gas history yet — check back after the syncer has run its periodic task.
+      </div>
+    );
+  }
+
+  const w = 800;
+  const h = 240;
+  const pad = { l: 56, r: 16, t: 12, b: 28 };
+  const innerW = w - pad.l - pad.r;
+  const innerH = h - pad.t - pad.b;
+  const xs = points.map((p) => p.x);
+  const ys = points.map((p) => p.y);
+  const xMin = Math.min(...xs);
+  const xMax = Math.max(...xs);
+  const yMin = 0;
+  const yMax = Math.max(...ys) * 1.05 || 1;
+  const sx = (x: number) => pad.l + ((x - xMin) / (xMax - xMin || 1)) * innerW;
+  const sy = (y: number) => pad.t + innerH - ((y - yMin) / (yMax - yMin || 1)) * innerH;
+
+  const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'}${sx(p.x).toFixed(1)},${sy(p.y).toFixed(1)}`).join(' ');
+  const areaPath = `${linePath} L${sx(points[points.length - 1].x).toFixed(1)},${sy(0).toFixed(1)} L${sx(points[0].x).toFixed(1)},${sy(0).toFixed(1)} Z`;
+
+  // Y-axis tick labels (4 ticks)
+  const yTicks = [0.25, 0.5, 0.75, 1].map((f) => yMax * f);
+  // X-axis tick labels (5 ticks)
+  const xTicks = Array.from({ length: 5 }, (_, i) => xMin + ((xMax - xMin) * i) / 4);
+
+  return (
+    <div className="w-full overflow-x-auto">
+      <svg viewBox={`0 0 ${w} ${h}`} className="w-full h-auto" preserveAspectRatio="xMidYMid meet">
+        <defs>
+          <linearGradient id="gasGradient" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="#ffa729" stopOpacity="0.7" />
+            <stop offset="100%" stopColor="#ffa729" stopOpacity="0.05" />
+          </linearGradient>
+        </defs>
+        {/* Grid */}
+        {yTicks.map((t, i) => (
+          <line key={i} x1={pad.l} x2={w - pad.r} y1={sy(t)} y2={sy(t)} stroke="#3d3d3d" strokeWidth="0.5" />
+        ))}
+        <path d={areaPath} fill="url(#gasGradient)" />
+        <path d={linePath} fill="none" stroke="#ffa729" strokeWidth="1.5" />
+        {/* Y labels */}
+        {yTicks.map((t, i) => (
+          <text key={i} x={pad.l - 6} y={sy(t)} dy="0.32em" textAnchor="end" fontSize="10" fill="#9ca3af">
+            {Math.round(t).toLocaleString()}
+          </text>
+        ))}
+        {/* X labels */}
+        {xTicks.map((t, i) => (
+          <text key={i} x={sx(t)} y={h - 8} textAnchor="middle" fontSize="10" fill="#9ca3af">
+            {new Date(t * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+          </text>
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+function HistogramChart({ buckets }: { buckets: GasSummary['gasPriceHistogram'] }): JSX.Element {
+  if (!buckets || buckets.length === 0) {
+    return <div className="text-center text-gray-500 text-sm py-12">Mempool is empty.</div>;
+  }
+  const w = 800;
+  const h = 220;
+  const pad = { l: 40, r: 16, t: 12, b: 36 };
+  const innerW = w - pad.l - pad.r;
+  const innerH = h - pad.t - pad.b;
+  const maxCount = Math.max(...buckets.map((b) => b.count), 1);
+  const barW = innerW / buckets.length;
+  return (
+    <div className="w-full overflow-x-auto">
+      <svg viewBox={`0 0 ${w} ${h}`} className="w-full h-auto" preserveAspectRatio="xMidYMid meet">
+        {buckets.map((b, i) => {
+          const barH = (b.count / maxCount) * innerH;
+          const x = pad.l + i * barW + 2;
+          const y = pad.t + innerH - barH;
+          return (
+            <g key={i}>
+              <rect x={x} y={y} width={barW - 4} height={barH} fill="#ffa729" opacity="0.8" />
+              <text
+                x={x + (barW - 4) / 2}
+                y={h - 18}
+                fontSize="9"
+                fill="#9ca3af"
+                textAnchor="middle"
+              >
+                {b.gweiLow === b.gweiHigh ? b.gweiLow.toFixed(0) : `${b.gweiLow.toFixed(0)}–${b.gweiHigh.toFixed(0)}`}
+              </text>
+              {b.count > 0 && (
+                <text x={x + (barW - 4) / 2} y={y - 3} fontSize="9" fill="#d1d5db" textAnchor="middle">
+                  {b.count}
+                </text>
+              )}
+            </g>
+          );
+        })}
+        <text x={w / 2} y={h - 4} fontSize="10" fill="#6b7280" textAnchor="middle">
+          gas price (Gwei)
+        </text>
+      </svg>
+    </div>
+  );
+}
+
+export default function GasClient(): JSX.Element {
+  const [summary, setSummary] = useState<GasSummary | null>(null);
+  const [history, setHistory] = useState<GasHistoryRow[]>([]);
+  const [range, setRange] = useState<'24h' | '7d'>('24h');
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const s = await axios.get<GasSummary>(`${config.handlerUrl}/gas/summary`);
+        if (!cancelled) setSummary(s.data);
+      } catch (e: unknown) {
+        if (!cancelled) setErr('Failed to load gas summary');
+        console.error(e);
+      }
+    };
+    load();
+    const id = setInterval(load, 10000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const r = await axios.get<GasHistoryResp>(`${config.handlerUrl}/gas/history?range=${range}`);
+        if (!cancelled) setHistory(r.data?.data ?? []);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    load();
+  }, [range]);
+
+  const utilization = useMemo(() => {
+    if (!summary) return null;
+    const used = hexBig(summary.lastGasUsedHex);
+    const limit = hexBig(summary.lastGasLimitHex);
+    if (limit === BigInt(0)) return null;
+    // percentage with 1 decimal
+    const pct = Number((used * BigInt(1000)) / limit) / 10;
+    return pct;
+  }, [summary]);
+
+  return (
+    <div className="p-4 sm:p-8 max-w-6xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h2 className="text-2xl font-bold text-[#ffa729]">Network Gas</h2>
+          <p className="text-sm text-gray-400 mt-1">
+            Live mempool + block stats from the QRL Zond network. Updated every 10s.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {(['24h', '7d'] as const).map((r) => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={`text-xs px-3 py-1 rounded-full border transition-colors ${
+                range === r
+                  ? 'bg-[#ffa729]/20 text-[#ffa729] border-[#ffa729]/40'
+                  : 'bg-[#1f1f1f] text-gray-400 border-[#3d3d3d] hover:text-gray-200'
+              }`}
+            >
+              {r}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {err && (
+        <div className="bg-red-900/20 border border-red-500/40 rounded-lg p-3 mb-4 text-sm text-red-400">{err}</div>
+      )}
+
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-6">
+        <StatCard
+          label="Avg Gas Price"
+          value={summary ? `${formatGasPrice(summary.avgGasPriceHex)} Gwei` : '—'}
+          sub="mempool median"
+        />
+        <StatCard
+          label="Avg Block Time"
+          value={summary ? `${summary.avgBlockTimeSec.toFixed(1)}s` : '—'}
+          sub="last 30 blocks"
+        />
+        <StatCard
+          label="Mempool Size"
+          value={summary ? summary.pendingCount.toString() : '—'}
+          sub="pending transactions"
+        />
+        <StatCard
+          label="Avg Gas Used"
+          value={summary ? formatBigGas(summary.avgGasUsedHex) : '—'}
+          sub="per block, last 30"
+        />
+        <StatCard
+          label="Last Block"
+          value={summary ? hexToNumber(summary.lastBlockNumberHex).toLocaleString() : '—'}
+          sub={summary ? `${formatBigGas(summary.lastGasUsedHex)} / ${formatBigGas(summary.lastGasLimitHex)} gas` : ''}
+        />
+        <StatCard
+          label="Gas Limit Utilization"
+          value={utilization !== null ? `${utilization.toFixed(1)}%` : '—'}
+          sub="last block"
+        />
+      </div>
+
+      <div className="rounded-xl bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f] border border-[#3d3d3d] shadow-lg p-4 sm:p-6 mb-6">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-sm font-semibold text-[#ffa729]">Gas Used per Block</h3>
+          <Badge variant="neutral">{range}</Badge>
+        </div>
+        <GasUsedChart rows={history} />
+      </div>
+
+      <div className="rounded-xl bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f] border border-[#3d3d3d] shadow-lg p-4 sm:p-6">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-sm font-semibold text-[#ffa729]">Mempool Gas Price Distribution</h3>
+          {summary && <Badge variant="neutral">{summary.pendingCount} tx</Badge>}
+        </div>
+        {summary && <HistogramChart buckets={summary.gasPriceHistogram} />}
+      </div>
+    </div>
+  );
+}

--- a/ExplorerFrontend/app/gas/gas-client.tsx
+++ b/ExplorerFrontend/app/gas/gas-client.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
 import config from '../../config';
 import Badge from '../components/Badge';
-import { formatGasPrice } from '../lib/helpers';
+import { formatGasPrice, hexToBigInt, hexToNumber, formatBigGas } from '../lib/helpers';
 
 interface GasSummary {
   avgGasPriceHex: string;
@@ -30,31 +30,6 @@ interface GasHistoryRow {
 interface GasHistoryResp {
   range: '24h' | '7d';
   data: GasHistoryRow[];
-}
-
-function hexBig(s: string | undefined | null): bigint {
-  if (!s) return BigInt(0);
-  try {
-    return BigInt(s.startsWith('0x') ? s : '0x' + s);
-  } catch {
-    return BigInt(0);
-  }
-}
-
-function hexToNumber(s: string | undefined | null): number {
-  if (!s) return 0;
-  try {
-    return Number(BigInt(s.startsWith('0x') ? s : '0x' + s));
-  } catch {
-    return 0;
-  }
-}
-
-function formatBigGas(s: string | undefined | null): string {
-  if (!s) return '—';
-  const v = hexBig(s);
-  if (v === BigInt(0)) return '0';
-  return v.toLocaleString();
 }
 
 function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }): JSX.Element {
@@ -130,7 +105,7 @@ function GasUsedChart({ rows }: { rows: GasHistoryRow[] }): JSX.Element {
         {/* X labels */}
         {xTicks.map((t, i) => (
           <text key={i} x={sx(t)} y={h - 8} textAnchor="middle" fontSize="10" fill="#9ca3af">
-            {new Date(t * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+            {new Date(t * 1000).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', timeZone: 'UTC', hour12: false })}
           </text>
         ))}
       </svg>
@@ -224,8 +199,8 @@ export default function GasClient(): JSX.Element {
 
   const utilization = useMemo(() => {
     if (!summary) return null;
-    const used = hexBig(summary.lastGasUsedHex);
-    const limit = hexBig(summary.lastGasLimitHex);
+    const used = hexToBigInt(summary.lastGasUsedHex);
+    const limit = hexToBigInt(summary.lastGasLimitHex);
     if (limit === BigInt(0)) return null;
     // percentage with 1 decimal
     const pct = Number((used * BigInt(1000)) / limit) / 10;

--- a/ExplorerFrontend/app/gas/page.tsx
+++ b/ExplorerFrontend/app/gas/page.tsx
@@ -1,0 +1,32 @@
+import { Suspense } from 'react';
+import type { Metadata } from 'next';
+import { sharedMetadata } from '../lib/seo/metaData';
+import GasClient from './gas-client';
+
+export const metadata: Metadata = {
+  ...sharedMetadata,
+  title: 'Gas | QRL Explorer',
+  description: 'Network gas metrics — average gas price, gas usage, mempool size, and recent block gas history on the QRL Zond network',
+  openGraph: {
+    ...sharedMetadata.openGraph,
+    title: 'Gas | QRL Explorer',
+    description: 'Network gas metrics for the QRL Zond network',
+    url: 'https://zondscan.com/gas',
+  },
+  twitter: {
+    ...sharedMetadata.twitter,
+    title: 'Gas | QRL Explorer',
+    description: 'Network gas metrics for the QRL Zond network',
+  },
+};
+
+export default function GasPage(): JSX.Element {
+  return (
+    <main>
+      <h1 className="sr-only">QRL Zond Network Gas Metrics</h1>
+      <Suspense fallback={<div className="p-4 text-center">Loading gas metrics...</div>}>
+        <GasClient />
+      </Suspense>
+    </main>
+  );
+}

--- a/ExplorerFrontend/app/home-client.tsx
+++ b/ExplorerFrontend/app/home-client.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import axios from 'axios';
-import { formatNumberWithCommas, timeAgo, formatStaked } from './lib/helpers';
+import { formatNumberWithCommas, timeAgo, formatStaked, formatGasPrice } from './lib/helpers';
 import config from '../config.js';
 import SearchBar from './components/SearchBar';
 import StatusBadge from './components/StatusBadge';
@@ -48,6 +48,7 @@ interface HomeData {
   blocks: BlockResult[];
   totalStaked: string;
   marketCap: number;
+  avgGasPriceHex: string | null;
   loading: boolean;
   error: boolean;
   dataInitialized: boolean;
@@ -111,6 +112,12 @@ const icons = {
       <path strokeLinecap="round" strokeLinejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
     </svg>
   ),
+  gas: (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 21h18" />
+    </svg>
+  ),
   block: (
     <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
@@ -143,7 +150,7 @@ const icons = {
 function StatBar({ data }: { data: HomeData }) {
   const stats = [
     { label: 'Epoch', value: data.epochInfo ? data.epochInfo.headEpoch : '—', icon: icons.epoch },
-    { label: 'Slot', value: data.epochInfo ? formatNumberWithCommas(data.epochInfo.headSlot) : '—', icon: icons.slot },
+    { label: 'Avg Gas Price', value: data.avgGasPriceHex ? `${formatGasPrice(data.avgGasPriceHex)} Gwei` : '—', icon: icons.gas },
     { label: 'Block Height', value: formatNumberWithCommas(data.blockHeight.toString()), icon: icons.block },
     { label: 'Validators', value: formatNumberWithCommas(data.validatorCount.toString()), icon: icons.validators },
     { label: 'Staked QRL', value: data.totalStaked !== '0' ? formatStaked(data.totalStaked) : '—', icon: icons.staked },
@@ -355,6 +362,7 @@ export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.El
     blocks: [],
     totalStaked: '0',
     marketCap: 0,
+    avgGasPriceHex: null,
     loading: true,
     error: false,
     dataInitialized: false,
@@ -364,13 +372,14 @@ export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.El
     try {
       if (!config.handlerUrl) return;
 
-      const [overviewRes, latestBlockRes, txsRes, epochRes, blocksRes, epochsRes] = await Promise.allSettled([
+      const [overviewRes, latestBlockRes, txsRes, epochRes, blocksRes, epochsRes, gasRes] = await Promise.allSettled([
         axios.get(config.handlerUrl + '/overview'),
         axios.get(config.handlerUrl + '/latestblock'),
         axios.get(config.handlerUrl + '/txs?page=1'),
         axios.get(config.handlerUrl + '/epoch'),
         axios.get(config.handlerUrl + '/blocks?page=1&limit=10'),
         axios.get(config.handlerUrl + '/epochs?page=1&limit=1'),
+        axios.get(config.handlerUrl + '/gas/summary'),
       ]);
 
       setData((prev) => {
@@ -398,6 +407,9 @@ export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.El
           if (latestEpoch?.totalStaked) {
             next.totalStaked = latestEpoch.totalStaked;
           }
+        }
+        if (gasRes.status === 'fulfilled' && gasRes.value.data?.avgGasPriceHex) {
+          next.avgGasPriceHex = gasRes.value.data.avgGasPriceHex;
         }
 
         return next;

--- a/ExplorerFrontend/app/lib/helpers.ts
+++ b/ExplorerFrontend/app/lib/helpers.ts
@@ -65,6 +65,42 @@ export function toFixed(x: number | string | undefined | null): string {
   return num.toString();
 }
 
+/**
+ * Parse a "0x"-prefixed hex string into a bigint. Returns 0n on missing or
+ * malformed input — gas-stats math should never throw on a dropped field.
+ */
+export function hexToBigInt(s: string | undefined | null): bigint {
+  if (!s) return BigInt(0);
+  try {
+    return BigInt(s.startsWith('0x') ? s : '0x' + s);
+  } catch {
+    return BigInt(0);
+  }
+}
+
+/**
+ * Parse a "0x"-prefixed hex string into a number. Lossy for values > 2^53,
+ * but block numbers / gas-used values fit comfortably in that range.
+ */
+export function hexToNumber(s: string | undefined | null): number {
+  if (!s) return 0;
+  try {
+    return Number(BigInt(s.startsWith('0x') ? s : '0x' + s));
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Format a hex gas count (gasUsed / gasLimit) as a thousands-separated decimal.
+ */
+export function formatBigGas(s: string | undefined | null): string {
+  if (!s) return '—';
+  const v = hexToBigInt(s);
+  if (v === BigInt(0)) return '0';
+  return v.toLocaleString('en-US');
+}
+
 export function formatGasPrice(wei: number | string | undefined | null): string {
   if (wei === undefined || wei === null || wei === 0 || wei === '0' || wei === '0x0') {
     return '0';

--- a/ExplorerFrontend/app/pending/tx/[hash]/pending-transaction-view.tsx
+++ b/ExplorerFrontend/app/pending/tx/[hash]/pending-transaction-view.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import type { PendingTransaction } from '@/app/types';
 import config from '../../../../config';
-import { formatAmount, formatGasPrice, decodeTokenTransferInput, formatTokenAmount } from '../../../lib/helpers';
+import { formatAmount, formatGasPrice, decodeTokenTransferInput, formatTokenAmount, hexToBigInt } from '../../../lib/helpers';
 import Badge from '../../../components/Badge';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import DetailRow from '../../../components/DetailRow';
@@ -27,15 +27,6 @@ interface EtaResponse {
   gasAheadHex: string;
   medianGasPriceHex: string;
   yourGasPriceHex: string;
-}
-
-function hexBig(s: string | undefined | null): bigint {
-  if (!s) return BigInt(0);
-  try {
-    return BigInt(s.startsWith('0x') ? s : '0x' + s);
-  } catch {
-    return BigInt(0);
-  }
 }
 
 function formatElapsed(seconds: number): string {
@@ -111,8 +102,11 @@ export default function PendingTransactionView({ pendingTx }: PendingTransaction
   }, [statusQuery.data?.status, pendingTx.hash, router]);
 
   // ── Elapsed counter (driven by local 1s tick, independent of polls) ────
-  const [nowSec, setNowSec] = useState(() => Math.floor(Date.now() / 1000));
+  // Seed from createdAt so SSR and the first client render produce identical
+  // markup (elapsed = 0); hydrate to real wall-clock time in the effect.
+  const [nowSec, setNowSec] = useState(pendingTx.createdAt ?? 0);
   useEffect(() => {
+    setNowSec(Math.floor(Date.now() / 1000));
     if (statusQuery.data?.status !== 'pending') return;
     const id = setInterval(() => setNowSec(Math.floor(Date.now() / 1000)), 1000);
     return () => clearInterval(id);
@@ -136,8 +130,8 @@ export default function PendingTransactionView({ pendingTx }: PendingTransaction
   // ── Gas-vs-median comparison ───────────────────────────────────────────
   const gasCompare = useMemo(() => {
     if (!etaQuery.data?.medianGasPriceHex) return null;
-    const yours = hexBig(pendingTx.gasPrice);
-    const median = hexBig(etaQuery.data.medianGasPriceHex);
+    const yours = hexToBigInt(pendingTx.gasPrice);
+    const median = hexToBigInt(etaQuery.data.medianGasPriceHex);
     if (median === BigInt(0)) return null;
     if (yours > median) return { variant: 'success' as const, label: 'above median' };
     if (yours < median) return { variant: 'warning' as const, label: 'below median' };

--- a/ExplorerFrontend/app/pending/tx/[hash]/pending-transaction-view.tsx
+++ b/ExplorerFrontend/app/pending/tx/[hash]/pending-transaction-view.tsx
@@ -1,8 +1,12 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
+import axios from 'axios';
+import { useRouter } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
 import type { PendingTransaction } from '@/app/types';
+import config from '../../../../config';
 import { formatAmount, formatGasPrice, decodeTokenTransferInput, formatTokenAmount } from '../../../lib/helpers';
 import Badge from '../../../components/Badge';
 import Breadcrumbs from '../../../components/Breadcrumbs';
@@ -13,15 +17,146 @@ interface PendingTransactionViewProps {
   pendingTx: PendingTransaction;
 }
 
+type LiveStatus = 'pending' | 'mined' | 'dropped';
+
+interface EtaResponse {
+  etaSec: number;
+  avgBlockTimeSec: number;
+  avgGasUsedHex: string;
+  pendingCount: number;
+  gasAheadHex: string;
+  medianGasPriceHex: string;
+  yourGasPriceHex: string;
+}
+
+function hexBig(s: string | undefined | null): bigint {
+  if (!s) return BigInt(0);
+  try {
+    return BigInt(s.startsWith('0x') ? s : '0x' + s);
+  } catch {
+    return BigInt(0);
+  }
+}
+
+function formatElapsed(seconds: number): string {
+  if (seconds < 0) seconds = 0;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
 export default function PendingTransactionView({ pendingTx }: PendingTransactionViewProps): JSX.Element {
   const [formattedValue, unit] = formatAmount(pendingTx.value);
   const formattedGasPrice = formatGasPrice(pendingTx.gasPrice);
+  const router = useRouter();
 
   const decodedTransfer = useMemo(() => {
     return decodeTokenTransferInput(pendingTx.input);
   }, [pendingTx.input]);
 
   const isTokenTransfer = decodedTransfer !== null;
+
+  // ── Status poll ─────────────────────────────────────────────────────────
+  // /pending-transaction returns 404 once the tx is tombstoned. On 404 we
+  // probe /tx to distinguish "mined → redirect" from "dropped → notice".
+  const statusQuery = useQuery<{ status: LiveStatus }>({
+    queryKey: ['pending-tx-status', pendingTx.hash],
+    queryFn: async () => {
+      try {
+        const res = await axios.get(`${config.handlerUrl}/pending-transaction/${pendingTx.hash}`);
+        if (res.data?.transaction?.status === 'pending') {
+          return { status: 'pending' };
+        }
+        return { status: 'mined' };
+      } catch (err: unknown) {
+        if (axios.isAxiosError(err) && err.response?.status === 404) {
+          try {
+            const tx = await axios.get(`${config.handlerUrl}/tx/${pendingTx.hash}`);
+            if (tx.data?.response) return { status: 'mined' };
+          } catch {
+            /* fallthrough */
+          }
+          return { status: 'dropped' };
+        }
+        return { status: 'pending' };
+      }
+    },
+    initialData: { status: 'pending' },
+    refetchInterval: (query) => (query.state.data?.status === 'pending' ? 5000 : false),
+  });
+
+  // ── ETA poll ────────────────────────────────────────────────────────────
+  const etaQuery = useQuery<EtaResponse | null>({
+    queryKey: ['pending-tx-eta', pendingTx.hash],
+    queryFn: async () => {
+      try {
+        const res = await axios.get<EtaResponse>(`${config.handlerUrl}/pending-tx-eta/${pendingTx.hash}`);
+        return res.data;
+      } catch {
+        return null;
+      }
+    },
+    refetchInterval: 5000,
+    enabled: statusQuery.data?.status === 'pending',
+  });
+
+  // ── Mined → navigate, dropped → flip local state ───────────────────────
+  const [isDropped, setIsDropped] = useState(false);
+  useEffect(() => {
+    if (statusQuery.data?.status === 'mined') {
+      router.replace(`/tx/${pendingTx.hash}`);
+    } else if (statusQuery.data?.status === 'dropped') {
+      setIsDropped(true);
+    }
+  }, [statusQuery.data?.status, pendingTx.hash, router]);
+
+  // ── Elapsed counter (driven by local 1s tick, independent of polls) ────
+  const [nowSec, setNowSec] = useState(() => Math.floor(Date.now() / 1000));
+  useEffect(() => {
+    if (statusQuery.data?.status !== 'pending') return;
+    const id = setInterval(() => setNowSec(Math.floor(Date.now() / 1000)), 1000);
+    return () => clearInterval(id);
+  }, [statusQuery.data?.status]);
+  const elapsedSec = Math.max(0, nowSec - (pendingTx.createdAt ?? nowSec));
+
+  // ── ETA countdown — seeded from each poll, ticks down every second ─────
+  const [etaRemaining, setEtaRemaining] = useState<number | null>(null);
+  useEffect(() => {
+    if (typeof etaQuery.data?.etaSec === 'number') {
+      setEtaRemaining(Math.max(0, Math.round(etaQuery.data.etaSec)));
+    }
+  }, [etaQuery.data?.etaSec]);
+  const hasEta = etaRemaining !== null;
+  useEffect(() => {
+    if (!hasEta) return;
+    const id = setInterval(() => setEtaRemaining((v) => (v === null ? null : Math.max(0, v - 1))), 1000);
+    return () => clearInterval(id);
+  }, [hasEta]);
+
+  // ── Gas-vs-median comparison ───────────────────────────────────────────
+  const gasCompare = useMemo(() => {
+    if (!etaQuery.data?.medianGasPriceHex) return null;
+    const yours = hexBig(pendingTx.gasPrice);
+    const median = hexBig(etaQuery.data.medianGasPriceHex);
+    if (median === BigInt(0)) return null;
+    if (yours > median) return { variant: 'success' as const, label: 'above median' };
+    if (yours < median) return { variant: 'warning' as const, label: 'below median' };
+    return { variant: 'info' as const, label: 'at median' };
+  }, [etaQuery.data?.medianGasPriceHex, pendingTx.gasPrice]);
+
+  if (isDropped) {
+    return (
+      <div className="container mx-auto px-4">
+        <div className="bg-red-900/20 border border-red-500/50 rounded-xl p-6 shadow-lg mt-6">
+          <h2 className="text-red-500 font-semibold mb-2">Transaction Not Found</h2>
+          <p className="text-gray-300">
+            This transaction is no longer in the mempool. It may have been dropped or replaced.
+            Please check if a transaction with a higher gas price was submitted with the same nonce.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="p-4 sm:p-8 max-w-6xl mx-auto">
@@ -42,6 +177,27 @@ export default function PendingTransactionView({ pendingTx }: PendingTransaction
             {isTokenTransfer && <Badge variant="brand">Token Transfer</Badge>}
           </div>
           <Badge variant="warning" size="md" dot>Pending</Badge>
+        </div>
+
+        {/* Live status strip */}
+        <div className="px-4 sm:px-6 py-3 border-b border-[#3d3d3d] bg-[#1a1a1a]/40">
+          <div className="flex flex-wrap items-center gap-2 mb-1">
+            <Badge variant="warning">Pending for {formatElapsed(elapsedSec)}</Badge>
+            {etaRemaining !== null && (
+              <Badge variant="info">
+                {etaRemaining > 0 ? `Next inclusion ~${formatElapsed(etaRemaining)}` : 'Any moment now…'}
+              </Badge>
+            )}
+            {typeof etaQuery.data?.pendingCount === 'number' && (
+              <Badge variant="neutral">Mempool: {etaQuery.data.pendingCount}</Badge>
+            )}
+            {gasCompare && (
+              <Badge variant={gasCompare.variant}>Gas: {gasCompare.label}</Badge>
+            )}
+          </div>
+          <p className="text-[11px] text-gray-500">
+            Auto-refreshing every 5s — this page will navigate to the confirmed transaction once it&apos;s included in a block.
+          </p>
         </div>
 
         {/* Content */}

--- a/QRL2MongoDB/db/gas_history.go
+++ b/QRL2MongoDB/db/gas_history.go
@@ -1,0 +1,145 @@
+package db
+
+import (
+	"QRL2MongoDB/configs"
+	"context"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.uber.org/zap"
+)
+
+// GasHistoryCollection is one document per block, sized for short-range
+// queries by the /gas API. We don't store all of history here — the
+// `blocks` collection already has that. This collection is shaped for fast
+// scans on a small (≤ 7d) timeseries.
+const GasHistoryCollection = "gasHistory"
+
+// GasHistoryRetention is how far back we keep gas-history rows. 7 d matches
+// the longest range the /gas page exposes; older rows can always be
+// rehydrated from `blocks` if needed.
+const GasHistoryRetention = 7 * 24 * time.Hour
+
+// gasHistoryRow is the bson shape written to the collection. `_id` is the
+// block number (int64) so re-runs of the periodic task are idempotent.
+type gasHistoryRow struct {
+	ID             int64  `bson:"_id"`
+	BlockNumberInt int64  `bson:"blockNumberInt"`
+	Timestamp      int64  `bson:"timestamp"`
+	GasUsed        string `bson:"gasUsed"`
+	GasLimit       string `bson:"gasLimit"`
+	BaseFeePerGas  string `bson:"baseFeePerGas"`
+	TxCount        int    `bson:"txCount"`
+}
+
+// UpdateGasHistory walks forward from the highest blockNumberInt currently in
+// `gasHistory` and appends one row per new block in `blocks`. It's safe to run
+// repeatedly: rows are upserted on the int block number. It also sweeps rows
+// older than GasHistoryRetention to keep the collection bounded.
+func UpdateGasHistory() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	col := configs.GetCollection(configs.DB, GasHistoryCollection)
+
+	// Highwater = the largest blockNumberInt already written, or -1 if empty.
+	var highwater int64 = -1
+	{
+		opts := options.FindOne().
+			SetProjection(bson.M{"blockNumberInt": 1}).
+			SetSort(bson.M{"blockNumberInt": -1})
+		var existing gasHistoryRow
+		err := col.FindOne(ctx, bson.M{}, opts).Decode(&existing)
+		if err == nil {
+			highwater = existing.BlockNumberInt
+		} else if err != mongo.ErrNoDocuments {
+			configs.Logger.Warn("gasHistory highwater lookup failed", zap.Error(err))
+			return err
+		}
+	}
+
+	// Scan new blocks newest→oldest? No — oldest→newest, capped, so we don't
+	// blow memory if the syncer has just caught up from a deep backfill. The
+	// retention sweep below will trim any historical excess.
+	blockOpts := options.Find().
+		SetProjection(bson.M{
+			"blockNumberInt":           1,
+			"result.number":            1,
+			"result.timestamp":         1,
+			"result.gasUsed":           1,
+			"result.gasLimit":          1,
+			"result.baseFeePerGas":     1,
+			"result.transactions.hash": 1,
+		}).
+		SetSort(bson.M{"blockNumberInt": 1}).
+		SetLimit(5000)
+
+	cur, err := configs.BlocksCollections.Find(ctx, bson.M{"blockNumberInt": bson.M{"$gt": highwater}}, blockOpts)
+	if err != nil {
+		return err
+	}
+	defer cur.Close(ctx)
+
+	type blockProjection struct {
+		BlockNumberInt int64 `bson:"blockNumberInt"`
+		Result         struct {
+			Number        string `bson:"number"`
+			Timestamp     string `bson:"timestamp"`
+			GasUsed       string `bson:"gasUsed"`
+			GasLimit      string `bson:"gasLimit"`
+			BaseFeePerGas string `bson:"baseFeePerGas"`
+			Transactions  []struct {
+				Hash string `bson:"hash"`
+			} `bson:"transactions"`
+		} `bson:"result"`
+	}
+
+	var ops []mongo.WriteModel
+	for cur.Next(ctx) {
+		var b blockProjection
+		if err := cur.Decode(&b); err != nil {
+			continue
+		}
+		ts := HexToInt64(b.Result.Timestamp)
+		// Skip blocks with a malformed timestamp — they'd corrupt the
+		// retention sweep below.
+		if ts <= 0 {
+			continue
+		}
+		row := gasHistoryRow{
+			ID:             b.BlockNumberInt,
+			BlockNumberInt: b.BlockNumberInt,
+			Timestamp:      ts,
+			GasUsed:        b.Result.GasUsed,
+			GasLimit:       b.Result.GasLimit,
+			BaseFeePerGas:  b.Result.BaseFeePerGas,
+			TxCount:        len(b.Result.Transactions),
+		}
+		ops = append(ops, mongo.NewReplaceOneModel().
+			SetFilter(bson.M{"_id": row.ID}).
+			SetReplacement(row).
+			SetUpsert(true))
+	}
+	if err := cur.Err(); err != nil {
+		return err
+	}
+
+	if len(ops) > 0 {
+		_, err := col.BulkWrite(ctx, ops, options.BulkWrite().SetOrdered(false))
+		if err != nil {
+			configs.Logger.Error("gasHistory bulk write failed", zap.Error(err))
+			return err
+		}
+		configs.Logger.Info("gasHistory updated", zap.Int("rows", len(ops)))
+	}
+
+	// Retention sweep
+	cutoff := time.Now().Add(-GasHistoryRetention).Unix()
+	if _, err := col.DeleteMany(ctx, bson.M{"timestamp": bson.M{"$lt": cutoff}}); err != nil {
+		configs.Logger.Warn("gasHistory retention sweep failed", zap.Error(err))
+	}
+
+	return nil
+}

--- a/QRL2MongoDB/db/gas_history.go
+++ b/QRL2MongoDB/db/gas_history.go
@@ -63,14 +63,17 @@ func UpdateGasHistory() error {
 	// Scan new blocks newest→oldest? No — oldest→newest, capped, so we don't
 	// blow memory if the syncer has just caught up from a deep backfill. The
 	// retention sweep below will trim any historical excess.
+	// Block documents store these fields in lowercase BSON (gasused, gaslimit,
+	// basefeepergas) — both the projection paths and the local struct tags
+	// below need to match that exactly.
 	blockOpts := options.Find().
 		SetProjection(bson.M{
 			"blockNumberInt":           1,
 			"result.number":            1,
 			"result.timestamp":         1,
-			"result.gasUsed":           1,
-			"result.gasLimit":          1,
-			"result.baseFeePerGas":     1,
+			"result.gasused":           1,
+			"result.gaslimit":          1,
+			"result.basefeepergas":     1,
 			"result.transactions.hash": 1,
 		}).
 		SetSort(bson.M{"blockNumberInt": 1}).
@@ -87,9 +90,9 @@ func UpdateGasHistory() error {
 		Result         struct {
 			Number        string `bson:"number"`
 			Timestamp     string `bson:"timestamp"`
-			GasUsed       string `bson:"gasUsed"`
-			GasLimit      string `bson:"gasLimit"`
-			BaseFeePerGas string `bson:"baseFeePerGas"`
+			GasUsed       string `bson:"gasused"`
+			GasLimit      string `bson:"gaslimit"`
+			BaseFeePerGas string `bson:"basefeepergas"`
 			Transactions  []struct {
 				Hash string `bson:"hash"`
 			} `bson:"transactions"`

--- a/QRL2MongoDB/synchroniser/periodic_tasks.go
+++ b/QRL2MongoDB/synchroniser/periodic_tasks.go
@@ -264,6 +264,13 @@ func updateDataPeriodically() {
 	} else {
 		configs.Logger.Info("Successfully updated block sizes collection")
 	}
+
+	// Update gas-history timeseries used by /gas page and home stats.
+	// Idempotent and bounded by GasHistoryRetention.
+	configs.Logger.Info("Updating gas history collection...")
+	if err := db.UpdateGasHistory(); err != nil {
+		configs.Logger.Error("Failed to update gas history", zap.Error(err))
+	}
 }
 
 // singleBlockInsertion starts continuous block monitoring with periodic tasks

--- a/backendAPI/db/gas.go
+++ b/backendAPI/db/gas.go
@@ -29,15 +29,16 @@ func hexToBig(s string) *big.Int {
 }
 
 // BlockGasSample is the minimal projection we need from each block for the gas
-// page and ETA math.
+// page and ETA math. Block documents are stored with lowercase BSON keys
+// (gasused, gaslimit, basefeepergas) — match that exactly.
 type BlockGasSample struct {
-	BlockNumberInt int64  `bson:"blockNumberInt"`
+	BlockNumberInt int64 `bson:"blockNumberInt"`
 	Result         struct {
 		Number        string `bson:"number"`
 		Timestamp     string `bson:"timestamp"`
-		GasUsed       string `bson:"gasUsed"`
-		GasLimit      string `bson:"gasLimit"`
-		BaseFeePerGas string `bson:"baseFeePerGas"`
+		GasUsed       string `bson:"gasused"`
+		GasLimit      string `bson:"gaslimit"`
+		BaseFeePerGas string `bson:"basefeepergas"`
 		Transactions  []struct {
 			Hash string `bson:"hash"`
 		} `bson:"transactions"`
@@ -59,9 +60,9 @@ func GetRecentBlockSamples(n int) ([]BlockGasSample, error) {
 			{Key: "blockNumberInt", Value: 1},
 			{Key: "result.number", Value: 1},
 			{Key: "result.timestamp", Value: 1},
-			{Key: "result.gasUsed", Value: 1},
-			{Key: "result.gasLimit", Value: 1},
-			{Key: "result.baseFeePerGas", Value: 1},
+			{Key: "result.gasused", Value: 1},
+			{Key: "result.gaslimit", Value: 1},
+			{Key: "result.basefeepergas", Value: 1},
 			{Key: "result.transactions.hash", Value: 1},
 		}).
 		SetSort(primitive.D{{Key: "blockNumberInt", Value: -1}}).

--- a/backendAPI/db/gas.go
+++ b/backendAPI/db/gas.go
@@ -1,0 +1,313 @@
+package db
+
+import (
+	"backendAPI/configs"
+	"context"
+	"math/big"
+	"sort"
+	"strings"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// hexToBig parses a "0x"-prefixed hex string into a *big.Int. Empty / malformed
+// input yields 0 — gas math should never panic on a missing field.
+func hexToBig(s string) *big.Int {
+	b := new(big.Int)
+	if s == "" {
+		return b
+	}
+	s = strings.TrimPrefix(s, "0x")
+	if s == "" {
+		return b
+	}
+	b.SetString(s, 16)
+	return b
+}
+
+// BlockGasSample is the minimal projection we need from each block for the gas
+// page and ETA math.
+type BlockGasSample struct {
+	BlockNumberInt int64  `bson:"blockNumberInt"`
+	Result         struct {
+		Number        string `bson:"number"`
+		Timestamp     string `bson:"timestamp"`
+		GasUsed       string `bson:"gasUsed"`
+		GasLimit      string `bson:"gasLimit"`
+		BaseFeePerGas string `bson:"baseFeePerGas"`
+		Transactions  []struct {
+			Hash string `bson:"hash"`
+		} `bson:"transactions"`
+	} `bson:"result"`
+}
+
+// GetRecentBlockSamples returns the last n blocks (newest first) projected to
+// just the gas/timing fields. Used by both the ETA endpoint and the /gas
+// summary endpoint.
+func GetRecentBlockSamples(n int) ([]BlockGasSample, error) {
+	if n <= 0 {
+		n = 30
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	opts := options.Find().
+		SetProjection(primitive.D{
+			{Key: "blockNumberInt", Value: 1},
+			{Key: "result.number", Value: 1},
+			{Key: "result.timestamp", Value: 1},
+			{Key: "result.gasUsed", Value: 1},
+			{Key: "result.gasLimit", Value: 1},
+			{Key: "result.baseFeePerGas", Value: 1},
+			{Key: "result.transactions.hash", Value: 1},
+		}).
+		SetSort(primitive.D{{Key: "blockNumberInt", Value: -1}}).
+		SetLimit(int64(n))
+
+	cur, err := configs.BlocksCollection.Find(ctx, primitive.D{}, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer cur.Close(ctx)
+
+	var out []BlockGasSample
+	if err := cur.All(ctx, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// BlockStats aggregates a set of recent block samples for the /gas summary
+// and the ETA computation. All "avg" values are simple arithmetic means over
+// the provided window.
+type BlockStats struct {
+	AvgBlockTimeSec float64
+	AvgGasUsed      *big.Int
+	AvgGasLimit     *big.Int
+	LastNumberHex   string
+	LastGasUsedHex  string
+	LastGasLimitHex string
+}
+
+func ComputeBlockStats(samples []BlockGasSample) BlockStats {
+	stats := BlockStats{
+		AvgBlockTimeSec: 60,
+		AvgGasUsed:      big.NewInt(0),
+		AvgGasLimit:     big.NewInt(0),
+	}
+	if len(samples) == 0 {
+		return stats
+	}
+	stats.LastNumberHex = samples[0].Result.Number
+	stats.LastGasUsedHex = samples[0].Result.GasUsed
+	stats.LastGasLimitHex = samples[0].Result.GasLimit
+
+	sumUsed := new(big.Int)
+	sumLimit := new(big.Int)
+	for _, s := range samples {
+		sumUsed.Add(sumUsed, hexToBig(s.Result.GasUsed))
+		sumLimit.Add(sumLimit, hexToBig(s.Result.GasLimit))
+	}
+	n := big.NewInt(int64(len(samples)))
+	stats.AvgGasUsed.Quo(sumUsed, n)
+	stats.AvgGasLimit.Quo(sumLimit, n)
+
+	if len(samples) >= 2 {
+		newest := hexToBig(samples[0].Result.Timestamp).Int64()
+		oldest := hexToBig(samples[len(samples)-1].Result.Timestamp).Int64()
+		span := newest - oldest
+		gaps := int64(len(samples) - 1)
+		if span > 0 && gaps > 0 {
+			stats.AvgBlockTimeSec = float64(span) / float64(gaps)
+		}
+	}
+	return stats
+}
+
+// MempoolSample is the minimal projection we need from each pending tx.
+type MempoolSample struct {
+	Hash     string `bson:"_id"`
+	Gas      string `bson:"gas"`
+	GasPrice string `bson:"gasPrice"`
+}
+
+// GetPendingMempoolSnapshot returns every pending (status="pending") tx with
+// just the hash + gas + gasPrice fields. The mempool is small enough on QRL
+// today that pulling the full set and doing big-int math in Go is simpler and
+// more correct than trying to compare hex-encoded big ints inside Mongo.
+func GetPendingMempoolSnapshot() ([]MempoolSample, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	col := configs.GetCollection(configs.DB, PENDING_COLLECTION)
+	opts := options.Find().SetProjection(primitive.D{
+		{Key: "gas", Value: 1},
+		{Key: "gasPrice", Value: 1},
+	})
+	cur, err := col.Find(ctx, bson.M{"status": "pending"}, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer cur.Close(ctx)
+
+	var out []MempoolSample
+	if err := cur.All(ctx, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// MempoolStats summarizes a mempool snapshot relative to a single tx.
+type MempoolStats struct {
+	Count           int
+	MedianGasPrice  *big.Int
+	GasAhead        *big.Int // sum of `gas` for txs with strictly higher gasPrice than the target
+	YourGasPrice    *big.Int
+}
+
+// ComputeMempoolStatsFor walks the snapshot once, computing the median
+// gasPrice across the whole set and the gas-ahead total relative to
+// `targetGasPriceHex` (the tx the ETA is being computed for).
+func ComputeMempoolStatsFor(samples []MempoolSample, targetGasPriceHex string) MempoolStats {
+	stats := MempoolStats{
+		Count:          len(samples),
+		MedianGasPrice: big.NewInt(0),
+		GasAhead:       big.NewInt(0),
+		YourGasPrice:   hexToBig(targetGasPriceHex),
+	}
+	if len(samples) == 0 {
+		return stats
+	}
+
+	prices := make([]*big.Int, 0, len(samples))
+	for _, s := range samples {
+		gp := hexToBig(s.GasPrice)
+		prices = append(prices, gp)
+		if gp.Cmp(stats.YourGasPrice) > 0 {
+			stats.GasAhead.Add(stats.GasAhead, hexToBig(s.Gas))
+		}
+	}
+	sort.Slice(prices, func(i, j int) bool { return prices[i].Cmp(prices[j]) < 0 })
+	mid := len(prices) / 2
+	if len(prices)%2 == 1 {
+		stats.MedianGasPrice.Set(prices[mid])
+	} else {
+		sum := new(big.Int).Add(prices[mid-1], prices[mid])
+		stats.MedianGasPrice.Quo(sum, big.NewInt(2))
+	}
+	return stats
+}
+
+// GasPriceBucket is one bin in the mempool gas-price histogram surfaced on the
+// /gas page.
+type GasPriceBucket struct {
+	GweiLow  float64 `json:"gweiLow"`
+	GweiHigh float64 `json:"gweiHigh"`
+	Count    int     `json:"count"`
+}
+
+// MempoolGasPriceHistogram bins the snapshot into up to `bins` evenly-spaced
+// Gwei buckets between the min and max gasPrice. Returns a single-bin result
+// if all txs share the same price (or the mempool is empty).
+func MempoolGasPriceHistogram(samples []MempoolSample, bins int) []GasPriceBucket {
+	if bins <= 0 {
+		bins = 10
+	}
+	if len(samples) == 0 {
+		return []GasPriceBucket{}
+	}
+	gwei := big.NewInt(1_000_000_000)
+	values := make([]float64, 0, len(samples))
+	for _, s := range samples {
+		gp := hexToBig(s.GasPrice)
+		// Gwei = wei / 1e9. We accept the float64 lossiness here — this is for
+		// a histogram, not accounting.
+		q := new(big.Int).Quo(gp, gwei)
+		values = append(values, float64(q.Int64()))
+	}
+	sort.Float64s(values)
+	minV, maxV := values[0], values[len(values)-1]
+	if maxV == minV {
+		return []GasPriceBucket{{GweiLow: minV, GweiHigh: maxV, Count: len(values)}}
+	}
+	width := (maxV - minV) / float64(bins)
+	out := make([]GasPriceBucket, bins)
+	for i := 0; i < bins; i++ {
+		out[i] = GasPriceBucket{
+			GweiLow:  minV + width*float64(i),
+			GweiHigh: minV + width*float64(i+1),
+		}
+	}
+	for _, v := range values {
+		idx := int((v - minV) / width)
+		if idx >= bins {
+			idx = bins - 1
+		}
+		out[idx].Count++
+	}
+	return out
+}
+
+// ---- /gas/history ---------------------------------------------------------
+//
+// The syncer maintains a `gasHistory` collection with one row per block. The
+// API serves it as-is for short ranges (24h ≈ 1440 rows at 60 s slots) and
+// downsamples to one row per hour for the 7d view.
+
+const GAS_HISTORY_COLLECTION = "gasHistory"
+
+type GasHistoryRow struct {
+	BlockNumberInt int64  `bson:"blockNumberInt" json:"blockNumber"`
+	Timestamp      int64  `bson:"timestamp"      json:"timestamp"`
+	GasUsed        string `bson:"gasUsed"        json:"gasUsed"`
+	GasLimit       string `bson:"gasLimit"       json:"gasLimit"`
+	BaseFeePerGas  string `bson:"baseFeePerGas"  json:"baseFeePerGas"`
+	TxCount        int    `bson:"txCount"        json:"txCount"`
+}
+
+// GetGasHistory returns gas-history rows newer than `since` (Unix seconds),
+// sorted oldest→newest. When `bucketSec > 0` the rows are downsampled to one
+// row per bucket window using the latest row inside each bucket.
+func GetGasHistory(sinceUnix int64, bucketSec int64) ([]GasHistoryRow, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	col := configs.GetCollection(configs.DB, GAS_HISTORY_COLLECTION)
+	opts := options.Find().SetSort(primitive.D{{Key: "timestamp", Value: 1}})
+	cur, err := col.Find(ctx, bson.M{"timestamp": bson.M{"$gte": sinceUnix}}, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer cur.Close(ctx)
+
+	var rows []GasHistoryRow
+	if err := cur.All(ctx, &rows); err != nil {
+		return nil, err
+	}
+
+	if bucketSec <= 0 || len(rows) == 0 {
+		return rows, nil
+	}
+
+	// Downsample: keep the latest row per bucket window.
+	byBucket := make(map[int64]GasHistoryRow)
+	var order []int64
+	for _, r := range rows {
+		b := (r.Timestamp / bucketSec) * bucketSec
+		if existing, ok := byBucket[b]; !ok || r.BlockNumberInt > existing.BlockNumberInt {
+			if _, seen := byBucket[b]; !seen {
+				order = append(order, b)
+			}
+			byBucket[b] = r
+		}
+	}
+	out := make([]GasHistoryRow, 0, len(order))
+	sort.Slice(order, func(i, j int) bool { return order[i] < order[j] })
+	for _, b := range order {
+		out = append(out, byBucket[b])
+	}
+	return out, nil
+}

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -6,6 +6,7 @@ import (
 	"backendAPI/models"
 	"fmt"
 	"log"
+	"math/big"
 	"net/http"
 	"strconv"
 	"strings"
@@ -840,5 +841,142 @@ func UserRoute(router *gin.Engine) {
 			Page:            page,
 			Limit:           limit,
 		})
+	})
+
+	// ---- Gas / mempool stats ---------------------------------------------
+	//
+	// /pending-tx-eta/:hash returns a best-effort inclusion ETA for one
+	// pending tx, plus the supporting numbers (avg block time, avg gas
+	// usage, mempool size, median gasPrice, gas-ahead sum). The math is in
+	// db/gas.go; the route just plumbs it together.
+	router.GET("/pending-tx-eta/:hash", func(c *gin.Context) {
+		hash := c.Param("hash")
+		v, err := routeCache.GetOrCompute("eta:"+hash, 5*time.Second, func() (interface{}, error) {
+			tx, err := db.GetPendingTransactionByHash(hash)
+			if err != nil {
+				return nil, err
+			}
+			if tx == nil || tx.Status != "pending" {
+				return nil, nil
+			}
+
+			samples, err := db.GetRecentBlockSamples(30)
+			if err != nil {
+				return nil, err
+			}
+			blockStats := db.ComputeBlockStats(samples)
+
+			mempool, err := db.GetPendingMempoolSnapshot()
+			if err != nil {
+				return nil, err
+			}
+			mp := db.ComputeMempoolStatsFor(mempool, tx.GasPrice)
+
+			// ETA = ceil(gasAhead / avgGasUsed) * avgBlockTime.
+			avgGas := blockStats.AvgGasUsed
+			if avgGas.Sign() <= 0 {
+				avgGas = big.NewInt(1)
+			}
+			// Integer ceil-division: (a + b - 1) / b.
+			num := new(big.Int).Add(mp.GasAhead, new(big.Int).Sub(avgGas, big.NewInt(1)))
+			blocksAhead := new(big.Int).Quo(num, avgGas).Int64()
+			etaSec := float64(blocksAhead) * blockStats.AvgBlockTimeSec
+			// At minimum one block-time of wait — gasAhead = 0 still means we
+			// wait for the next block to be produced.
+			if etaSec < blockStats.AvgBlockTimeSec {
+				etaSec = blockStats.AvgBlockTimeSec
+			}
+
+			return gin.H{
+				"etaSec":            etaSec,
+				"avgBlockTimeSec":   blockStats.AvgBlockTimeSec,
+				"avgGasUsedHex":     "0x" + blockStats.AvgGasUsed.Text(16),
+				"pendingCount":      mp.Count,
+				"gasAheadHex":       "0x" + mp.GasAhead.Text(16),
+				"medianGasPriceHex": "0x" + mp.MedianGasPrice.Text(16),
+				"yourGasPriceHex":   tx.GasPrice,
+			}, nil
+		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if v == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Pending transaction not found"})
+			return
+		}
+		c.JSON(http.StatusOK, v)
+	})
+
+	// /gas/summary feeds the top stat cards on the /gas page and the home
+	// "Avg Gas Price" tile. Combines the same block + mempool snapshots used
+	// by the ETA endpoint.
+	router.GET("/gas/summary", func(c *gin.Context) {
+		v, err := routeCache.GetOrCompute("gas:summary", 5*time.Second, func() (interface{}, error) {
+			samples, err := db.GetRecentBlockSamples(30)
+			if err != nil {
+				return nil, err
+			}
+			blockStats := db.ComputeBlockStats(samples)
+
+			mempool, err := db.GetPendingMempoolSnapshot()
+			if err != nil {
+				return nil, err
+			}
+			// Pass an empty target so GasAhead is just total mempool gas
+			// (callers ignore that field for the summary).
+			mp := db.ComputeMempoolStatsFor(mempool, "0x0")
+			histogram := db.MempoolGasPriceHistogram(mempool, 12)
+
+			return gin.H{
+				"avgGasPriceHex":     "0x" + mp.MedianGasPrice.Text(16),
+				"avgGasUsedHex":      "0x" + blockStats.AvgGasUsed.Text(16),
+				"avgGasLimitHex":     "0x" + blockStats.AvgGasLimit.Text(16),
+				"avgBlockTimeSec":    blockStats.AvgBlockTimeSec,
+				"pendingCount":       mp.Count,
+				"lastBlockNumberHex": blockStats.LastNumberHex,
+				"lastGasUsedHex":     blockStats.LastGasUsedHex,
+				"lastGasLimitHex":    blockStats.LastGasLimitHex,
+				"gasPriceHistogram":  histogram,
+			}, nil
+		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, v)
+	})
+
+	// /gas/history?range=24h|7d serves the timeseries used by the /gas page
+	// charts. Data is sourced from the `gasHistory` collection populated by
+	// the syncer's periodic task.
+	router.GET("/gas/history", func(c *gin.Context) {
+		rng := c.DefaultQuery("range", "24h")
+		var sinceSec, bucketSec int64
+		switch rng {
+		case "7d":
+			sinceSec = time.Now().Unix() - 7*24*3600
+			bucketSec = 3600 // 1 row per hour
+		default:
+			rng = "24h"
+			sinceSec = time.Now().Unix() - 24*3600
+			bucketSec = 0 // raw per-block rows
+		}
+		key := "gas:history:" + rng
+		v, err := routeCache.GetOrCompute(key, 30*time.Second, func() (interface{}, error) {
+			rows, err := db.GetGasHistory(sinceSec, bucketSec)
+			if err != nil {
+				return nil, err
+			}
+			if rows == nil {
+				rows = []db.GasHistoryRow{}
+			}
+			return gin.H{"range": rng, "data": rows}, nil
+		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, v)
 	})
 }


### PR DESCRIPTION
## Summary
- Pending tx page now polls every 5s and auto-navigates to `/tx/<hash>` once the tx is mined. Adds a live "Pending for mm:ss" counter and an inclusion-ETA chip backed by a new `/pending-tx-eta/:hash` endpoint that factors in average block time, average per-block gas usage, and the sum of `gas` (limit) for pending txs with strictly higher `gasPrice`. Also shows mempool size and a gas-vs-median chip.
- New `/gas` top-level page with stat cards (avg gas price, avg block time, mempool size, avg/last gas used, gas-limit utilization), an inline-SVG gas-used-per-block area chart with a 24h/7d toggle, and a mempool gas-price histogram. Sidebar gains a `/gas` entry under Blockchain.
- Syncer: `UpdateGasHistory()` appends one bounded row per new block into a new `gasHistory` collection every 30 min, with a 7d retention sweep.
- Home overview: replaces the largely-redundant **Slot** tile with **Avg Gas Price** wired to `/gas/summary` so the homepage finally surfaces gas info.

### New backend endpoints (all wrapped in the sprint-2b singleflight TTL cache)
- `GET /pending-tx-eta/:hash` — 5s TTL
- `GET /gas/summary` — 5s TTL
- `GET /gas/history?range=24h|7d` — 30s TTL (7d view downsampled to one row per hour)

### Why this shape for the ETA
The mempool is small enough on QRL today that pulling the full `status:"pending"` snapshot and doing `*big.Int` math in Go is simpler and more correct than trying to make Mongo compare hex-encoded big ints. `ComputeMempoolStatsFor` walks the snapshot once: median gasPrice across the set, and gas-ahead = sum of `gas` for txs with strictly higher `gasPrice` than the target. ETA = `ceil(gasAhead / avgBlockGasUsed) * avgBlockTimeSec`, floored at one block time so "no one ahead of you" still produces "next block".

### Edge cases handled
- Fewer than 2 blocks in the window → falls back to `avgBlockTimeSec = 60`.
- Empty mempool, malformed hex fields, and missing baseFeePerGas all return safe zeros — the gas-page UI hides chips that would render as "—" rather than splashing errors.
- Pending page: on `404` from `/pending-transaction/:hash` it probes `/tx/:hash` to distinguish mined (→ `router.replace`) from dropped (→ inline red card), then stops polling either way.
- 0n `bigint` literal explicitly avoided (ES2019 target).

## Test plan
- [ ] `/gas` renders stat cards, area chart, and histogram against live data
- [ ] Range toggle (24h ↔ 7d) re-fetches and re-renders the gas-used chart
- [ ] Homepage shows "Avg Gas Price" tile in Gwei in place of the Slot tile
- [ ] Pending tx page: open `/pending/tx/<live-pending-hash>` in devtools → confirm `/pending-transaction/:hash` and `/pending-tx-eta/:hash` poll every ~5s; elapsed counter ticks every second; ETA counter ticks every second and re-syncs on each poll
- [ ] Pending → mined: tx confirms → page auto-navigates to `/tx/:hash`, polling stops
- [ ] Dropped tx: stale hash → "Transaction Not Found" card renders inline, polling stops
- [ ] Already-mined-on-load: existing server-side redirect in `pending/tx/[hash]/page.tsx` still fires (no regression)
- [ ] Syncer: `pm2 logs synchroniser` shows "gasHistory updated" within ~30 min of restart, no errors
- [ ] `mongosh ... --eval 'db.gasHistory.countDocuments({})'` grows over time and stays under ~10k rows (7d × ~1440 blocks/day) thanks to the retention sweep

## Notes for reviewer
- Frontend `npm run lint` was already broken on `dev` (ESLint plugin "import" not resolved); `next build` + `tsc --noEmit` are clean for this branch.
- Backend `go test ./...` requires `MONGOURI`; not run in CI for this PR.