### PR TITLE
feat(contracts): M2 — hypc-backed contract source verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ QRL2MongoDB/rpc/.env
 backendAPI/main.exe
 backendAPI/.env.production
 backendAPI/.env.development
+backendAPI/verification/runner/node_modules
 *.exe
 .DS_Store
 npm-debug.log*

--- a/backendAPI/db/contract.go
+++ b/backendAPI/db/contract.go
@@ -250,6 +250,31 @@ func UpdateVerificationJob(jobID string, patch bson.M) error {
 	return nil
 }
 
+// FindVerificationJobsByAddress lists verification jobs for a contract
+// address, filtered to a single status (e.g. "pending" or "compiling").
+// `limit` bounds the result; pass 1 for a "does any in-flight job exist"
+// check.
+func FindVerificationJobsByAddress(address string, status models.VerificationJobStatus, limit int64) ([]models.ContractVerificationJob, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	normalizedAddr := normalizeAddress(address)
+	filter := bson.M{"address": normalizedAddr, "status": status}
+	opts := options.Find().SetLimit(limit).SetSort(bson.D{{Key: "createdAt", Value: -1}})
+
+	cursor, err := configs.ContractVerificationsCollection.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var jobs []models.ContractVerificationJob
+	if err := cursor.All(ctx, &jobs); err != nil {
+		return nil, err
+	}
+	return jobs, nil
+}
+
 // GetContractByCreationTx returns contract info for a given creation transaction hash
 func GetContractByCreationTx(txHash string) (*models.ContractInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/backendAPI/handler/handler.go
+++ b/backendAPI/handler/handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"backendAPI/configs"
 	"backendAPI/routes"
+	"backendAPI/verification"
 	"log"
 	"os"
 	"runtime/debug"
@@ -73,6 +74,15 @@ func RequestHandler() {
 		log.Fatal("Failed to get MongoDB client, shutting down")
 	}
 	log.Println("MongoDB connection successful")
+
+	// Init the contract-verification singleton before routes register —
+	// the handlers tolerate a nil verifier (503 response) so a missing
+	// HYPC_RUNNER env never blocks the rest of the backend from booting.
+	if err := verification.Init(); err != nil {
+		log.Printf("Contract verification disabled: %v", err)
+	} else {
+		log.Println("Contract verification ready")
+	}
 
 	// Configure routes
 	log.Println("Configuring API routes...")

--- a/backendAPI/middleware/verify_ratelimit.go
+++ b/backendAPI/middleware/verify_ratelimit.go
@@ -1,0 +1,66 @@
+// Package middleware contains lightweight Gin middlewares that don't
+// warrant a dedicated package per concern. Currently: a per-IP rate
+// limiter used by the contract-verification endpoints to keep the
+// hypc runner from being DOSed by repeated submissions.
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// PerIPRateLimit returns a Gin middleware that enforces a token-bucket-
+// style limit per remote IP. The bucket holds `burst` tokens and refills
+// at `refill` tokens per `window`. Tokens are floats so partial refill
+// granularity matches the request cadence.
+//
+// Implementation is sync.Map + a per-entry mutex; cheap enough for the
+// small request volume we expect on /contract/verify (one submission per
+// human action). Eviction is opportunistic — buckets that haven't been
+// touched in 10×window get garbage-collected on the next access.
+func PerIPRateLimit(burst float64, refill float64, window time.Duration) gin.HandlerFunc {
+	var buckets sync.Map // key: string IP, val: *bucket
+	evictAfter := 10 * window
+
+	return func(c *gin.Context) {
+		ip := c.ClientIP()
+		now := time.Now()
+
+		val, _ := buckets.LoadOrStore(ip, &bucket{tokens: burst, last: now})
+		b := val.(*bucket)
+
+		b.mu.Lock()
+		// Evict idle bucket (other IPs sharing this map don't get cleaned
+		// up automatically — opportunistic on access is fine for our
+		// volume).
+		if now.Sub(b.last) > evictAfter {
+			b.tokens = burst
+		} else {
+			elapsed := now.Sub(b.last).Seconds()
+			b.tokens += elapsed * (refill / window.Seconds())
+			if b.tokens > burst {
+				b.tokens = burst
+			}
+		}
+		b.last = now
+
+		if b.tokens < 1 {
+			b.mu.Unlock()
+			c.JSON(http.StatusTooManyRequests, gin.H{"error": "rate limit exceeded"})
+			c.Abort()
+			return
+		}
+		b.tokens -= 1
+		b.mu.Unlock()
+		c.Next()
+	}
+}
+
+type bucket struct {
+	mu     sync.Mutex
+	tokens float64
+	last   time.Time
+}

--- a/backendAPI/middleware/verify_ratelimit.go
+++ b/backendAPI/middleware/verify_ratelimit.go
@@ -19,11 +19,33 @@ import (
 //
 // Implementation is sync.Map + a per-entry mutex; cheap enough for the
 // small request volume we expect on /contract/verify (one submission per
-// human action). Eviction is opportunistic — buckets that haven't been
-// touched in 10×window get garbage-collected on the next access.
+// human action). A janitor goroutine fully evicts idle buckets every
+// `window` so the map doesn't grow unbounded as unique IPs hit the endpoint.
 func PerIPRateLimit(burst float64, refill float64, window time.Duration) gin.HandlerFunc {
 	var buckets sync.Map // key: string IP, val: *bucket
-	evictAfter := 10 * window
+	const idleMultiplier = 10
+	evictAfter := time.Duration(idleMultiplier) * window
+
+	// Start the janitor once per middleware instance. It walks the map
+	// each `window` and `buckets.Delete`s any entry untouched for longer
+	// than `evictAfter`. Costs O(active IPs) per tick, which is fine — we
+	// never expect more than thousands of concurrent verifiers.
+	go func() {
+		ticker := time.NewTicker(window)
+		defer ticker.Stop()
+		for now := range ticker.C {
+			buckets.Range(func(k, v interface{}) bool {
+				b := v.(*bucket)
+				b.mu.Lock()
+				idle := now.Sub(b.last)
+				b.mu.Unlock()
+				if idle > evictAfter {
+					buckets.Delete(k)
+				}
+				return true
+			})
+		}
+	}()
 
 	return func(c *gin.Context) {
 		ip := c.ClientIP()
@@ -33,9 +55,8 @@ func PerIPRateLimit(burst float64, refill float64, window time.Duration) gin.Han
 		b := val.(*bucket)
 
 		b.mu.Lock()
-		// Evict idle bucket (other IPs sharing this map don't get cleaned
-		// up automatically — opportunistic on access is fine for our
-		// volume).
+		// Belt-and-braces in case a request races the janitor: if the
+		// bucket was effectively dropped mid-tick, reset it.
 		if now.Sub(b.last) > evictAfter {
 			b.tokens = burst
 		} else {

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -56,6 +56,12 @@ func UserRoute(router *gin.Engine) {
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	})
 
+	// Contract-verification endpoints (POST /contract/verify, GET
+	// /contract/verify/:jobId, GET /contract/compiler-info). The
+	// individual handlers return 503 when verification.Default() is nil,
+	// so this is safe to wire unconditionally.
+	RegisterVerificationRoutes(router)
+
 	// Add pending transactions endpoint with pagination
 	router.GET("/pending-transactions", func(c *gin.Context) {
 		page, limit := getPaginationParams(c, 1, 10)

--- a/backendAPI/routes/verification_routes.go
+++ b/backendAPI/routes/verification_routes.go
@@ -33,12 +33,21 @@ func RegisterVerificationRoutes(router *gin.Engine) {
 		c.JSON(http.StatusOK, v.Compiler.CompilerInfo())
 	})
 
+	// Maximum body size for a verify submission. The compiler also has
+	// VERIFIER_SOURCE_MAX_BYTES (default 256 KiB) on the marshalled
+	// standard-JSON payload, but that fires AFTER ShouldBindJSON has
+	// already buffered the request. Cap the raw stream too so a malicious
+	// gigantic body can't OOM the process during JSON binding.
+	const verifyMaxRequestBytes int64 = 1 << 20 // 1 MiB
+
 	router.POST("/contract/verify", verifyLimiter, func(c *gin.Context) {
 		v := verification.Default()
 		if v == nil {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "contract verification not configured"})
 			return
 		}
+
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, verifyMaxRequestBytes)
 
 		var req verification.VerifyRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -129,10 +138,14 @@ func RegisterVerificationRoutes(router *gin.Engine) {
 
 // newJobID returns a short opaque token (16 hex chars). Crypto random is
 // overkill for an externally-opaque handle but it's free and keeps callers
-// from guessing other users' jobs.
+// from guessing other users' jobs. A rand.Read failure on Linux/macOS
+// means /dev/urandom is unreadable — the process is unsalvageable, so
+// panic rather than continue with a degenerate ID.
 func newJobID() string {
 	var buf [8]byte
-	_, _ = rand.Read(buf[:])
+	if _, err := rand.Read(buf[:]); err != nil {
+		panic("verification: crypto/rand unavailable: " + err.Error())
+	}
 	return hex.EncodeToString(buf[:])
 }
 

--- a/backendAPI/routes/verification_routes.go
+++ b/backendAPI/routes/verification_routes.go
@@ -1,0 +1,154 @@
+package routes
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"time"
+
+	"backendAPI/db"
+	"backendAPI/middleware"
+	"backendAPI/models"
+	"backendAPI/verification"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterVerificationRoutes wires the three contract-verification
+// endpoints onto the supplied router. Always registered — when the
+// verifier isn't configured, individual handlers return 503 so the rest
+// of the backend keeps working.
+func RegisterVerificationRoutes(router *gin.Engine) {
+	// Per-IP rate limit: 5 in-flight verifications per minute is plenty
+	// for human-driven submissions and trivially budgets the runner.
+	verifyLimiter := middleware.PerIPRateLimit(5, 5, time.Minute)
+
+	router.GET("/contract/compiler-info", func(c *gin.Context) {
+		v := verification.Default()
+		if v == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "contract verification not configured"})
+			return
+		}
+		c.JSON(http.StatusOK, v.Compiler.CompilerInfo())
+	})
+
+	router.POST("/contract/verify", verifyLimiter, func(c *gin.Context) {
+		v := verification.Default()
+		if v == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "contract verification not configured"})
+			return
+		}
+
+		var req verification.VerifyRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body: " + err.Error()})
+			return
+		}
+		if !isValidAddress(req.Address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid Q-prefixed address"})
+			return
+		}
+		if req.ContractName == "" || req.SourceCode == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "contractName and sourceCode are required"})
+			return
+		}
+		if req.CompilerVersion != "" && req.CompilerVersion != v.Compiler.BuildID {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":           "unsupported compilerVersion — see /contract/compiler-info",
+				"supportedBuild":  v.Compiler.BuildID,
+				"requestedBuild":  req.CompilerVersion,
+			})
+			return
+		}
+
+		// Idempotency: if the contract is already verified, return success
+		// without spawning another compile.
+		already, err := verification.AlreadyVerified(req.Address)
+		if err == nil && already {
+			c.JSON(http.StatusOK, gin.H{
+				"alreadyVerified": true,
+				"address":         req.Address,
+			})
+			return
+		}
+
+		// Reject duplicate in-flight jobs for the same address.
+		pending, err := verification.HasPendingJob(req.Address)
+		if err == nil && pending {
+			c.JSON(http.StatusConflict, gin.H{"error": "a verification job is already in flight for this address"})
+			return
+		}
+
+		jobID := newJobID()
+		job := models.ContractVerificationJob{
+			JobID:   jobID,
+			Address: req.Address,
+			Status:  models.VerificationJobPending,
+			Payload: models.VerificationJobPayload{
+				SourceCode:           req.SourceCode,
+				ContractName:         req.ContractName,
+				CompilerVersion:      v.Compiler.BuildID,
+				OptimizationEnabled:  req.OptimizerEnabled,
+				OptimizationRuns:     req.OptimizerRuns,
+				EvmVersion:           req.EvmVersion,
+				ConstructorArguments: req.ConstructorArguments,
+				Libraries:            req.Libraries,
+				License:              req.License,
+				VerificationMethod:   "full-source",
+			},
+		}
+		if err := db.CreateVerificationJob(job); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "create job: " + err.Error()})
+			return
+		}
+
+		v.RunAsync(jobID, req)
+
+		c.JSON(http.StatusAccepted, verification.VerifyEnqueueResponse{
+			JobID:   jobID,
+			Status:  string(models.VerificationJobPending),
+			Address: req.Address,
+		})
+	})
+
+	router.GET("/contract/verify/:jobId", func(c *gin.Context) {
+		jobID := c.Param("jobId")
+		job, err := db.GetVerificationJob(jobID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "lookup: " + err.Error()})
+			return
+		}
+		if job == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "job not found"})
+			return
+		}
+		c.JSON(http.StatusOK, job)
+	})
+}
+
+// newJobID returns a short opaque token (16 hex chars). Crypto random is
+// overkill for an externally-opaque handle but it's free and keeps callers
+// from guessing other users' jobs.
+func newJobID() string {
+	var buf [8]byte
+	_, _ = rand.Read(buf[:])
+	return hex.EncodeToString(buf[:])
+}
+
+// isValidAddress is a permissive Q-prefix check. The full validation
+// happens at the storage layer (normalizeAddress canonicalises case).
+func isValidAddress(a string) bool {
+	if !strings.HasPrefix(a, "Q") {
+		return false
+	}
+	if len(a) != 41 {
+		return false
+	}
+	for _, r := range a[1:] {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+			return false
+		}
+	}
+	return true
+}

