### PR TITLE
Disable caching for transaction details to show fresh confirmation counts

### DIFF
--- a/ExplorerFrontend/app/tx/[query]/page.tsx
+++ b/ExplorerFrontend/app/tx/[query]/page.tsx
@@ -22,10 +22,15 @@ async function getTransaction(txHash: string): Promise<TransactionDetails> {
     throw new Error('Invalid transaction hash format');
   }
 
+  // The backend bundles `latestBlock` (from sync_state, dynamic) with the
+  // tx record (immutable once mined) in the same payload. Caching the whole
+  // response froze `latestBlock` for 60 s, so a freshly-mined tx viewed
+  // mid-cache-window showed a stale confirmation count (e.g. "1 Confirmation")
+  // and a refresh after expiry would jump dozens higher. Always fetch fresh.
   const response = await fetch(`${config.handlerUrl}/tx/${txHash}`, {
     method: 'GET',
     headers: { Accept: 'application/json' },
-    next: { revalidate: 60 }, // Cache for 60 seconds
+    cache: 'no-store',
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
Changed the transaction details fetch to disable caching, ensuring users always see current confirmation counts rather than stale data from a previous cache window.

## Problem
The backend bundles two types of data in the `/tx/{hash}` response:
- **Immutable data**: The transaction record (doesn't change once mined)
- **Dynamic data**: `latestBlock` from `sync_state` (updates as new blocks are mined)

With 60-second caching enabled, the entire response was frozen, causing:
- A freshly-mined transaction viewed mid-cache-window would show stale confirmation counts (e.g., "1 Confirmation")
- After cache expiry, a refresh would jump to dozens of confirmations higher
- Poor UX for users monitoring transaction status

## Changes
- Replaced `next: { revalidate: 60 }` with `cache: 'no-store'` in the `getTransaction()` fetch call
- Added explanatory comment documenting why caching is disabled
- Transaction details are now always fetched fresh from the backend

## Implementation Details
- This is a server-side change in `ExplorerFrontend/app/tx/[query]/page.tsx`
- Uses Next.js fetch API's `cache: 'no-store'` option to bypass all caching layers
- No changes to backend API or data structures required

https://claude.ai/code/session_01Mo1ZdXPp2jTEWnNixkbPEq