### PR TITLE
feat(explorer): M3 — verified badge, Code/Read/Write tabs, verify form

### DIFF
--- a/ExplorerFrontend/app/address/[query]/address-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-view.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect } from 'react';
 import CopyButton from "../../components/CopyButton";
 import QRCodeButton from "../../components/QRCodeButton";
-import ContractBytecode from "../../components/ContractBytecode";
+import ContractTabs from "../../components/ContractTabs";
+import VerifiedBadge from "../../components/VerifiedBadge";
 import TanStackTable from "../../components/TanStackTable";
 import BalanceDisplay from "./balance-display";
 import ActivityDisplay from "./activity-display";
@@ -130,9 +131,12 @@ export default function AddressView({ addressData, addressSegment }: AddressView
                     {contractData && contractData.contractCode && (
                         <div className="mt-4 md:mt-6">
                             <div className="card-simple p-3 md:p-4 lg:p-6 space-y-3 md:space-y-4">
-                                <h3 className="text-base md:text-lg font-semibold text-accent">
-                                    {contractData.isToken ? 'Token Contract' : 'Contract'} Information
-                                </h3>
+                                <div className="flex items-center gap-2 flex-wrap">
+                                    <h3 className="text-base md:text-lg font-semibold text-accent">
+                                        {contractData.isToken ? 'Token Contract' : 'Contract'} Information
+                                    </h3>
+                                    {contractData.verified && <VerifiedBadge />}
+                                </div>
                                 
                                 <div className="space-y-3">
                                     {/* Creator Address */}
@@ -205,8 +209,11 @@ export default function AddressView({ addressData, addressSegment }: AddressView
                                         </div>
                                     </div>
 
-                                    {/* Contract Bytecode */}
-                                    <ContractBytecode contractCode={contractData.contractCode} />
+                                    {/* Contract Code (verified source / ABI / bytecode) +
+                                        Read / Write tabs. Replaces the old standalone bytecode
+                                        block. ContractTabs handles both the unverified state
+                                        (bytecode + Verify & Publish CTA) and the verified state. */}
+                                    <ContractTabs contractData={contractData} />
                                 </div>
                             </div>
                         </div>

--- a/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
@@ -4,7 +4,9 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import CopyButton from "../../components/CopyButton";
 import QRCodeButton from "../../components/QRCodeButton";
-import ContractBytecode from "../../components/ContractBytecode";
+import ContractTabs from "../../components/ContractTabs";
+import VerifiedBadge from "../../components/VerifiedBadge";
+import type { ContractData } from "../../types/address";
 import { formatAmount } from "../../lib/helpers";
 import Breadcrumbs from "../../components/Breadcrumbs";
 
@@ -55,7 +57,10 @@ interface CreationTxData {
 
 interface TokenContractViewProps {
     address: string;
-    contractData: {
+    // Accept the shared ContractData shape so verification fields flow
+    // through to the Code/Read/Write tabs alongside the existing
+    // creator/symbol/decimals metadata.
+    contractData: Partial<ContractData> & {
         creatorAddress?: string;
         creationTransaction?: string;
         contractCode?: string;
@@ -342,11 +347,39 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                             </div>
                         </div>
 
-                        {/* Contract Bytecode */}
+                        {/* Contract Code (verified source / ABI / bytecode) + Read / Write tabs.
+                            Replaces the standalone bytecode block on token pages too — same
+                            behaviour as the address page, just nested inside the Overview tab. */}
                         {contractData.contractCode && (
                             <div>
-                                <h3 className="text-lg font-semibold text-accent mb-4">Bytecode</h3>
-                                <ContractBytecode contractCode={contractData.contractCode} />
+                                <div className="flex items-center gap-2 flex-wrap mb-4">
+                                    <h3 className="text-lg font-semibold text-accent">Contract</h3>
+                                    {contractData.verified && <VerifiedBadge />}
+                                </div>
+                                <ContractTabs
+                                    contractData={{
+                                        creatorAddress: creatorAddress,
+                                        address: address,
+                                        contractCode: contractData.contractCode,
+                                        creationTransaction: contractData.creationTransaction ?? '',
+                                        isToken: contractData.isToken ?? true,
+                                        status: contractData.status ?? '',
+                                        decimals: contractData.decimals ?? 0,
+                                        name: contractData.name ?? '',
+                                        symbol: contractData.symbol ?? '',
+                                        updatedAt: contractData.updatedAt ?? '',
+                                        verified: contractData.verified ?? false,
+                                        sourceCode: contractData.sourceCode,
+                                        abi: contractData.abi,
+                                        contractName: contractData.contractName,
+                                        compilerVersion: contractData.compilerVersion,
+                                        optimizationEnabled: contractData.optimizationEnabled,
+                                        optimizationRuns: contractData.optimizationRuns,
+                                        evmVersion: contractData.evmVersion,
+                                        license: contractData.license,
+                                        verifiedAt: contractData.verifiedAt,
+                                    }}
+                                />
                             </div>
                         )}
 

--- a/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
@@ -357,7 +357,13 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                     {contractData.verified && <VerifiedBadge />}
                                 </div>
                                 <ContractTabs
+                                    // Forward the whole contractData and only override
+                                    // the few required-string fields that ContractData
+                                    // wants non-optional. Avoids hand-listing every
+                                    // optional verification field — adding a new field
+                                    // to ContractData just flows through.
                                     contractData={{
+                                        ...contractData,
                                         creatorAddress: creatorAddress,
                                         address: address,
                                         contractCode: contractData.contractCode,
@@ -369,15 +375,6 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                         symbol: contractData.symbol ?? '',
                                         updatedAt: contractData.updatedAt ?? '',
                                         verified: contractData.verified ?? false,
-                                        sourceCode: contractData.sourceCode,
-                                        abi: contractData.abi,
-                                        contractName: contractData.contractName,
-                                        compilerVersion: contractData.compilerVersion,
-                                        optimizationEnabled: contractData.optimizationEnabled,
-                                        optimizationRuns: contractData.optimizationRuns,
-                                        evmVersion: contractData.evmVersion,
-                                        license: contractData.license,
-                                        verifiedAt: contractData.verifiedAt,
                                     }}
                                 />
                             </div>

--- a/ExplorerFrontend/app/components/ContractTabs.tsx
+++ b/ExplorerFrontend/app/components/ContractTabs.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import CopyButton from './CopyButton';
+import ContractBytecode from './ContractBytecode';
+import type { ContractData } from '../types/address';
+
+interface ContractTabsProps {
+  contractData: ContractData;
+}
+
+type TabKey = 'code' | 'read' | 'write';
+
+/**
+ * Replacement for the old standalone ContractBytecode block on the address
+ * page. Three tabs:
+ *
+ *  - Code  — for verified contracts: source + compiler settings + ABI +
+ *            bytecode (as a sub-section). For unverified: bytecode + a
+ *            "Verify & Publish" CTA linking to /verify-contract.
+ *  - Read  — `view`/`pure` function dispatcher. M4 fills this in.
+ *  - Write — `nonpayable`/`payable` function dispatcher via the QRL Connect
+ *            session. M5 fills this in.
+ *
+ * Read/Write tabs are scaffolds in this PR; their bodies show a
+ * "coming soon" placeholder so the layout is final but the runtime is
+ * deferred.
+ */
+export default function ContractTabs({ contractData }: ContractTabsProps): JSX.Element {
+  const [tab, setTab] = useState<TabKey>('code');
+
+  const parsedAbi = useMemo(() => {
+    if (!contractData.abi) return null;
+    try {
+      return JSON.parse(contractData.abi) as unknown;
+    } catch {
+      return null;
+    }
+  }, [contractData.abi]);
+
+  return (
+    <div>
+      <div role="tablist" aria-label="Contract sections" className="flex gap-1 border-b border-border mb-3 md:mb-4">
+        <TabButton active={tab === 'code'} onClick={() => setTab('code')}>Code</TabButton>
+        <TabButton active={tab === 'read'} onClick={() => setTab('read')}>Read</TabButton>
+        <TabButton active={tab === 'write'} onClick={() => setTab('write')}>Write</TabButton>
+      </div>
+
+      {tab === 'code' && <CodeTab contractData={contractData} parsedAbi={parsedAbi} />}
+      {tab === 'read' && <ComingSoonTab label="Read contract" subhead="View/pure function dispatcher arrives in a follow-up." />}
+      {tab === 'write' && <ComingSoonTab label="Write contract" subhead="State-changing calls via wallet pairing arrive in a follow-up." />}
+    </div>
+  );
+}
+
+function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      type="button"
+      className={`px-3 md:px-4 py-2 text-xs md:text-sm border-b-2 -mb-px transition-colors ${
+        active
+          ? 'border-accent text-accent'
+          : 'border-transparent text-gray-400 hover:text-gray-200'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function CodeTab({ contractData, parsedAbi }: { contractData: ContractData; parsedAbi: unknown | null }) {
+  if (!contractData.verified) {
+    return (
+      <div className="space-y-3 md:space-y-4">
+        <div className="rounded-lg border border-border bg-card-gradient p-3 md:p-4 flex flex-col sm:flex-row gap-2 sm:items-center sm:justify-between">
+          <div>
+            <div className="text-sm md:text-base font-medium text-gray-200">
+              This contract isn&apos;t verified yet
+            </div>
+            <div className="text-xs md:text-sm text-gray-400 mt-0.5">
+              Upload the source to publish the contract&apos;s ABI and source code, enabling read / write interaction.
+            </div>
+          </div>
+          <Link
+            href={`/verify-contract?address=${contractData.address}`}
+            className="inline-flex items-center justify-center px-3 py-1.5 rounded-lg bg-accent text-black text-sm font-medium hover:bg-accent-hover transition-colors"
+          >
+            Verify &amp; Publish
+          </Link>
+        </div>
+        <ContractBytecode contractCode={contractData.contractCode} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 md:space-y-4">
+      <CompilerSettings contractData={contractData} />
+      <SourcePanel contractData={contractData} />
+      <AbiPanel abi={parsedAbi} raw={contractData.abi ?? ''} />
+      <ContractBytecode contractCode={contractData.contractCode} />
+    </div>
+  );
+}
+
+function CompilerSettings({ contractData }: { contractData: ContractData }) {
+  const rows: Array<[string, React.ReactNode]> = [
+    ['Contract name', contractData.contractName ?? '—'],
+    ['Compiler', contractData.compilerVersion ?? '—'],
+    ['Optimizer', contractData.optimizationEnabled ? `enabled (${contractData.optimizationRuns ?? 0} runs)` : 'disabled'],
+    ['EVM version', contractData.evmVersion ?? '—'],
+    ['License', contractData.license ?? '—'],
+    ['Verified at', contractData.verifiedAt ?? '—'],
+  ];
+  return (
+    <div className="rounded-lg border border-border bg-card-gradient p-3 md:p-4 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2 text-xs md:text-sm">
+      {rows.map(([label, value]) => (
+        <div key={label}>
+          <div className="text-gray-400">{label}</div>
+          <div className="text-gray-200 font-mono break-all">{value}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SourcePanel({ contractData }: { contractData: ContractData }) {
+  const [expanded, setExpanded] = useState(true);
+  if (!contractData.sourceCode) return null;
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-xs md:text-sm text-gray-400">Contract source</div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => setExpanded(e => !e)}
+            aria-expanded={expanded}
+            className="inline-flex items-center px-3 py-1.5 rounded-lg bg-card-gradient border border-border hover:border-accent text-sm text-gray-300 hover:text-accent transition-colors"
+          >
+            {expanded ? 'Collapse' : 'Expand'}
+          </button>
+          <CopyButton value={contractData.sourceCode} label="Copy source" />
+        </div>
+      </div>
+      <pre
+        className={`rounded-lg bg-black/40 border border-border p-3 font-mono text-xs text-gray-300 overflow-x-auto whitespace-pre transition-[max-height] duration-200 ${
+          expanded ? 'max-h-[36rem] overflow-y-auto' : 'max-h-24 overflow-hidden'
+        }`}
+      >
+        {contractData.sourceCode}
+      </pre>
+    </div>
+  );
+}
+
+function AbiPanel({ abi, raw }: { abi: unknown | null; raw: string }) {
+  const [expanded, setExpanded] = useState(false);
+  if (!raw) return null;
+  const pretty = useMemo(() => {
+    if (abi === null) return raw;
+    try {
+      return JSON.stringify(abi, null, 2);
+    } catch {
+      return raw;
+    }
+  }, [abi, raw]);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-xs md:text-sm text-gray-400">Contract ABI</div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => setExpanded(e => !e)}
+            aria-expanded={expanded}
+            className="inline-flex items-center px-3 py-1.5 rounded-lg bg-card-gradient border border-border hover:border-accent text-sm text-gray-300 hover:text-accent transition-colors"
+          >
+            {expanded ? 'Collapse' : 'Expand'}
+          </button>
+          <CopyButton value={raw} label="Copy ABI" />
+        </div>
+      </div>
+      <pre
+        className={`rounded-lg bg-black/40 border border-border p-3 font-mono text-xs text-gray-300 overflow-x-auto whitespace-pre transition-[max-height] duration-200 ${
+          expanded ? 'max-h-[24rem] overflow-y-auto' : 'max-h-24 overflow-hidden'
+        }`}
+      >
+        {pretty}
+      </pre>
+    </div>
+  );
+}
+
+function ComingSoonTab({ label, subhead }: { label: string; subhead: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-card-gradient p-6 text-center">
+      <div className="text-sm md:text-base font-medium text-gray-300">{label} — coming soon</div>
+      <div className="text-xs md:text-sm text-gray-400 mt-1">{subhead}</div>
+    </div>
+  );
+}

--- a/ExplorerFrontend/app/components/VerifiedBadge.tsx
+++ b/ExplorerFrontend/app/components/VerifiedBadge.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+interface VerifiedBadgeProps {
+  /** Compact variant fits inside table rows / headers; default sits inline next to titles. */
+  size?: 'sm' | 'md';
+  /** Tooltip / aria text. Defaults to "Source verified". */
+  title?: string;
+}
+
+/**
+ * Small green pill rendered next to verified-contract titles. Visual only —
+ * the parent must already have determined `contractData.verified === true`
+ * before mounting this.
+ */
+export default function VerifiedBadge({ size = 'md', title = 'Source verified' }: VerifiedBadgeProps): JSX.Element {
+  const sizing = size === 'sm' ? 'px-1.5 py-0.5 text-[10px]' : 'px-2 py-0.5 text-xs';
+  return (
+    <span
+      title={title}
+      aria-label={title}
+      className={`inline-flex items-center gap-1 rounded-full border border-green-500/40 bg-green-500/10 text-green-400 font-medium ${sizing}`}
+    >
+      <svg
+        className={size === 'sm' ? 'h-2.5 w-2.5' : 'h-3 w-3'}
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          fillRule="evenodd"
+          d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.707-9.293a1 1 0 1 0-1.414-1.414L9 10.586 7.707 9.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4Z"
+          clipRule="evenodd"
+        />
+      </svg>
+      Verified
+    </span>
+  );
+}

--- a/ExplorerFrontend/app/faq/faq-client.tsx
+++ b/ExplorerFrontend/app/faq/faq-client.tsx
@@ -20,11 +20,11 @@ const faqs = [
   },
   {
     question: "What information can I find about smart contracts?",
-    answer: "Zondscan provides comprehensive information about smart contracts:\n\n1. Contract source code (if verified)\n2. Contract creation transaction\n3. Contract interactions and internal transactions\n4. Contract balance and token holdings\n5. Contract events and logs\n\nVerified contracts also include their ABI and can be interacted with directly through the explorer."
+    answer: "Zondscan provides comprehensive information about smart contracts:\n\n1. Contract source code (if verified) under the Code tab\n2. Contract creation transaction\n3. Contract interactions and internal transactions\n4. Contract balance and token holdings\n5. Contract events and logs\n\nVerified contracts also publish their ABI; Read and Write tabs for direct interaction are rolling out in follow-up milestones."
   },
   {
     question: "How do I verify smart contract source code?",
-    answer: "To verify a smart contract on Zondscan:\n\n1. Navigate to the contract address page\n2. Click on the 'Verify & Publish' button\n3. Upload the original source code\n4. Provide the exact compiler version and optimization settings used\n5. Submit for verification\n\nOnce verified, the contract's source code and interactions become publicly visible on Zondscan."
+    answer: "To verify a smart contract on Zondscan:\n\n1. Navigate to the contract address page and open the Code tab\n2. Click on the 'Verify & Publish' button (or go to /verify-contract directly)\n3. Paste the original source code (and any imports as a JSON map)\n4. Match the exact optimizer settings used at deploy time\n5. Submit — Zondscan re-compiles with the pinned Hyperion build and byte-matches against the on-chain runtime\n\nOnce verified, the contract's source code and ABI become publicly visible on the address page."
   },
   {
     question: "What are the differences between QRL Zond and Ethereum?",

--- a/ExplorerFrontend/app/verify-contract/page.tsx
+++ b/ExplorerFrontend/app/verify-contract/page.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next';
+import { Suspense } from 'react';
+import VerifyContractClient from './verify-contract-client';
+
+export const metadata: Metadata = {
+  title: 'Verify Contract | Zondscan',
+  description: 'Verify and publish a Hyperion smart contract on the QRL Zond network.',
+};
+
+export default function VerifyContractPage(): JSX.Element {
+  return (
+    <div className="mx-auto max-w-3xl px-3 md:px-4 py-4 md:py-8">
+      <div className="card-simple p-3 md:p-4 lg:p-6 space-y-3 md:space-y-4">
+        <div>
+          <h1 className="text-lg md:text-xl lg:text-2xl font-semibold text-accent">Verify smart contract</h1>
+          <p className="text-xs md:text-sm text-gray-400 mt-1">
+            Submit your contract&apos;s source code. The backend re-compiles it with the pinned Hyperion build and byte-matches the result against the on-chain runtime code. On success the source, ABI, and compiler settings are published on the contract&apos;s page.
+          </p>
+        </div>
+        {/* `useSearchParams()` requires a Suspense boundary during static
+            export so the page can pre-render shell HTML without the
+            client-side query string. */}
+        <Suspense fallback={<div className="text-sm text-gray-400">Loading form…</div>}>
+          <VerifyContractClient />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/ExplorerFrontend/app/verify-contract/verify-contract-client.tsx
+++ b/ExplorerFrontend/app/verify-contract/verify-contract-client.tsx
@@ -73,13 +73,17 @@ export default function VerifyContractClient(): JSX.Element {
 
   const isTerminal = job?.status === 'success' || job?.status === 'failed';
 
-  // Poll the job to terminal.
+  // Poll the job to terminal. Depend on the stable jobId (not the whole
+  // job object) so setJob() inside the poller doesn't restart the timer
+  // — without this the effective cadence drifts between 1.5–3s as the
+  // interval re-arms after every response.
+  const jobId = job?.jobId;
   useEffect(() => {
-    if (!job || isTerminal) return;
+    if (!jobId || isTerminal) return;
     let cancelled = false;
     const id = setInterval(async () => {
       try {
-        const r = await axios.get<VerificationJob>(`${config.handlerUrl}/contract/verify/${job.jobId}`);
+        const r = await axios.get<VerificationJob>(`${config.handlerUrl}/contract/verify/${jobId}`);
         if (cancelled) return;
         setJob(r.data);
       } catch (e) {
@@ -88,7 +92,7 @@ export default function VerifyContractClient(): JSX.Element {
       }
     }, 1500);
     return () => { cancelled = true; clearInterval(id); };
-  }, [job, isTerminal]);
+  }, [jobId, isTerminal]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -119,7 +123,10 @@ export default function VerifyContractClient(): JSX.Element {
         sourceCode,
         contractName: contractName.trim(),
         optimizerEnabled,
-        optimizerRuns: Number(optimizerRuns) || 200,
+        // Pass the raw optimizerRuns through — 0 is a legitimate
+        // configuration distinct from the default, so don't fall back
+        // via `|| 200`.
+        optimizerRuns: optimizerRuns,
         evmVersion: evmVersion.trim() || undefined,
         constructorArguments: constructorArgs.trim() || undefined,
         imports,

--- a/ExplorerFrontend/app/verify-contract/verify-contract-client.tsx
+++ b/ExplorerFrontend/app/verify-contract/verify-contract-client.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import type { FormEvent } from 'react';
+import axios, { AxiosError } from 'axios';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import config from '../../config';
+
+interface CompilerInfo {
+  language: string;
+  buildId: string;
+}
+
+interface VerifyEnqueueResponse {
+  jobId: string;
+  status: string;
+  address: string;
+  alreadyVerified?: boolean;
+}
+
+interface VerificationJob {
+  jobId: string;
+  status: 'pending' | 'compiling' | 'success' | 'failed';
+  error?: string;
+  address: string;
+  payload?: {
+    contractName?: string;
+    compilerVersion?: string;
+  };
+}
+
+const COMMON_LICENSES = ['MIT', 'GPL-3.0', 'Apache-2.0', 'BSD-2-Clause', 'BSD-3-Clause', 'Unlicense', 'No license'];
+
+/**
+ * Client-side verify-contract form. Posts to /contract/verify and polls
+ * /contract/verify/:jobId until terminal. Compiler-version selector is
+ * intentionally absent — the backend supports exactly one pinned build
+ * (read-only display).
+ */
+export default function VerifyContractClient(): JSX.Element {
+  const searchParams = useSearchParams();
+  const prefillAddress = searchParams?.get('address') ?? '';
+
+  const [address, setAddress] = useState(prefillAddress);
+  const [contractName, setContractName] = useState('');
+  const [sourceCode, setSourceCode] = useState('');
+  const [importsText, setImportsText] = useState('');
+  const [optimizerEnabled, setOptimizerEnabled] = useState(false);
+  const [optimizerRuns, setOptimizerRuns] = useState(200);
+  const [evmVersion, setEvmVersion] = useState('');
+  const [constructorArgs, setConstructorArgs] = useState('');
+  const [license, setLicense] = useState('MIT');
+
+  const [compilerInfo, setCompilerInfo] = useState<CompilerInfo | null>(null);
+  const [compilerErr, setCompilerErr] = useState<string | null>(null);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [job, setJob] = useState<VerificationJob | null>(null);
+  const [alreadyVerified, setAlreadyVerified] = useState<string | null>(null);
+
+  // Fetch the pinned compiler build once on mount. If the backend doesn't
+  // expose it (503), surface that as a banner — submitting in that state
+  // will just 503 from the backend.
+  useEffect(() => {
+    let cancelled = false;
+    axios.get<CompilerInfo>(`${config.handlerUrl}/contract/compiler-info`)
+      .then(r => { if (!cancelled) setCompilerInfo(r.data); })
+      .catch(e => { if (!cancelled) setCompilerErr(extractAxiosError(e)); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const isTerminal = job?.status === 'success' || job?.status === 'failed';
+
+  // Poll the job to terminal.
+  useEffect(() => {
+    if (!job || isTerminal) return;
+    let cancelled = false;
+    const id = setInterval(async () => {
+      try {
+        const r = await axios.get<VerificationJob>(`${config.handlerUrl}/contract/verify/${job.jobId}`);
+        if (cancelled) return;
+        setJob(r.data);
+      } catch (e) {
+        if (cancelled) return;
+        setJob(j => j ? { ...j, status: 'failed', error: extractAxiosError(e) } : j);
+      }
+    }, 1500);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [job, isTerminal]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitError(null);
+    setAlreadyVerified(null);
+    setJob(null);
+
+    let imports: Record<string, string> | undefined;
+    if (importsText.trim()) {
+      try {
+        const parsed = JSON.parse(importsText) as unknown;
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          imports = parsed as Record<string, string>;
+        } else {
+          setSubmitError('Imports must be a JSON object: { "Filename.hyp": "<source>" }');
+          return;
+        }
+      } catch (e) {
+        setSubmitError('Imports field is not valid JSON: ' + (e instanceof Error ? e.message : String(e)));
+        return;
+      }
+    }
+
+    setSubmitting(true);
+    try {
+      const resp = await axios.post<VerifyEnqueueResponse>(`${config.handlerUrl}/contract/verify`, {
+        address: address.trim(),
+        sourceCode,
+        contractName: contractName.trim(),
+        optimizerEnabled,
+        optimizerRuns: Number(optimizerRuns) || 200,
+        evmVersion: evmVersion.trim() || undefined,
+        constructorArguments: constructorArgs.trim() || undefined,
+        imports,
+        license: license || undefined,
+      });
+      if (resp.data.alreadyVerified) {
+        setAlreadyVerified(resp.data.address);
+      } else {
+        setJob({ jobId: resp.data.jobId, status: 'pending', address: resp.data.address });
+      }
+    } catch (e) {
+      setSubmitError(extractAxiosError(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const compilerBanner = useMemo(() => {
+    if (compilerErr) {
+      return (
+        <div className="rounded-lg border border-red-500/40 bg-red-500/10 text-red-300 text-xs md:text-sm p-3">
+          Verification is not available right now (compiler-info: {compilerErr}).
+        </div>
+      );
+    }
+    if (!compilerInfo) return null;
+    return (
+      <div className="rounded-lg border border-border bg-card-gradient p-3 text-xs md:text-sm text-gray-300">
+        <div className="text-gray-400">Pinned compiler</div>
+        <div className="font-mono break-all">{compilerInfo.language} {compilerInfo.buildId}</div>
+      </div>
+    );
+  }, [compilerErr, compilerInfo]);
+
+  return (
+    <div className="space-y-3 md:space-y-4">
+      {compilerBanner}
+
+      {alreadyVerified && (
+        <div className="rounded-lg border border-green-500/40 bg-green-500/10 text-green-300 text-xs md:text-sm p-3">
+          This contract is already verified.{' '}
+          <Link href={`/address/${alreadyVerified}`} className="underline">Go to address page →</Link>
+        </div>
+      )}
+
+      {job && (
+        <div className={`rounded-lg border p-3 text-xs md:text-sm ${
+          job.status === 'success' ? 'border-green-500/40 bg-green-500/10 text-green-300' :
+          job.status === 'failed' ? 'border-red-500/40 bg-red-500/10 text-red-300' :
+          'border-border bg-card-gradient text-gray-300'
+        }`}>
+          <div className="font-medium">
+            {job.status === 'pending' && 'Queued…'}
+            {job.status === 'compiling' && 'Compiling + matching bytecode…'}
+            {job.status === 'success' && 'Verified ✓'}
+            {job.status === 'failed' && 'Verification failed'}
+          </div>
+          {job.status === 'success' && (
+            <div className="mt-1">
+              <Link href={`/address/${job.address}`} className="underline">View verified contract →</Link>
+            </div>
+          )}
+          {job.error && (
+            <pre className="mt-2 whitespace-pre-wrap break-words font-mono text-[11px] opacity-80">
+              {job.error}
+            </pre>
+          )}
+        </div>
+      )}
+
+      {submitError && (
+        <div className="rounded-lg border border-red-500/40 bg-red-500/10 text-red-300 text-xs md:text-sm p-3">
+          {submitError}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-3 md:space-y-4">
+        <Field label="Contract address (Q…)">
+          <input
+            required
+            value={address}
+            onChange={e => setAddress(e.target.value)}
+            placeholder="Q…"
+            className="form-input font-mono"
+          />
+        </Field>
+
+        <Field label="Contract name" hint="Must match a contract declared in the source.">
+          <input
+            required
+            value={contractName}
+            onChange={e => setContractName(e.target.value)}
+            placeholder="e.g. SimpleERC721"
+            className="form-input"
+          />
+        </Field>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3 md:gap-4">
+          <Field label="Optimizer">
+            <label className="flex items-center gap-2 text-sm text-gray-200">
+              <input
+                type="checkbox"
+                checked={optimizerEnabled}
+                onChange={e => setOptimizerEnabled(e.target.checked)}
+                className="form-checkbox"
+              />
+              Enabled
+            </label>
+          </Field>
+          <Field label="Optimizer runs">
+            <input
+              type="number"
+              min={0}
+              value={optimizerRuns}
+              onChange={e => setOptimizerRuns(Number(e.target.value))}
+              disabled={!optimizerEnabled}
+              className="form-input"
+            />
+          </Field>
+          <Field label="License">
+            <select
+              value={license}
+              onChange={e => setLicense(e.target.value)}
+              className="form-input"
+            >
+              {COMMON_LICENSES.map(l => <option key={l} value={l}>{l}</option>)}
+            </select>
+          </Field>
+        </div>
+
+        <Field label="EVM version (optional)">
+          <input
+            value={evmVersion}
+            onChange={e => setEvmVersion(e.target.value)}
+            placeholder="e.g. shanghai"
+            className="form-input"
+          />
+        </Field>
+
+        <Field label="Source code (single file)" hint="Submit the contract source as a single .hyp file. Multi-file imports go in the Imports field below.">
+          <textarea
+            required
+            value={sourceCode}
+            onChange={e => setSourceCode(e.target.value)}
+            rows={14}
+            placeholder="// SPDX-License-Identifier: MIT&#10;pragma hyperion ^0.0.2;&#10;contract MyContract { … }"
+            className="form-input font-mono text-xs"
+          />
+        </Field>
+
+        <Field
+          label="Imports (optional)"
+          hint='JSON object mapping import paths → source contents. Example: {"Context.hyp": "...source..."}'
+        >
+          <textarea
+            value={importsText}
+            onChange={e => setImportsText(e.target.value)}
+            rows={6}
+            placeholder='{"Context.hyp": "// SPDX-License-Identifier: MIT&#10;pragma hyperion ^0.0.2;&#10;abstract contract Context { … }"}'
+            className="form-input font-mono text-xs"
+          />
+        </Field>
+
+        <Field label="Constructor arguments (optional)" hint="Hex-encoded ABI tuple. Advisory — not used for the byte-match check.">
+          <input
+            value={constructorArgs}
+            onChange={e => setConstructorArgs(e.target.value)}
+            placeholder="0x…"
+            className="form-input font-mono text-xs"
+          />
+        </Field>
+
+        <button
+          type="submit"
+          disabled={submitting || (job?.status === 'pending' || job?.status === 'compiling')}
+          className="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-accent text-black text-sm font-medium hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {submitting ? 'Submitting…' : 'Verify & Publish'}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-xs md:text-sm text-gray-400 mb-1">{label}</div>
+      {children}
+      {hint && <div className="text-[11px] text-gray-500 mt-1">{hint}</div>}
+    </div>
+  );
+}
+
+function extractAxiosError(e: unknown): string {
+  if (e instanceof AxiosError) {
+    const d = e.response?.data as { error?: string; message?: string } | undefined;
+    return d?.error || d?.message || e.message;
+  }
+  return e instanceof Error ? e.message : String(e);
+}


### PR DESCRIPTION
Third milestone of the contract-verification track. Pure-UI PR — surfaces M1's data shape and M2's /contract/verify endpoint in the explorer. M4 (Read) and M5 (Write) inherit the tab scaffold left here.

## What lands

### New components
- **\`VerifiedBadge.tsx\`** — small green pill rendered next to the Contract Information heading on the address and token-contract pages when \`contractData.verified === true\`.
- **\`ContractTabs.tsx\`** — three tabs (Code | Read | Write) replacing the old standalone bytecode block on contract pages.
  - **Code tab (verified)**: compiler settings panel + collapsible source + collapsible ABI + bytecode as a sub-section.
  - **Code tab (unverified)**: \"Verify & Publish\" CTA linking to \`/verify-contract?address=<addr>\` + the existing bytecode block — worst case is no worse than today.
  - **Read / Write tabs**: \"coming soon\" placeholders. Layout is final; runtime lands in M4/M5.

### New route
- **\`/verify-contract\`** — public verify form following \`BalanceCheckTool.tsx\` conventions (axios + loading/error state).
  - Address prefills from \`?address=\` when arriving from the Code-tab CTA.
  - Compiler-info banner fetched once on mount from \`/contract/compiler-info\`. **No version selector** — the backend pins a single build, so it's display-only.
  - Optimizer toggle + runs, EVM version, license dropdown, single-file source textarea, optional JSON-map imports field for multi-file contracts.
  - Submit → \`POST /contract/verify\` → polls \`GET /contract/verify/:jobId\` every 1.5s until terminal. Surfaces \`alreadyVerified=true\` shortcut, success with a link back to the verified address page, and failure with the full ParserError / bytecode-diff message.

### Integration
- \`address-view.tsx\` — badge next to Contract Information; \`<ContractTabs/>\` replaces the standalone bytecode block.
- \`token-contract-view.tsx\` — same; local \`contractData\` interface widened to \`Partial<ContractData>\` so M1's verification fields flow through.

### Copy
- \`faq-client.tsx\` — replaced the old \"can be interacted with directly\" claim with the actually shipped workflow (Code tab, ABI publish, Read/Write tabs landing later).

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`SKIP_DAPP_EXAMPLE=1 npm run build\` clean — \`/verify-contract\` pre-renders as a static page (useSearchParams wrapped in Suspense so the static export works)
- [x] Backend running locally — confirmed \`GET /contract/compiler-info\` responds and \`GET /address/aggregate/<verified Q…>\` surfaces the full verification block (verified / abi / sourceCode / compilerVersion / optimizer + runs / license / verifiedAt) so ContractTabs has data to render.

## Out of scope (M4 / M5)

- Read tab body — view/pure function dispatcher (M4).
- Write tab body — \`@qrlwallet/connect\` pairing + nonpayable/payable functions (M5).
- Multi-file standard-JSON submissions in the form (single-file + imports map is the v1 surface).

## Note on dev backend

The verify form needs the \`/contract/*\` endpoints live. On the dev backend those only activate once \`HYPC_RUNNER\` + \`HYPC_BUILD_ID\` env vars are set and \`node\` is on PATH; without them the routes return 503 and the form's compiler-info banner falls back to an error. Provisioning the runner on the dev box is a one-off ops change (manual \`npm install\` in \`backendAPI/verification/runner/\` + env vars), tracked as a separate small follow-up.