--- a/backendAPI/verification/compiler.go
+++ b/backendAPI/verification/compiler.go
@@ -1,0 +1,188 @@
+package verification
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Compiler wraps the @theqrl/hypc WASM via a one-shot Node subprocess
+// (backendAPI/verification/runner/hypc-runner.js). The Go layer holds the
+// sandboxing budget — timeout, concurrency cap, stdin size cap, scratch
+// env — so the runner can stay tiny.
+type Compiler struct {
+	NodeBin    string        // path to the `node` binary
+	RunnerPath string        // absolute path to hypc-runner.js
+	BuildID    string        // pinned version string (e.g. "0.0.2+commit.3e18e55d.Emscripten.clang")
+	Timeout    time.Duration // per-compile hard deadline
+	MaxStdin   int           // bytes — reject standard-JSON inputs larger than this
+
+	sem  chan struct{}
+	once sync.Once
+}
+
+// ErrPayloadTooLarge is returned when the standard-JSON payload exceeds
+// MaxStdin. The cap protects the runner from being asked to compile a
+// payload so large that its mere parse exhausts heap.
+var ErrPayloadTooLarge = errors.New("verification: standard-JSON payload exceeds MaxStdin")
+
+// ErrCompileTimeout is returned when the per-call deadline fires.
+var ErrCompileTimeout = errors.New("verification: compile timed out")
+
+// NewCompiler constructs a Compiler from environment variables:
+//
+//	HYPC_NODE_BIN           path to the node binary           (default "node")
+//	HYPC_RUNNER             abs path to hypc-runner.js        (required)
+//	HYPC_BUILD_ID           pinned version string             (required)
+//	VERIFIER_MAX_CONCURRENCY in-process concurrent compiles   (default 2)
+//	VERIFIER_COMPILE_TIMEOUT per-compile hard timeout         (default 30s)
+//	VERIFIER_SOURCE_MAX_BYTES standard-JSON payload cap       (default 256KiB)
+//
+// The Compiler fails fast at startup if HYPC_RUNNER / HYPC_BUILD_ID are
+// missing or if the runner's reported version doesn't match HYPC_BUILD_ID.
+func NewCompiler() (*Compiler, error) {
+	nodeBin := envWithDefault("HYPC_NODE_BIN", "node")
+	runner := os.Getenv("HYPC_RUNNER")
+	if runner == "" {
+		return nil, errors.New("HYPC_RUNNER env var is required (abs path to hypc-runner.js)")
+	}
+	buildID := os.Getenv("HYPC_BUILD_ID")
+	if buildID == "" {
+		return nil, errors.New("HYPC_BUILD_ID env var is required (pinned hypc version string)")
+	}
+	maxConc := envInt("VERIFIER_MAX_CONCURRENCY", 2)
+	if maxConc < 1 {
+		maxConc = 1
+	}
+	timeout := envDuration("VERIFIER_COMPILE_TIMEOUT", 30*time.Second)
+	maxStdin := envInt("VERIFIER_SOURCE_MAX_BYTES", 256*1024)
+
+	c := &Compiler{
+		NodeBin:    nodeBin,
+		RunnerPath: runner,
+		BuildID:    buildID,
+		Timeout:    timeout,
+		MaxStdin:   maxStdin,
+		sem:        make(chan struct{}, maxConc),
+	}
+
+	// Validate the runner can be invoked + reports the expected build.
+	got, err := c.probeVersion()
+	if err != nil {
+		return nil, fmt.Errorf("hypc-runner version probe failed: %w", err)
+	}
+	if got != buildID {
+		return nil, fmt.Errorf("hypc-runner build mismatch: want %q, got %q", buildID, got)
+	}
+	log.Printf("verification.Compiler ready: runner=%s build=%s timeout=%s concurrency=%d", runner, buildID, timeout, maxConc)
+	return c, nil
+}
+
+// CompilerInfo returns the pinned build ID. Used by GET /contract/compiler-info.
+func (c *Compiler) CompilerInfo() CompilerInfoResponse {
+	return CompilerInfoResponse{Language: "Hyperion", BuildID: c.BuildID}
+}
+
+// Compile invokes the runner with the supplied standard-JSON input and
+// parses its JSON output. Compile errors (severity=="error") are
+// returned in the StandardJSONOutput.Errors field — they are NOT a
+// Go-level error. Only infrastructure failures (timeout, marshalling,
+// runner non-zero exit) surface as error returns.
+func (c *Compiler) Compile(ctx context.Context, input StandardJSONInput) (*StandardJSONOutput, error) {
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("marshal standard-JSON: %w", err)
+	}
+	if c.MaxStdin > 0 && len(payload) > c.MaxStdin {
+		return nil, ErrPayloadTooLarge
+	}
+
+	// Acquire concurrency permit. Honour caller's context (so a request
+	// timeout fires even while we're queued).
+	select {
+	case c.sem <- struct{}{}:
+		defer func() { <-c.sem }()
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	// Apply our per-call timeout on top of whatever the caller provided.
+	subCtx, cancel := context.WithTimeout(ctx, c.Timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(subCtx, c.NodeBin, c.RunnerPath)
+	cmd.Stdin = bytes.NewReader(payload)
+	// Scrub the env — the runner only needs PATH to find node-bundled
+	// shared libs. Anything else is signalling we don't want leaking.
+	cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if errors.Is(subCtx.Err(), context.DeadlineExceeded) {
+			return nil, ErrCompileTimeout
+		}
+		return nil, fmt.Errorf("hypc-runner exec: %w (stderr: %s)", err, strings.TrimSpace(stderr.String()))
+	}
+
+	var out StandardJSONOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		return nil, fmt.Errorf("hypc-runner produced invalid JSON: %w", err)
+	}
+	return &out, nil
+}
+
+// probeVersion runs the runner with --version and returns the trimmed
+// stdout. Used at startup to gate boot on a build-ID match.
+func (c *Compiler) probeVersion() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, c.NodeBin, c.RunnerPath, "--version")
+	cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func envWithDefault(k, d string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return d
+}
+
+func envInt(k string, d int) int {
+	v := os.Getenv(k)
+	if v == "" {
+		return d
+	}
+	var n int
+	if _, err := fmt.Sscanf(v, "%d", &n); err != nil {
+		return d
+	}
+	return n
+}
+
+func envDuration(k string, d time.Duration) time.Duration {
+	v := os.Getenv(k)
+	if v == "" {
+		return d
+	}
+	dur, err := time.ParseDuration(v)
+	if err != nil {
+		return d
+	}
+	return dur
+}

