### PR TITLE
feat(contracts): M4 — read contract (NodeRPC + /contract/call + Read tab)

### DIFF
--- a/ExplorerFrontend/app/components/ContractTabs.tsx
+++ b/ExplorerFrontend/app/components/ContractTabs.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import CopyButton from './CopyButton';
 import ContractBytecode from './ContractBytecode';
+import ReadContract from './ReadContract';
 import type { ContractData } from '../types/address';
 
 interface ContractTabsProps {
@@ -48,7 +49,7 @@ export default function ContractTabs({ contractData }: ContractTabsProps): JSX.E
       </div>
 
       {tab === 'code' && <CodeTab contractData={contractData} parsedAbi={parsedAbi} />}
-      {tab === 'read' && <ComingSoonTab label="Read contract" subhead="View/pure function dispatcher arrives in a follow-up." />}
+      {tab === 'read' && <ReadContract contractData={contractData} />}
       {tab === 'write' && <ComingSoonTab label="Write contract" subhead="State-changing calls via wallet pairing arrive in a follow-up." />}
     </div>
   );

--- a/ExplorerFrontend/app/components/ReadContract.tsx
+++ b/ExplorerFrontend/app/components/ReadContract.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import axios, { AxiosError } from 'axios';
+import * as zondAbi from '@theqrl/web3-zond-abi';
+import type { ContractData } from '../types/address';
+import config from '../../config';
+
+interface AbiInput {
+  name: string;
+  type: string;
+  components?: AbiInput[];
+}
+
+interface AbiFunction {
+  type: 'function';
+  name: string;
+  stateMutability: 'view' | 'pure' | 'nonpayable' | 'payable';
+  inputs: AbiInput[];
+  outputs?: { name: string; type: string }[];
+}
+
+interface ReadContractProps {
+  contractData: ContractData;
+}
+
+/**
+ * Renders one collapsible card per view/pure ABI function. Each card has
+ * inputs for the function's parameters, a Call button, and a result area
+ * that decodes the bytes returned by the backend's /contract/call proxy.
+ *
+ * ABI encode + decode runs entirely client-side via @theqrl/web3-zond-abi
+ * — the backend never sees decoded values, it just forwards the hex
+ * calldata to the node and returns hex.
+ */
+export default function ReadContract({ contractData }: ReadContractProps): JSX.Element {
+  const readFns = useMemo(() => {
+    if (!contractData.verified || !contractData.abi) return [] as AbiFunction[];
+    try {
+      const parsed = JSON.parse(contractData.abi) as AbiFunction[];
+      return parsed.filter(
+        f => f.type === 'function' && (f.stateMutability === 'view' || f.stateMutability === 'pure'),
+      );
+    } catch {
+      return [] as AbiFunction[];
+    }
+  }, [contractData.abi, contractData.verified]);
+
+  if (!contractData.verified) {
+    return (
+      <div className="rounded-lg border border-border bg-card-gradient p-4 text-sm text-gray-300">
+        Verify this contract first to enable Read interactions.
+      </div>
+    );
+  }
+  if (readFns.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-card-gradient p-4 text-sm text-gray-300">
+        This contract has no view/pure functions to read.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-2 md:space-y-3">
+      {readFns.map((fn, idx) => (
+        <ReadFunctionCard
+          key={`${fn.name}-${idx}-${fn.inputs.map(i => i.type).join(',')}`}
+          fn={fn}
+          address={contractData.address}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ReadFunctionCard({ fn, address }: { fn: AbiFunction; address: string }) {
+  const [values, setValues] = useState<string[]>(() => fn.inputs.map(() => ''));
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reverted, setReverted] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const setVal = (i: number, v: string) =>
+    setValues(cur => cur.map((x, j) => (j === i ? v : x)));
+
+  const onCall = async () => {
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    setReverted(false);
+    try {
+      const args = fn.inputs.map((input, i) => parseArg(values[i] ?? '', input.type));
+      const data = zondAbi.encodeFunctionCall(fn as never, args as never[]);
+
+      const resp = await axios.post<{ result?: string; error?: string; reverted?: boolean }>(
+        `${config.handlerUrl}/contract/call`,
+        { to: address, data },
+      );
+
+      if (resp.data.error) {
+        setError(resp.data.error);
+        setReverted(Boolean(resp.data.reverted));
+        return;
+      }
+      if (!resp.data.result) {
+        setError('No result returned by node');
+        return;
+      }
+      const outTypes = (fn.outputs ?? []).map(o => o.type);
+      if (outTypes.length === 0) {
+        setResult('(void)');
+        return;
+      }
+      const decoded = zondAbi.decodeParameters(outTypes as never[], resp.data.result);
+      setResult(formatDecoded(decoded, fn.outputs ?? []));
+    } catch (e) {
+      const ae = e as AxiosError;
+      const msg = (ae.response?.data as { error?: string } | undefined)?.error
+        ?? (e instanceof Error ? e.message : String(e));
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const sig = `${fn.name}(${fn.inputs.map(i => `${i.type}${i.name ? ' ' + i.name : ''}`).join(', ')})`;
+
+  return (
+    <div className="rounded-lg border border-border bg-card-gradient">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+        className="w-full flex items-center justify-between gap-2 px-3 py-2 text-left"
+      >
+        <span className="font-mono text-xs md:text-sm text-gray-200 break-all">{sig}</span>
+        <span className="text-xs text-gray-500">{open ? '–' : '+'}</span>
+      </button>
+      {open && (
+        <div className="border-t border-border p-3 space-y-3">
+          {fn.inputs.map((input, i) => (
+            <div key={i}>
+              <div className="text-xs text-gray-400 mb-1">
+                {input.name ? `${input.name} ` : ''}
+                <span className="font-mono text-gray-500">({input.type})</span>
+              </div>
+              <input
+                value={values[i] ?? ''}
+                onChange={e => setVal(i, e.target.value)}
+                placeholder={placeholderFor(input.type)}
+                className="form-input font-mono text-xs"
+              />
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={onCall}
+            disabled={loading}
+            className="inline-flex items-center justify-center px-3 py-1.5 rounded-lg bg-accent text-black text-xs font-medium hover:bg-accent-hover transition-colors disabled:opacity-50"
+          >
+            {loading ? 'Calling…' : 'Call'}
+          </button>
+
+          {error && (
+            <div className={`rounded-md border p-2 text-xs ${
+              reverted
+                ? 'border-orange-500/40 bg-orange-500/10 text-orange-300'
+                : 'border-red-500/40 bg-red-500/10 text-red-300'
+            }`}>
+              {reverted ? 'execution reverted: ' : ''}{error}
+            </div>
+          )}
+
+          {result !== null && !error && (
+            <pre className="rounded-md bg-black/40 border border-border p-3 font-mono text-xs text-gray-300 whitespace-pre-wrap break-words">
+              {result}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// parseArg converts a user-typed string into the right JS shape for
+// @theqrl/web3-zond-abi.encodeFunctionCall. Keep this minimal — anything
+// fancy (tuples, fixed arrays) the user can express as JSON.
+function parseArg(raw: string, type: string): unknown {
+  const t = raw.trim();
+  if (t === '') {
+    if (type === 'bool') return false;
+    if (type.startsWith('uint') || type.startsWith('int')) return '0';
+    return '';
+  }
+  if (type === 'bool') return t === 'true' || t === '1';
+  if (type.endsWith(']') || type === 'tuple') {
+    try { return JSON.parse(t); } catch {
+      throw new Error(`expected JSON for ${type}: e.g. [1,2,3]`);
+    }
+  }
+  if (type.startsWith('uint') || type.startsWith('int')) {
+    // Hand string through — web3-zond-abi accepts strings for big ints.
+    return t;
+  }
+  return t;
+}
+
+function placeholderFor(type: string): string {
+  if (type === 'address') return 'Q…';
+  if (type === 'bool') return 'true / false';
+  if (type.startsWith('uint') || type.startsWith('int')) return '0';
+  if (type === 'string') return 'text';
+  if (type.startsWith('bytes')) return '0x…';
+  if (type.endsWith(']') || type === 'tuple') return 'JSON: [1,2,3]';
+  return '';
+}
+
+// formatDecoded renders @theqrl/web3-zond-abi.decodeParameters output for
+// human consumption. The Result object carries both `0,1,…` index keys
+// and any named keys, plus a `__length__`. We flatten to a stable shape,
+// and Q-normalise any address-typed value because the 0.3.x ABI decoder
+// emits the legacy Z prefix that nothing else in zondscan uses.
+function formatDecoded(decoded: unknown, outputs: { name: string; type: string }[]): string {
+  const out: Record<string, unknown> = {};
+  outputs.forEach((o, i) => {
+    const v = (decoded as Record<string, unknown>)[String(i)];
+    out[o.name && o.name !== '' ? o.name : `_${i}`] = qNormalise(v, o.type);
+  });
+  return JSON.stringify(out, replacer, 2);
+}
+
+function qNormalise(v: unknown, type: string): unknown {
+  if (type === 'address' && typeof v === 'string' && /^Z[0-9a-fA-F]{40}$/.test(v)) {
+    return 'Q' + v.slice(1);
+  }
+  if (type.startsWith('address[') && Array.isArray(v)) {
+    return v.map(x => qNormalise(x, 'address'));
+  }
+  return v;
+}
+
+function replacer(_k: string, v: unknown): unknown {
+  return typeof v === 'bigint' ? v.toString() : v;
+}

--- a/ExplorerFrontend/app/components/ReadContract.tsx
+++ b/ExplorerFrontend/app/components/ReadContract.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import axios, { AxiosError } from 'axios';
 import * as zondAbi from '@theqrl/web3-zond-abi';
 import type { ContractData } from '../types/address';
+import { qNormaliseAbiValue } from '../lib/helpers';
 import config from '../../config';
 
 interface AbiInput {
@@ -193,7 +194,7 @@ function parseArg(raw: string, type: string): unknown {
     if (type.startsWith('uint') || type.startsWith('int')) return '0';
     return '';
   }
-  if (type === 'bool') return t === 'true' || t === '1';
+  if (type === 'bool') return t.toLowerCase() === 'true' || t === '1';
   if (type.endsWith(']') || type === 'tuple') {
     try { return JSON.parse(t); } catch {
       throw new Error(`expected JSON for ${type}: e.g. [1,2,3]`);
@@ -219,25 +220,16 @@ function placeholderFor(type: string): string {
 // formatDecoded renders @theqrl/web3-zond-abi.decodeParameters output for
 // human consumption. The Result object carries both `0,1,…` index keys
 // and any named keys, plus a `__length__`. We flatten to a stable shape,
-// and Q-normalise any address-typed value because the 0.3.x ABI decoder
-// emits the legacy Z prefix that nothing else in zondscan uses.
+// and qNormaliseAbiValue (in app/lib/helpers.ts) maps any address-typed
+// value from the legacy Z prefix the 0.3.x decoder emits to the canonical
+// Q prefix the rest of zondscan uses.
 function formatDecoded(decoded: unknown, outputs: { name: string; type: string }[]): string {
   const out: Record<string, unknown> = {};
   outputs.forEach((o, i) => {
     const v = (decoded as Record<string, unknown>)[String(i)];
-    out[o.name && o.name !== '' ? o.name : `_${i}`] = qNormalise(v, o.type);
+    out[o.name && o.name !== '' ? o.name : `_${i}`] = qNormaliseAbiValue(v, o.type);
   });
   return JSON.stringify(out, replacer, 2);
-}
-
-function qNormalise(v: unknown, type: string): unknown {
-  if (type === 'address' && typeof v === 'string' && /^Z[0-9a-fA-F]{40}$/.test(v)) {
-    return 'Q' + v.slice(1);
-  }
-  if (type.startsWith('address[') && Array.isArray(v)) {
-    return v.map(x => qNormalise(x, 'address'));
-  }
-  return v;
 }
 
 function replacer(_k: string, v: unknown): unknown {

--- a/ExplorerFrontend/app/lib/helpers.ts
+++ b/ExplorerFrontend/app/lib/helpers.ts
@@ -467,3 +467,23 @@ export function formatTokenAmount(amount: string | undefined | null, decimals: n
     return amount;
   }
 }
+
+/**
+ * Normalise an ABI-decoded value tree to use the canonical Q-prefix for
+ * QRL v2 addresses. The 0.3.x @theqrl/web3-zond-abi decoder still emits
+ * the legacy Z prefix for `address` outputs; every other surface in
+ * zondscan uses Q. Mutually recursive on array types so nested shapes
+ * like `address[][]` flatten correctly.
+ */
+export function qNormaliseAbiValue(v: unknown, type: string): unknown {
+  if (type === 'address' && typeof v === 'string' && /^Z[0-9a-fA-F]{40}$/.test(v)) {
+    return 'Q' + v.slice(1);
+  }
+  // Strip the last `[N]` or `[]` dimension and recurse so nested array
+  // types (e.g. `address[][]`) get fully unwound.
+  if (/\[\d*\]$/.test(type) && Array.isArray(v)) {
+    const innerType = type.replace(/\[\d*\]$/, '');
+    return v.map(x => qNormaliseAbiValue(x, innerType));
+  }
+  return v;
+}

--- a/backendAPI/db/address.go
+++ b/backendAPI/db/address.go
@@ -3,15 +3,11 @@ package db
 import (
 	"backendAPI/configs"
 	"backendAPI/models"
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"math/big"
-	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -119,8 +115,6 @@ func ReturnRankAddress(address string) (int64, error) {
 }
 
 func GetBalance(address string) (float64, string) {
-	var result models.Balance
-
 	// Ensure address has Q prefix for RPC calls
 	rpcAddress := address
 	if strings.HasPrefix(rpcAddress, "0x") {
@@ -129,64 +123,39 @@ func GetBalance(address string) (float64, string) {
 		rpcAddress = "Q" + rpcAddress
 	}
 
-	group := models.JsonRPC{
-		Jsonrpc: "2.0",
-		Method:  "qrl_getBalance",
-		Params:  []interface{}{rpcAddress, "latest"},
-		ID:      1,
-	}
-	b, err := json.Marshal(group)
-	if err != nil {
-		log.Printf("error marshaling RPC request: %v", err)
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
-	nodeURL := os.Getenv("NODE_URL")
-	if nodeURL == "" {
-		nodeURL = "http://127.0.0.1:8545" // fallback to default if not set
-	}
-
-	req, err := http.NewRequest("POST", nodeURL, bytes.NewBuffer(b))
+	raw, rpcErr, err := NodeRPC(ctx, "qrl_getBalance", []interface{}{rpcAddress, "latest"})
 	if err != nil {
-		log.Printf("error creating balance request: %v", err)
+		log.Printf("GetBalance(%s): %v", address, err)
 		return 0, "Error connecting to node"
 	}
-	req.Header.Set("Content-Type", "application/json")
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		log.Printf("error making balance request: %v", err)
-		return 0, "Error connecting to node"
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Printf("error reading balance response: %v", err)
-		return 0, "Error reading node response"
+	if rpcErr != nil {
+		return 0, rpcErr.Message
 	}
 
-	err = json.Unmarshal(body, &result)
-	if err != nil {
-		log.Printf("error unmarshaling balance response: %v", err)
+	var hexResult string
+	if err := json.Unmarshal(raw, &hexResult); err != nil {
+		log.Printf("GetBalance(%s): unmarshal result: %v", address, err)
+		return 0, "Error parsing node response"
+	}
+	if len(hexResult) < 3 || !strings.HasPrefix(hexResult, "0x") {
+		log.Printf("GetBalance(%s): unexpected balance shape %q", address, hexResult)
 		return 0, "Error parsing node response"
 	}
 
-	if result.Error.Message != "" {
-		return 0, result.Error.Message
-	} else {
-		balance := new(big.Int)
-		balance, success := balance.SetString(result.Result[2:], 16)
-		if !success {
-			log.Printf("error converting hex balance to big.Int for address %s", address)
-		}
-
-		balanceFloat := new(big.Float).SetInt(balance)
-		divisor := new(big.Float).SetFloat64(1e18)
-		result := new(big.Float).Quo(balanceFloat, divisor)
-		float64Value, _ := result.Float64()
-		return float64Value, ""
+	balance := new(big.Int)
+	balance, success := balance.SetString(hexResult[2:], 16)
+	if !success {
+		log.Printf("error converting hex balance to big.Int for address %s", address)
 	}
+
+	balanceFloat := new(big.Float).SetInt(balance)
+	divisor := new(big.Float).SetFloat64(1e18)
+	res := new(big.Float).Quo(balanceFloat, divisor)
+	float64Value, _ := res.Float64()
+	return float64Value, ""
 }
 
 func ReturnWalletDistribution(query uint64) (int64, error) {

--- a/backendAPI/db/rpc.go
+++ b/backendAPI/db/rpc.go
@@ -1,0 +1,105 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"backendAPI/models"
+)
+
+// RPCError is a JSON-RPC error payload as returned by the QRL execution
+// node. Surfaced as a distinct return value (rather than wrapped in a
+// Go error) so callers can distinguish between transport failures and
+// node-level errors (e.g. "execution reverted") that may carry useful
+// metadata for the client.
+type RPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+func (e *RPCError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("rpc error %d: %s", e.Code, e.Message)
+}
+
+// Default upstream HTTP client tuned for short-lived JSON-RPC calls.
+// Pulled to package-level so every call shares the connection pool
+// (keep-alive saves a TCP+TLS handshake per request).
+var nodeRPCClient = &http.Client{Timeout: 12 * time.Second}
+
+// NodeRPC issues a single JSON-RPC request to the configured node and
+// returns the raw `result` field. Callers unmarshal `result` into whatever
+// shape the method emits (string, hex, object, …).
+//
+// `ctx` controls cancellation/timeout in addition to the client's own
+// 12s default — callers with per-call budgets shorter than that should
+// pass a derived context.
+//
+// Returns:
+//
+//	(result, nil, nil)         on success
+//	(nil, rpcErr, nil)         when the node returned a JSON-RPC error
+//	(nil, nil, transportErr)   on network / marshalling failure
+//
+// `result` is `nil` only on error.
+func NodeRPC(ctx context.Context, method string, params []interface{}) (json.RawMessage, *RPCError, error) {
+	nodeURL := os.Getenv("NODE_URL")
+	if nodeURL == "" {
+		nodeURL = "http://127.0.0.1:8545"
+	}
+
+	body, err := json.Marshal(models.JsonRPC{
+		Jsonrpc: "2.0",
+		Method:  method,
+		Params:  params,
+		ID:      1,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal rpc body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, nodeURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, nil, fmt.Errorf("build rpc request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := nodeRPCClient.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("rpc transport: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("rpc transport: HTTP %d", resp.StatusCode)
+	}
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("rpc read body: %w", err)
+	}
+
+	var parsed struct {
+		Result json.RawMessage `json:"result"`
+		Error  *RPCError       `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, nil, fmt.Errorf("rpc decode envelope: %w", err)
+	}
+	if parsed.Error != nil {
+		return nil, parsed.Error, nil
+	}
+	if len(parsed.Result) == 0 {
+		return nil, nil, errors.New("rpc envelope: missing result")
+	}
+	return parsed.Result, nil, nil
+}

--- a/backendAPI/routes/contract_call_route.go
+++ b/backendAPI/routes/contract_call_route.go
@@ -1,0 +1,154 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"backendAPI/db"
+	"backendAPI/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+// contract-call gas cap. The node treats this as "if your call gas-uses
+// more than X, fail" — a hard ceiling against pathological reads that
+// would tie up the node. 50M is comfortably above any real read flow.
+const contractCallGasCap = uint64(50_000_000)
+
+// Maximum size of the hex `data` field. Generous enough for any realistic
+// ABI-encoded calldata (a function selector + tens of dynamic args), but
+// small enough that abuse is bounded.
+const contractCallMaxDataBytes = 8 * 1024 // 8 KiB raw hex = ~4 KiB decoded
+
+// RegisterContractCallRoute wires POST /contract/call. Distinct file from
+// verification_routes.go to keep the M4 surface obviously separable from
+// the verifier surface for review purposes.
+//
+// The route is effectively a typed `eth_call` proxy: the same network
+// primitive Etherscan uses to back its "Read Contract" tab. Open-ended
+// reads of view/pure functions are read-only and have no on-chain side
+// effects, but the proxy must still cap (a) the request rate per IP, (b)
+// the data payload size, (c) the gas cap, and (d) the per-call timeout —
+// all together, those bound how much node work an attacker can elicit.
+func RegisterContractCallRoute(router *gin.Engine) {
+	// 60 calls/min/IP — generous for a Read tab where each click on a view
+	// function fires one call. The token bucket bursts at 60 too.
+	callLimiter := middleware.PerIPRateLimit(60, 60, time.Minute)
+
+	router.POST("/contract/call", callLimiter, func(c *gin.Context) {
+		// Cap the request body so a malicious huge payload can't tie up
+		// the JSON decoder before our size checks kick in.
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, 32*1024) // 32 KiB
+
+		var req struct {
+			To   string `json:"to" binding:"required"`
+			Data string `json:"data" binding:"required"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body: " + err.Error()})
+			return
+		}
+
+		req.To = strings.TrimSpace(req.To)
+		req.Data = strings.ToLower(strings.TrimSpace(req.Data))
+
+		if !isValidAddress(req.To) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid Q-prefixed `to` address"})
+			return
+		}
+		if !isValidHex(req.Data) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "`data` must be hex (0x…) with even length"})
+			return
+		}
+		if len(req.Data) > contractCallMaxDataBytes {
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "`data` exceeds size cap", "max": contractCallMaxDataBytes})
+			return
+		}
+
+		// Refuse to proxy reads of addresses that haven't been observed as
+		// contracts. This is the only gate stopping the endpoint from
+		// being a free open eth_call: querying arbitrary node state via a
+		// non-contract `to` would still work but offers no useful surface
+		// to an attacker (returns 0x). Keeping it scoped to known contracts
+		// also lets us bound the audit story.
+		known, err := db.ReturnContractCode(req.To)
+		if err != nil || known.ContractAddress == "" {
+			c.JSON(http.StatusNotFound, gin.H{"error": "address is not a known contract"})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 8*time.Second)
+		defer cancel()
+
+		callObj := map[string]interface{}{
+			"to":   req.To,
+			"data": req.Data,
+			// Pinned gas cap. The node may impose its own ceiling too;
+			// having ours guarantees we never relay an uncapped read.
+			"gas": uintToHex(contractCallGasCap),
+		}
+
+		raw, rpcErr, err := db.NodeRPC(ctx, "qrl_call", []interface{}{callObj, "latest"})
+		if err != nil {
+			c.JSON(http.StatusBadGateway, gin.H{"error": "node call failed: " + err.Error()})
+			return
+		}
+		if rpcErr != nil {
+			// Surface the upstream error verbatim — "execution reverted"
+			// is the most common case and clients (Read tab) display it.
+			c.JSON(http.StatusOK, gin.H{
+				"error":   rpcErr.Message,
+				"code":    rpcErr.Code,
+				"data":    rpcErr.Data,
+				"reverted": true,
+			})
+			return
+		}
+
+		var result string
+		if err := json.Unmarshal(raw, &result); err != nil {
+			c.JSON(http.StatusBadGateway, gin.H{"error": "could not decode node response"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"result": result})
+	})
+}
+
+// isValidHex returns true for "0x"-prefixed even-length strings of hex
+// digits. Empty payloads (0x by itself) are allowed since some view
+// functions take no arguments and call data is just the 4-byte selector.
+func isValidHex(s string) bool {
+	if !strings.HasPrefix(s, "0x") {
+		return false
+	}
+	hex := s[2:]
+	if len(hex)%2 != 0 {
+		return false
+	}
+	for _, r := range hex {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+// uintToHex formats a uint64 as an 0x-prefixed hex string (no leading
+// zeros, lowercase). Used for the `gas` field in the qrl_call params.
+func uintToHex(n uint64) string {
+	if n == 0 {
+		return "0x0"
+	}
+	const hexDigits = "0123456789abcdef"
+	var buf [16]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = hexDigits[n&0xf]
+		n >>= 4
+	}
+	return "0x" + string(buf[i:])
+}

--- a/backendAPI/routes/contract_call_route.go
+++ b/backendAPI/routes/contract_call_route.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -75,6 +76,11 @@ func RegisterContractCallRoute(router *gin.Engine) {
 		// to an attacker (returns 0x). Keeping it scoped to known contracts
 		// also lets us bound the audit story.
 		known, err := db.ReturnContractCode(req.To)
+		if err != nil {
+			// Log unexpected database failures so they don't silently
+			// hide behind the public 404 response.
+			log.Printf("contract_call: ReturnContractCode(%s) failed: %v", req.To, err)
+		}
 		if err != nil || known.ContractAddress == "" {
 			c.JSON(http.StatusNotFound, gin.H{"error": "address is not a known contract"})
 			return

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -62,6 +62,11 @@ func UserRoute(router *gin.Engine) {
 	// so this is safe to wire unconditionally.
 	RegisterVerificationRoutes(router)
 
+	// Contract-read endpoint (POST /contract/call). Open eth_call proxy
+	// scoped to known contract addresses, with rate-limit + size-cap +
+	// gas-cap + per-call timeout.
+	RegisterContractCallRoute(router)
+
 	// Add pending transactions endpoint with pagination
 	router.GET("/pending-transactions", func(c *gin.Context) {
 		page, limit := getPaginationParams(c, 1, 10)


### PR DESCRIPTION
Stacked on M3 (#75). Please review/merge #75 first; this PR's base auto-retargets to \`dev\` once that lands.

Fourth milestone of the contract verification track. M3 made the Code tab usable; this PR makes the **Read** tab work by wiring view/pure ABI functions through a typed \`eth_call\` proxy.

## Backend

### \`backendAPI/db/rpc.go\` — \`NodeRPC()\` helper

The generalised JSON-RPC helper the plan called for.

\`\`\`go
NodeRPC(ctx, method, params) (json.RawMessage, *RPCError, error)
\`\`\`

Distinguishes transport failures from upstream node errors (e.g. \"execution reverted\") so callers like the Read tab can surface revert reasons cleanly. Reuses \`models.JsonRPC\` and a package-level \`http.Client\` so every call shares the connection pool.

### \`backendAPI/db/address.go\` GetBalance refactor

Dropped the ~40 lines of inline \`http.NewRequest\` boilerplate that lived in \`GetBalance\`; refactored to call \`NodeRPC\`. Behaviour preserved (verified via \`/getBalance\` still returning 12.37 QRL for the deployer).

### \`POST /contract/call\`

Effectively a typed \`eth_call\` proxy:

| Concern | Cap |
|---|---|
| Per-IP rate limit | 60 calls/min |
| Request body | 32 KiB (\`MaxBytesReader\`) |
| \`data\` hex | 8 KiB |
| Gas cap | 50M |
| Per-call deadline | 8 s |
| Address validity | \`to\` must exist in the contracts collection (else 404) |

\`data\` must be \`0x\`-prefixed, even-length hex (selector + ABI-encoded args). On node-level errors the response is \`{ error, code, reverted: true }\` so the Read tab can show \"execution reverted\" inline.

## Frontend

### \`ReadContract.tsx\`

One collapsible card per view/pure ABI function. Inputs accept user-typed values, \`parseArg\` coerces to the right shape (string for big ints, JSON for tuples/arrays, \"true\"/\"false\" for bools), encodes via \`@theqrl/web3-zond-abi.encodeFunctionCall\`, POSTs to \`/contract/call\`, decodes via \`decodeParameters\`, and renders the result. **Z-prefix → Q-prefix normalisation** on address-typed outputs (the 0.3.x decoder still emits the legacy Z prefix; everything else in zondscan uses Q).

### \`ContractTabs.tsx\`

Read tab swapped from M3's \`ComingSoonTab\` to \`<ReadContract>\`. Write tab stays a placeholder until M5.

## Validation

Live full-stack test (mongo + syncer + backend + Next.js built+running) against the verified contract \`Q830f30ace20b9d3658a74f8cb1195054791c8871\`:

- [x] \`/getBalance\` → 12.37 QRL (NodeRPC refactor still works)
- [x] \`POST /contract/call\` \`name()\` → ABI-decodes to \"IPFS Proxy Test\"
- [x] \`POST /contract/call\` \`owner()\` → Z→Q normalised to \`Q6153d3…\`
- [x] \`POST /contract/call\` \`tokenURI(1)\` → \`https://dev.qrlwallet.com/nft-test/ipfs-test-1.json\`
- [x] Bad address → 400
- [x] Unknown contract → 404
- [x] \`npx tsc --noEmit\` clean; \`SKIP_DAPP_EXAMPLE=1 npm run build\` clean

## Out of scope (M5)

- Write tab — state-changing \`safeTransferFrom\` / \`approve\` / etc. via the \`@qrlwallet/connect\` SDK paired with the wallet (M5).