--- a/backendAPI/verification/init.go
+++ b/backendAPI/verification/init.go
@@ -1,0 +1,38 @@
+package verification
+
+import (
+	"log"
+	"sync"
+)
+
+// Process-wide default Verifier. nil when the runner isn't configured —
+// the routes layer must check Default() and return 503 in that case so
+// the rest of the backend boots normally.
+var (
+	defaultMu sync.RWMutex
+	def       *Verifier
+)
+
+// Init constructs the package-level Verifier from environment variables.
+// Called once at backend startup. A nil error here means /contract/verify*
+// routes are live; a non-nil error logs a warning and leaves the default
+// nil — the rest of the backend remains usable.
+func Init() error {
+	c, err := NewCompiler()
+	if err != nil {
+		log.Printf("WARN: contract verification disabled — %v", err)
+		return err
+	}
+	defaultMu.Lock()
+	def = &Verifier{Compiler: c}
+	defaultMu.Unlock()
+	return nil
+}
+
+// Default returns the package-level Verifier or nil when verification is
+// not configured.
+func Default() *Verifier {
+	defaultMu.RLock()
+	defer defaultMu.RUnlock()
+	return def
+}

--- a/backendAPI/verification/match.go
+++ b/backendAPI/verification/match.go
@@ -1,0 +1,186 @@
+package verification
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"backendAPI/models"
+)
+
+// MatchOutcome is the result of comparing fresh-compile bytecode against
+// on-chain runtime code. NotFound separates "no contract code at this
+// address" from a clean mismatch so the caller can pick the right error
+// message.
+type MatchOutcome struct {
+	Matched         bool
+	CompiledLen     int
+	OnChainLen      int
+	OnChainHex      string // the authoritative runtime code (canonical, no 0x)
+	CompiledHex     string // the masked compile output (no 0x)
+	DiffByteOffset  int    // first divergent byte (only set when !Matched); -1 = identical prefix, longer side has extra bytes
+	NotFound        bool   // true when qrl_getCode returned empty / 0x
+	ImmutablesCount int
+}
+
+// FetchOnChainCode pulls the authoritative runtime code via qrl_getCode.
+// Never trust the syncer's base64-encoded contractCode field for matching:
+// the syncer source might lag, and any byte-shape difference between
+// "what's actually deployed" and "what the indexer captured" would silently
+// invalidate verification.
+func FetchOnChainCode(ctx context.Context, address string) (string, error) {
+	nodeURL := os.Getenv("NODE_URL")
+	if nodeURL == "" {
+		nodeURL = "http://127.0.0.1:8545"
+	}
+
+	body, err := json.Marshal(models.JsonRPC{
+		Jsonrpc: "2.0",
+		Method:  "qrl_getCode",
+		Params:  []interface{}{address, "latest"},
+		ID:      1,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, nodeURL, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("node RPC: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("node RPC returned %d", resp.StatusCode)
+	}
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var parsed struct {
+		Result string `json:"result"`
+		Error  *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return "", fmt.Errorf("node RPC body: %w", err)
+	}
+	if parsed.Error != nil {
+		return "", fmt.Errorf("node RPC error %d: %s", parsed.Error.Code, parsed.Error.Message)
+	}
+	return parsed.Result, nil
+}
+
+// Match compares freshly-compiled deployedBytecode against authoritative
+// on-chain runtime code, masking any `immutable`-backed byte ranges in
+// both before comparing.
+//
+// Per the M2.0 spike, Hyperion v0.0.2 does NOT emit a Solidity-style
+// CBOR metadata trailer, so there's no trailer to strip — the masked
+// bytes simply have to match exactly. If a future hypc build starts
+// emitting a trailer, extend this function with a strip step *before*
+// the length / equal compare.
+func Match(compiledHex, onChainHex string, immRefs map[string][]ImmutableRange) (MatchOutcome, error) {
+	compiledHex = strings.ToLower(strings.TrimPrefix(compiledHex, "0x"))
+	onChainHex = strings.ToLower(strings.TrimPrefix(onChainHex, "0x"))
+
+	out := MatchOutcome{
+		CompiledHex: compiledHex,
+		OnChainHex:  onChainHex,
+		CompiledLen: len(compiledHex) / 2,
+		OnChainLen:  len(onChainHex) / 2,
+	}
+
+	if onChainHex == "" || onChainHex == "0" {
+		out.NotFound = true
+		return out, nil
+	}
+
+	cb, err := hex.DecodeString(compiledHex)
+	if err != nil {
+		return out, fmt.Errorf("decode compiled hex: %w", err)
+	}
+	ob, err := hex.DecodeString(onChainHex)
+	if err != nil {
+		return out, fmt.Errorf("decode on-chain hex: %w", err)
+	}
+
+	immutablesCount := 0
+	for _, ranges := range immRefs {
+		immutablesCount += len(ranges)
+	}
+	out.ImmutablesCount = immutablesCount
+
+	// Mask immutable ranges on BOTH sides. Bounds-checked so a malformed
+	// immutableReferences map can't OOB.
+	for _, ranges := range immRefs {
+		for _, r := range ranges {
+			if r.Start < 0 || r.Length < 0 {
+				continue
+			}
+			endA := r.Start + r.Length
+			if endA > len(cb) {
+				endA = len(cb)
+			}
+			endB := r.Start + r.Length
+			if endB > len(ob) {
+				endB = len(ob)
+			}
+			for i := r.Start; i < endA; i++ {
+				cb[i] = 0
+			}
+			for i := r.Start; i < endB; i++ {
+				ob[i] = 0
+			}
+		}
+	}
+
+	if len(cb) != len(ob) {
+		// Length mismatch is a hard fail; report the first divergent
+		// byte for diagnostics.
+		min := len(cb)
+		if len(ob) < min {
+			min = len(ob)
+		}
+		out.DiffByteOffset = -1
+		for i := 0; i < min; i++ {
+			if cb[i] != ob[i] {
+				out.DiffByteOffset = i
+				break
+			}
+		}
+		return out, nil
+	}
+
+	if bytes.Equal(cb, ob) {
+		out.Matched = true
+		return out, nil
+	}
+
+	// Same length but bytes differ — surface the first diff offset.
+	for i := range cb {
+		if cb[i] != ob[i] {
+			out.DiffByteOffset = i
+			return out, nil
+		}
+	}
+	return out, errors.New("byte slices unequal but no diff found")
+}

--- a/backendAPI/verification/match.go
+++ b/backendAPI/verification/match.go
@@ -31,6 +31,13 @@ type MatchOutcome struct {
 	ImmutablesCount int
 }
 
+// nodeHTTPClient is a process-wide HTTP client reused for every
+// qrl_getCode call. Reusing the same client (and thus the same connection
+// pool / DNS cache) is materially cheaper than `&http.Client{}` per call,
+// which would force a fresh TCP+TLS handshake every time the verifier
+// queries the node.
+var nodeHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
 // FetchOnChainCode pulls the authoritative runtime code via qrl_getCode.
 // Never trust the syncer's base64-encoded contractCode field for matching:
 // the syncer source might lag, and any byte-shape difference between
@@ -58,8 +65,7 @@ func FetchOnChainCode(ctx context.Context, address string) (string, error) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := nodeHTTPClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("node RPC: %w", err)
 	}

--- a/backendAPI/verification/runner/hypc-runner.js
+++ b/backendAPI/verification/runner/hypc-runner.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// hypc-runner: thin Node entry-point invoked by the Go backend's
+// verification pipeline. Reads a Hyperion standard-JSON input from stdin
+// (or a single source file path via --file plus a synthesised wrapper) and
+// emits the compiler's JSON output to stdout. Exits non-zero only on
+// runner-internal failure (compile errors are reported as a JSON output
+// with `errors` populated, exit 0).
+//
+// Invocation modes:
+//   echo '<standard-json>' | node hypc-runner.js
+//   node hypc-runner.js --version          → prints the pinned compiler ID
+//
+// The Go layer enforces timeouts, concurrency caps, source-size caps,
+// and the no-network policy via exec.CommandContext + cgroups/rlimits;
+// this script just wraps @theqrl/hypc as cleanly as possible.
+
+const hypc = require('@theqrl/hypc');
+
+if (process.argv.includes('--version')) {
+  process.stdout.write(hypc.version() + '\n');
+  process.exit(0);
+}
+
+let stdin = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (c) => { stdin += c; });
+process.stdin.on('end', () => {
+  let input;
+  try {
+    input = JSON.parse(stdin);
+  } catch (e) {
+    process.stderr.write('hypc-runner: invalid stdin JSON: ' + e.message + '\n');
+    process.exit(2);
+  }
+  if (!input || input.language !== 'Hyperion') {
+    process.stderr.write('hypc-runner: input.language must be "Hyperion"\n');
+    process.exit(2);
+  }
+
+  // Resolve imports STRICTLY from the input.sources map — no filesystem,
+  // no network. The Go caller is responsible for inlining every dependency
+  // before invoking the runner; anything not present in `sources` is a
+  // hard error.
+  const sources = input.sources || {};
+  function findImports(p) {
+    if (Object.prototype.hasOwnProperty.call(sources, p)) {
+      return { contents: sources[p].content };
+    }
+    return { error: 'hypc-runner: import not found: ' + p };
+  }
+
+  let out;
+  try {
+    out = hypc.compile(stdin, { import: findImports });
+  } catch (e) {
+    process.stderr.write('hypc-runner: compile threw: ' + (e && e.stack ? e.stack : e) + '\n');
+    process.exit(3);
+  }
+
+  process.stdout.write(out);
+  process.exit(0);
+});

--- a/backendAPI/verification/runner/package-lock.json
+++ b/backendAPI/verification/runner/package-lock.json
@@ -1,0 +1,112 @@
+{
+  "name": "hypc-runner",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hypc-runner",
+      "version": "0.0.1",
+      "dependencies": {
+        "@theqrl/hypc": "^0.0.2"
+      }
+    },
+    "node_modules/@theqrl/hypc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@theqrl/hypc/-/hypc-0.0.2.tgz",
+      "integrity": "sha512-XsP7hETJdlmmdGtmp/K5ZtTcz3EzZaP+WhjuOTf4PmhE+6oijN271H10htYHvBo95ED2OYiuUCYucYNw7Q6mfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "command-exists": "^1.2.8",
+        "commander": "^8.1.0",
+        "follow-redirects": "^1.12.1",
+        "js-sha3": "0.8.0",
+        "memorystream": "^0.3.1",
+        "semver": "^5.5.0",
+        "tmp": "0.0.33"
+      },
+      "bin": {
+        "hypcjs": "hypc.js"
+      }
+    },
+    "node_modules/command-exists": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "license": "MIT"
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    }
+  }
+}

--- a/backendAPI/verification/runner/package.json
+++ b/backendAPI/verification/runner/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "hypc-runner",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Node entry that wraps @theqrl/hypc for the Go verifier backend. Invoked one-shot per verify request.",
+  "scripts": {
+    "version": "node hypc-runner.js --version"
+  },
+  "dependencies": {
+    "@theqrl/hypc": "^0.0.2"
+  }
+}

--- a/backendAPI/verification/types.go
+++ b/backendAPI/verification/types.go
@@ -1,0 +1,115 @@
+package verification
+
+import "encoding/json"
+
+// VerifyRequest is the JSON body for POST /contract/verify.
+//
+// Single-file submissions wrap the primary contract source in the
+// `sourceCode` field; additional dependencies (imports) go into the
+// `imports` map keyed by the path the source uses for the import (e.g.
+// "./Context.hyp" → the Context.hyp content). The Go layer wraps both
+// into a Hyperion standard-JSON `sources` map before invoking the
+// runner — users never see standard-JSON directly in v1.
+type VerifyRequest struct {
+	Address              string            `json:"address" binding:"required"`
+	SourceCode           string            `json:"sourceCode" binding:"required"`
+	ContractName         string            `json:"contractName" binding:"required"`
+	CompilerVersion      string            `json:"compilerVersion,omitempty"`
+	OptimizerEnabled     bool              `json:"optimizerEnabled"`
+	OptimizerRuns        int               `json:"optimizerRuns"`
+	EvmVersion           string            `json:"evmVersion,omitempty"`
+	ConstructorArguments string            `json:"constructorArguments,omitempty"`
+	Libraries            map[string]string `json:"libraries,omitempty"`
+	Imports              map[string]string `json:"imports,omitempty"`
+	License              string            `json:"license,omitempty"`
+}
+
+// VerifyEnqueueResponse is returned synchronously from POST /contract/verify
+// once the job has been created. Clients poll GET /contract/verify/:jobId
+// for the real outcome.
+type VerifyEnqueueResponse struct {
+	JobID   string `json:"jobId"`
+	Status  string `json:"status"`
+	Address string `json:"address"`
+}
+
+// CompilerInfoResponse is the body of GET /contract/compiler-info — the
+// single pinned hypc build the backend is willing to verify against.
+type CompilerInfoResponse struct {
+	Language string `json:"language"`
+	BuildID  string `json:"buildId"`
+}
+
+// StandardJSONInput is the Hyperion standard-JSON shape we feed to the
+// runner. Mirrors the Solidity standard-JSON layout — see
+// theQRL/hyperion docs for details.
+type StandardJSONInput struct {
+	Language string                              `json:"language"`
+	Sources  map[string]StandardJSONSource       `json:"sources"`
+	Settings StandardJSONSettings                `json:"settings"`
+}
+
+type StandardJSONSource struct {
+	Content string `json:"content"`
+}
+
+type StandardJSONSettings struct {
+	Optimizer       *Optimizer                              `json:"optimizer,omitempty"`
+	EVMVersion      string                                  `json:"evmVersion,omitempty"`
+	Libraries       map[string]map[string]string            `json:"libraries,omitempty"`
+	OutputSelection map[string]map[string][]string          `json:"outputSelection"`
+}
+
+type Optimizer struct {
+	Enabled bool `json:"enabled"`
+	Runs    int  `json:"runs"`
+}
+
+// StandardJSONOutput is the runner's JSON output shape.
+type StandardJSONOutput struct {
+	Errors    []CompilerError                            `json:"errors,omitempty"`
+	Contracts map[string]map[string]CompiledContract     `json:"contracts,omitempty"`
+}
+
+type CompilerError struct {
+	Severity         string `json:"severity"`
+	Message          string `json:"message"`
+	FormattedMessage string `json:"formattedMessage,omitempty"`
+	Type             string `json:"type,omitempty"`
+}
+
+// CompiledContract is the per-contract artifact from the compiler's output
+// for a given source unit. Hyperion uses `zvm` (Zond VM) rather than `evm`.
+type CompiledContract struct {
+	ABI json.RawMessage `json:"abi,omitempty"`
+	ZVM struct {
+		DeployedBytecode struct {
+			Object              string                          `json:"object"`
+			ImmutableReferences map[string][]ImmutableRange     `json:"immutableReferences,omitempty"`
+		} `json:"deployedBytecode"`
+		Bytecode struct {
+			Object string `json:"object"`
+		} `json:"bytecode"`
+	} `json:"zvm"`
+	Metadata string `json:"metadata,omitempty"`
+}
+
+// ImmutableRange is a byte slice within deployedBytecode that holds an
+// `immutable` value patched at deploy time. We mask these ranges in both
+// the compiled output and the on-chain code before byte-matching.
+type ImmutableRange struct {
+	Start  int `json:"start"`
+	Length int `json:"length"`
+}
+
+// FatalErrors filters a runner's output for errors that should fail the
+// verification (severity == "error"). Warnings are surfaced but not fatal.
+func (o *StandardJSONOutput) FatalErrors() []CompilerError {
+	out := []CompilerError{}
+	for _, e := range o.Errors {
+		if e.Severity == "error" {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/backendAPI/verification/verifier.go
+++ b/backendAPI/verification/verifier.go
@@ -1,0 +1,239 @@
+package verification
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"backendAPI/db"
+	"backendAPI/models"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// Verifier ties Compiler + on-chain code + byte match + the M1 storage
+// layer (MarkContractVerified + UpdateVerificationJob) into a single
+// background runner. One Verifier per process.
+type Verifier struct {
+	Compiler *Compiler
+}
+
+// RunAsync runs the verification flow in the background and updates the
+// job document along the way. Returns immediately so the HTTP handler
+// can hand the jobId back to the client without blocking.
+//
+// Status transitions:
+//
+//	pending → compiling → success    (mark contract verified, store ResultRef)
+//	pending → compiling → failed     (record error message)
+//
+// The supplied ctx should typically be context.Background() so the job
+// survives the client connection being torn down mid-compile.
+func (v *Verifier) RunAsync(jobID string, req VerifyRequest) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), v.Compiler.Timeout+15*time.Second)
+		defer cancel()
+		v.run(ctx, jobID, req)
+	}()
+}
+
+func (v *Verifier) run(ctx context.Context, jobID string, req VerifyRequest) {
+	_ = db.UpdateVerificationJob(jobID, bson.M{"status": models.VerificationJobCompiling})
+
+	input := wrapStandardJSON(req)
+
+	out, err := v.Compiler.Compile(ctx, input)
+	if err != nil {
+		failJob(jobID, fmt.Sprintf("compile invocation failed: %s", err.Error()))
+		return
+	}
+	if fatal := out.FatalErrors(); len(fatal) > 0 {
+		failJob(jobID, formatCompileErrors(fatal))
+		return
+	}
+
+	contract, ok := findContract(out, req.ContractName)
+	if !ok {
+		failJob(jobID, fmt.Sprintf("contract %q not found in compiler output", req.ContractName))
+		return
+	}
+
+	onchain, err := FetchOnChainCode(ctx, req.Address)
+	if err != nil {
+		failJob(jobID, fmt.Sprintf("fetch on-chain code: %s", err.Error()))
+		return
+	}
+
+	match, err := Match(contract.ZVM.DeployedBytecode.Object, onchain, contract.ZVM.DeployedBytecode.ImmutableReferences)
+	if err != nil {
+		failJob(jobID, fmt.Sprintf("match: %s", err.Error()))
+		return
+	}
+	if match.NotFound {
+		failJob(jobID, "no contract code at address (qrl_getCode returned empty)")
+		return
+	}
+	if !match.Matched {
+		failJob(jobID, fmt.Sprintf("bytecode mismatch (compiled=%d B, on-chain=%d B, diff@byte=%d)",
+			match.CompiledLen, match.OnChainLen, match.DiffByteOffset))
+		return
+	}
+
+	abiBytes, _ := json.Marshal(contract.ABI)
+	result := models.VerificationResult{
+		SourceCode:           req.SourceCode,
+		Abi:                  string(abiBytes),
+		ContractName:         req.ContractName,
+		CompilerVersion:      v.Compiler.BuildID,
+		OptimizationEnabled:  req.OptimizerEnabled,
+		OptimizationRuns:     req.OptimizerRuns,
+		EvmVersion:           req.EvmVersion,
+		ConstructorArguments: req.ConstructorArguments,
+		Libraries:            req.Libraries,
+		License:              req.License,
+		VerificationMethod:   "full-source",
+	}
+	if err := db.MarkContractVerified(req.Address, result); err != nil {
+		failJob(jobID, fmt.Sprintf("write verification: %s", err.Error()))
+		return
+	}
+
+	_ = db.UpdateVerificationJob(jobID, bson.M{
+		"status": models.VerificationJobSuccess,
+		"error":  "",
+		"result": models.VerificationJobResultRef{
+			Abi:        string(abiBytes),
+			VerifiedAt: time.Now().UTC().Format(time.RFC3339),
+		},
+	})
+}
+
+func failJob(jobID, msg string) {
+	_ = db.UpdateVerificationJob(jobID, bson.M{
+		"status": models.VerificationJobFailed,
+		"error":  msg,
+	})
+}
+
+// wrapStandardJSON builds the Hyperion standard-JSON input from the user-
+// submitted single-file request. The primary source is keyed by
+// `<ContractName>.hyp`; any caller-supplied imports are passed through
+// verbatim so the runner's import resolver can find them.
+func wrapStandardJSON(req VerifyRequest) StandardJSONInput {
+	sources := map[string]StandardJSONSource{
+		req.ContractName + ".hyp": {Content: req.SourceCode},
+	}
+	for path, content := range req.Imports {
+		sources[normalizeImportPath(path)] = StandardJSONSource{Content: content}
+	}
+
+	settings := StandardJSONSettings{
+		Optimizer: &Optimizer{
+			Enabled: req.OptimizerEnabled,
+			Runs:    req.OptimizerRuns,
+		},
+		EVMVersion: req.EvmVersion,
+		OutputSelection: map[string]map[string][]string{
+			"*": {
+				"*": {
+					"abi",
+					"zvm.deployedBytecode.object",
+					"zvm.deployedBytecode.immutableReferences",
+					"metadata",
+				},
+			},
+		},
+	}
+	if len(req.Libraries) > 0 {
+		// Libraries map is keyed by file → name → address. Best-effort:
+		// hoist into a single sentinel "<ContractName>.hyp" entry so users
+		// don't have to know the multi-file shape.
+		settings.Libraries = map[string]map[string]string{
+			req.ContractName + ".hyp": req.Libraries,
+		}
+	}
+
+	return StandardJSONInput{
+		Language: "Hyperion",
+		Sources:  sources,
+		Settings: settings,
+	}
+}
+
+// normalizeImportPath strips a leading "./" from a user-supplied import
+// key so it lines up with whatever Hyperion's resolver looks up. Users
+// who literally write `import "./Context.hyp"` in their source might
+// reasonably key the imports map either way; we accept both.
+func normalizeImportPath(p string) string {
+	if strings.HasPrefix(p, "./") {
+		return p[2:]
+	}
+	return p
+}
+
+// findContract walks the compiler output for a contract with the supplied
+// name. Hypc nests contracts under <sourceUnit>.<contractName> so we scan
+// every source unit for a matching name.
+func findContract(out *StandardJSONOutput, name string) (*CompiledContract, bool) {
+	for _, unit := range out.Contracts {
+		if c, ok := unit[name]; ok {
+			return &c, true
+		}
+	}
+	return nil, false
+}
+
+func formatCompileErrors(es []CompilerError) string {
+	parts := []string{}
+	for _, e := range es {
+		if e.FormattedMessage != "" {
+			parts = append(parts, e.FormattedMessage)
+		} else {
+			parts = append(parts, e.Message)
+		}
+	}
+	msg := strings.Join(parts, "\n---\n")
+	if len(msg) > 8000 {
+		msg = msg[:8000] + "…(truncated)"
+	}
+	return msg
+}
+
+// AlreadyVerified returns true when the contract document at `address`
+// already carries a verified=true marker, so duplicate submissions can
+// be made idempotent.
+func AlreadyVerified(address string) (bool, error) {
+	c, err := db.ReturnContractCode(address)
+	if err != nil {
+		return false, err
+	}
+	return c.Verified, nil
+}
+
+// HasPendingJob returns true when a job for `address` is currently
+// pending or compiling. Used to reject duplicate submissions.
+func HasPendingJob(address string) (bool, error) {
+	// Walk through (limited) — only a tiny number of jobs per contract
+	// are expected in practice.
+	for _, status := range []models.VerificationJobStatus{models.VerificationJobPending, models.VerificationJobCompiling} {
+		jobs, err := db.FindVerificationJobsByAddress(address, status, 1)
+		if err != nil {
+			return false, err
+		}
+		if len(jobs) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ErrAlreadyVerified is returned by Enqueue when the contract is already
+// verified — callers should treat this as success (idempotency).
+var ErrAlreadyVerified = errors.New("verification: address already verified")
+
+// ErrDuplicateJob is returned by Enqueue when a pending job already exists
+// for the same address.
+var ErrDuplicateJob = errors.New("verification: another job is already in-flight for this address")

--- a/backendAPI/verification/verifier.go
+++ b/backendAPI/verification/verifier.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -41,7 +42,12 @@ func (v *Verifier) RunAsync(jobID string, req VerifyRequest) {
 }
 
 func (v *Verifier) run(ctx context.Context, jobID string, req VerifyRequest) {
-	_ = db.UpdateVerificationJob(jobID, bson.M{"status": models.VerificationJobCompiling})
+	if err := db.UpdateVerificationJob(jobID, bson.M{"status": models.VerificationJobCompiling}); err != nil {
+		// Status transition failures aren't fatal — the rest of the run
+		// continues and the client will see the eventual terminal state.
+		// But we log so persistent mongo issues don't go unnoticed.
+		log.Printf("verifier: failed to mark job %s compiling: %v", jobID, err)
+	}
 
 	input := wrapStandardJSON(req)
 
@@ -101,21 +107,25 @@ func (v *Verifier) run(ctx context.Context, jobID string, req VerifyRequest) {
 		return
 	}
 
-	_ = db.UpdateVerificationJob(jobID, bson.M{
+	if err := db.UpdateVerificationJob(jobID, bson.M{
 		"status": models.VerificationJobSuccess,
 		"error":  "",
 		"result": models.VerificationJobResultRef{
 			Abi:        string(abiBytes),
 			VerifiedAt: time.Now().UTC().Format(time.RFC3339),
 		},
-	})
+	}); err != nil {
+		log.Printf("verifier: failed to mark job %s success: %v", jobID, err)
+	}
 }
 
 func failJob(jobID, msg string) {
-	_ = db.UpdateVerificationJob(jobID, bson.M{
+	if err := db.UpdateVerificationJob(jobID, bson.M{
 		"status": models.VerificationJobFailed,
 		"error":  msg,
-	})
+	}); err != nil {
+		log.Printf("verifier: failed to mark job %s failed (%q): %v", jobID, msg, err)
+	}
 }
 
 // wrapStandardJSON builds the Hyperion standard-JSON input from the user-


### PR DESCRIPTION
**Stacked on M1 (#72)** — please review/merge #72 first; once it lands on \`dev\` this PR's base auto-retargets.

## Summary

Second milestone of the contract verification track. Wires submitted source through @theqrl/hypc, fetches authoritative runtime code via \`qrl_getCode\`, byte-matches, and on match calls M1's \`MarkContractVerified\` to land the verified=true + abi + … fields on the contract document.

## Endpoints

| Method | Path | Purpose |
|---|---|---|
| GET | \`/contract/compiler-info\` | Returns the pinned hypc build. |
| POST | \`/contract/verify\` | Accepts a single-file submission. Validates address, short-circuits on already-verified, rejects duplicate in-flight jobs, creates a \`contractVerifications\` row, returns 202 + jobId. |
| GET | \`/contract/verify/:jobId\` | Returns the job document with current status + on-success ResultRef. |

## Compiler path (decided this PR)

Per the question I asked at the start of M2, we use Option B — the existing @theqrl/hypc WASM via a one-shot Node subprocess (\`backendAPI/verification/runner/hypc-runner.js\`). The Go layer holds all the sandboxing budget (timeout, concurrency cap, stdin-size cap, scrubbed env via \`exec.CommandContext\`). The plan's argument against Node was *"no Node service"* — this is one-shot per request, not a long-running sidecar. Output is deterministic (verified by the M2.0 spike); identical WASM that compiled every on-chain test fixture today.

Future migration to a native \`hypc\` binary built from \`theQRL/hyperion\` is a deploy-script change without touching the Go layer (swap HYPC_RUNNER to point at the native binary entry).

## M2.0 spike findings (locked in)

| Check | Result |
|---|---|
| Compiler ID | \`0.0.2+commit.3e18e55d.Emscripten.clang\` |
| Fresh compile vs on-chain (SimpleERC721) | **exact byte match** — no CBOR metadata trailer |
| Determinism (same source, same settings) | identical |
| Optimizer on vs off | differs (6320 → 3162 bytes) |
| ImmutableReferences on fixture | empty |

So the match algorithm is just: lowercase + strip \`0x\` + mask immutables + \`bytes.Equal\`. No trailer logic. Code is structured so a future build that DOES emit a trailer can drop in a strip pass at the top of \`Match()\`.

## Config

| Var | Required | Default | Purpose |
|---|---|---|---|
| \`HYPC_NODE_BIN\` | n | \`node\` | Path to node binary |
| \`HYPC_RUNNER\` | y | — | Abs path to hypc-runner.js |
| \`HYPC_BUILD_ID\` | y | — | Pinned hypc version. Boot fails if runner reports a different one. |
| \`VERIFIER_MAX_CONCURRENCY\` | n | 2 | In-process concurrent compiles |
| \`VERIFIER_COMPILE_TIMEOUT\` | n | 30s | Per-compile hard deadline |
| \`VERIFIER_SOURCE_MAX_BYTES\` | n | 262144 | Standard-JSON payload cap |

Missing \`HYPC_RUNNER\` / \`HYPC_BUILD_ID\` logs a warning and leaves the routes returning 503 — backend still boots.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] **End-to-end** against deployed \`Qae995c113d75baea40ef345ed016eb300e68c5da\` (Zondscan SimpleERC721): \`POST /contract/verify\` → 202 → poll → success. Mongo confirms \`verified=true\`, full ABI, sourceCode, compilerVersion stamp.
- [x] **Idempotency**: re-submit same address → 200 \`{alreadyVerified: true}\`.
- [x] **Address validation**: bad Q-address → 400.
- [x] **Settings sensitivity**: optimizer:true on contract deployed with optimizer:false → failed with \`bytecode mismatch (compiled=3162 B, on-chain=6320 B, diff@byte=23)\`.
- [x] **Compile error surfacing**: bad source → failed with full ParserError + line marker.

## Out of scope (M3 ships)

- Verify form UI / \`Code | Read | Write\` tabs in ExplorerFrontend
- "Verified" badge on the address + contract pages
- FAQ copy fix
- Multi-file standard-JSON submissions (v1 takes single-file + imports map)
- \`deploy.sh\` / \`update-backend.sh\` provisioning the runner (manual on dev box for now — small follow-up PR to keep this code-only)