### PR TITLE
M5: Write contract via @qrlwallet/connect pairing

### DIFF
--- a/ExplorerFrontend/app/block/[query]/block-detail-client.tsx
+++ b/ExplorerFrontend/app/block/[query]/block-detail-client.tsx
@@ -87,30 +87,38 @@ const formatTimestampUTC = (timestamp: string | null | undefined): string => {
 };
 
 export default function BlockDetailClient({ blockNumber }: BlockDetailClientProps): JSX.Element {
-  const [blockData, setBlockData] = useState<Block | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [notFound, setNotFound] = useState(false);
-
-  const blockNum = parseInt(blockNumber);
-
   // Reject obviously-bad inputs before hitting the API: negative numbers,
   // non-integers, NaN, and absurdly long hex strings would all just earn
   // a 400 from the backend. Catching them here keeps the URL bar honest
   // and skips the network round-trip + console noise.
-  const isValidBlockId = (() => {
+  const isValidBlockId = ((): boolean => {
     if (!blockNumber) return false;
     if (blockNumber.startsWith('0x')) return /^0x[0-9a-fA-F]{1,16}$/.test(blockNumber);
     const n = parseInt(blockNumber, 10);
     return Number.isFinite(n) && n >= 0 && String(n) === blockNumber;
   })();
 
+  const [blockData, setBlockData] = useState<Block | null>(null);
+  // Initialise loading/notFound from the validity check so the invalid-id
+  // path doesn't need to write state inside a useEffect (set-state-in-effect
+  // rule). React's "adjusting state on prop change" pattern below resyncs
+  // when the user navigates between blocks.
+  const [loading, setLoading] = useState<boolean>(isValidBlockId);
+  const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState<boolean>(!isValidBlockId);
+  const [prevBlock, setPrevBlock] = useState<string>(blockNumber);
+  if (prevBlock !== blockNumber) {
+    setPrevBlock(blockNumber);
+    setBlockData(null);
+    setError(null);
+    setLoading(isValidBlockId);
+    setNotFound(!isValidBlockId);
+  }
+
+  const blockNum = parseInt(blockNumber);
+
   useEffect(() => {
-    if (!isValidBlockId) {
-      setLoading(false);
-      setNotFound(true);
-      return;
-    }
+    if (!isValidBlockId) return;
     const fetchBlock = async (): Promise<void> => {
       try {
         setLoading(true);

--- a/ExplorerFrontend/app/components/ConnectButton.tsx
+++ b/ExplorerFrontend/app/components/ConnectButton.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { QRCodeCanvas } from 'qrcode.react';
+import { getQrlConnect, ConnectionStatus, type QRLConnectProvider } from '../lib/qrlConnect';
+
+interface ConnectButtonProps {
+  /** Called whenever the connected account changes (or null on disconnect). */
+  onAccount?: (account: string | null) => void;
+  /** Optional: expose the underlying provider so callers can issue requests. */
+  onProvider?: (provider: QRLConnectProvider | null) => void;
+}
+
+const STATUS_LABEL: Record<ConnectionStatus, string> = {
+  [ConnectionStatus.DISCONNECTED]: 'Disconnected',
+  [ConnectionStatus.CONNECTING]: 'Connecting to relay…',
+  [ConnectionStatus.WAITING]: 'Waiting for wallet scan…',
+  [ConnectionStatus.KEY_EXCHANGE]: 'Exchanging keys…',
+  [ConnectionStatus.CONNECTED]: 'Connected',
+  [ConnectionStatus.RECONNECTING]: 'Reconnecting…',
+};
+
+/**
+ * Pair-with-wallet button used by the Write contract tab. On click, opens a
+ * modal with a QR code + deep-link URI from `@qrlwallet/connect`. After a
+ * successful handshake the wallet's address is surfaced upward via
+ * `onAccount`. Closing the modal doesn't disconnect — only the explicit
+ * Disconnect button does.
+ *
+ * The QRLConnect instance is a module-level singleton (see
+ * lib/qrlConnect.ts) so multiple components sharing it don't double-announce
+ * via EIP-6963 or stomp on the persisted-session storage key.
+ */
+export default function ConnectButton({ onAccount, onProvider }: ConnectButtonProps): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [uri, setUri] = useState<string | null>(null);
+  const [status, setStatus] = useState<ConnectionStatus>(ConnectionStatus.DISCONNECTED);
+  const [account, setAccount] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const providerRef = useRef<QRLConnectProvider | null>(null);
+
+  // One-time SDK init + event wire-up. Guarded by `providerRef.current`
+  // rather than the empty-deps array alone, because React 18 Strict Mode
+  // double-invokes effects in dev and we must not register listeners twice.
+  useEffect(() => {
+    if (providerRef.current) return;
+    const qrl = getQrlConnect();
+    providerRef.current = qrl;
+    onProvider?.(qrl);
+
+    const onConnect = () => {
+      setStatus(ConnectionStatus.CONNECTED);
+      const accounts = qrl.getAccounts();
+      const next = accounts[0] ?? null;
+      setAccount(next);
+      onAccount?.(next);
+      // Close the modal once we've got an account.
+      setOpen(false);
+      setUri(null);
+    };
+    const onAccountsChanged = (accounts: string[]) => {
+      const next = accounts[0] ?? null;
+      setAccount(next);
+      onAccount?.(next);
+    };
+    const onDisconnect = () => {
+      setStatus(ConnectionStatus.DISCONNECTED);
+      setAccount(null);
+      onAccount?.(null);
+    };
+    const onStatusChanged = (s: ConnectionStatus) => setStatus(s);
+
+    qrl.on('connect', onConnect);
+    qrl.on('accountsChanged', onAccountsChanged);
+    qrl.on('disconnect', onDisconnect);
+    qrl.on('statusChanged', onStatusChanged);
+
+    // Auto-reconnect if a session is in localStorage. Surface the cached
+    // accounts immediately so the Write tab doesn't render a stale
+    // "Connect Wallet" CTA while the relay handshake completes in the
+    // background.
+    if (qrl.hasStoredSession()) {
+      const cached = qrl.getAccounts();
+      if (cached.length > 0) {
+        setAccount(cached[0]);
+        onAccount?.(cached[0]);
+      }
+      setStatus(ConnectionStatus.RECONNECTING);
+    }
+
+    return () => {
+      qrl.off('connect', onConnect);
+      qrl.off('accountsChanged', onAccountsChanged);
+      qrl.off('disconnect', onDisconnect);
+      qrl.off('statusChanged', onStatusChanged);
+    };
+  }, [onAccount, onProvider]);
+
+  const openPairing = useCallback(async () => {
+    const qrl = providerRef.current;
+    if (!qrl) return;
+    setError(null);
+    setOpen(true);
+    try {
+      const next = await qrl.getConnectionURI();
+      setUri(next);
+      // Mobile devices: jump straight into the wallet via deep link. The
+      // QR modal remains rendered as a fallback if the launch fails.
+      if (qrl.isMobile()) {
+        window.location.href = next;
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  const newConnection = useCallback(async () => {
+    const qrl = providerRef.current;
+    if (!qrl) return;
+    setError(null);
+    try {
+      const next = await qrl.newConnection();
+      setUri(next);
+      setStatus(ConnectionStatus.WAITING);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  const disconnect = useCallback(async () => {
+    const qrl = providerRef.current;
+    if (!qrl) return;
+    try {
+      await qrl.disconnect();
+    } catch {
+      // Best-effort; the local state will be cleared by the disconnect event.
+    }
+    setOpen(false);
+    setUri(null);
+  }, []);
+
+  if (account) {
+    const short = `${account.slice(0, 8)}…${account.slice(-6)}`;
+    return (
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-green-500/15 text-green-300 text-xs font-mono">
+          <span className="h-1.5 w-1.5 rounded-full bg-green-400" /> {short}
+        </span>
+        <button
+          type="button"
+          onClick={disconnect}
+          className="inline-flex items-center justify-center px-3 py-1.5 rounded-lg bg-card-gradient border border-border hover:border-accent text-xs text-gray-300 hover:text-accent transition-colors"
+        >
+          Disconnect
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openPairing}
+        className="inline-flex items-center justify-center px-3 py-1.5 rounded-lg bg-accent text-black text-xs font-medium hover:bg-accent-hover transition-colors"
+      >
+        Connect Wallet
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+          onClick={() => setOpen(false)}
+          role="dialog"
+          aria-modal="true"
+        >
+          <div
+            className="max-w-sm w-full rounded-xl border border-border bg-card-gradient p-4 md:p-5 space-y-3"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm md:text-base font-semibold text-gray-200">Pair MyQRLWallet</h3>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="text-xs text-gray-400 hover:text-gray-200"
+                aria-label="Close"
+              >
+                ✕
+              </button>
+            </div>
+
+            <p className="text-xs text-gray-400">
+              Scan the QR with MyQRLWallet (mobile) or tap the URI to deep-link if you&apos;re on a phone.
+            </p>
+
+            <div className="flex justify-center">
+              {uri ? (
+                <div className="rounded-md bg-white p-3">
+                  <QRCodeCanvas value={uri} size={224} level="M" />
+                </div>
+              ) : (
+                <div className="h-[248px] w-[248px] flex items-center justify-center text-xs text-gray-500">
+                  Generating QR…
+                </div>
+              )}
+            </div>
+
+            <div className="text-[10px] text-gray-500 font-mono break-all">
+              {uri ?? ''}
+            </div>
+
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-gray-400">{STATUS_LABEL[status]}</span>
+              <button
+                type="button"
+                onClick={newConnection}
+                className="text-accent hover:text-accent-hover"
+              >
+                New connection
+              </button>
+            </div>
+
+            {error && (
+              <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-xs text-red-300">
+                {error}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/ExplorerFrontend/app/components/ConnectButton.tsx
+++ b/ExplorerFrontend/app/components/ConnectButton.tsx
@@ -31,22 +31,53 @@ const STATUS_LABEL: Record<ConnectionStatus, string> = {
  * lib/qrlConnect.ts) so multiple components sharing it don't double-announce
  * via EIP-6963 or stomp on the persisted-session storage key.
  */
+// Lazy snapshot of any stored session so the initial render shows the
+// connected pill instead of flashing the "Connect Wallet" CTA before the
+// reconnect effect runs. Returning these from useState initializers (rather
+// than calling setState() inside useEffect) satisfies the new
+// `react-hooks/set-state-in-effect` rule.
+function initialAccount(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const qrl = getQrlConnect();
+    if (qrl.hasStoredSession()) return qrl.getAccounts()[0] ?? null;
+  } catch {
+    // SSR / test environments without window.crypto etc.
+  }
+  return null;
+}
+function initialStatus(): ConnectionStatus {
+  if (typeof window === 'undefined') return ConnectionStatus.DISCONNECTED;
+  try {
+    const qrl = getQrlConnect();
+    if (qrl.hasStoredSession()) return ConnectionStatus.RECONNECTING;
+  } catch {
+    // Fall through to disconnected.
+  }
+  return ConnectionStatus.DISCONNECTED;
+}
+
 export default function ConnectButton({ onAccount, onProvider }: ConnectButtonProps): JSX.Element {
   const [open, setOpen] = useState(false);
   const [uri, setUri] = useState<string | null>(null);
-  const [status, setStatus] = useState<ConnectionStatus>(ConnectionStatus.DISCONNECTED);
-  const [account, setAccount] = useState<string | null>(null);
+  const [status, setStatus] = useState<ConnectionStatus>(initialStatus);
+  const [account, setAccount] = useState<string | null>(initialAccount);
   const [error, setError] = useState<string | null>(null);
   const providerRef = useRef<QRLConnectProvider | null>(null);
 
-  // One-time SDK init + event wire-up. Guarded by `providerRef.current`
-  // rather than the empty-deps array alone, because React 18 Strict Mode
-  // double-invokes effects in dev and we must not register listeners twice.
+  // Event wire-up. Guarded by `providerRef.current` rather than the empty-
+  // deps array alone, because React 18 Strict Mode double-invokes effects
+  // in dev and we must not register listeners twice. All state writes
+  // happen inside event-emitter callbacks (never in the effect body), so
+  // this complies with `react-hooks/set-state-in-effect`.
   useEffect(() => {
     if (providerRef.current) return;
     const qrl = getQrlConnect();
     providerRef.current = qrl;
     onProvider?.(qrl);
+    // Notify the parent once on mount if we already restored an account
+    // from the stored session via the useState initializer above.
+    if (account) onAccount?.(account);
 
     const onConnect = () => {
       setStatus(ConnectionStatus.CONNECTED);
@@ -75,25 +106,15 @@ export default function ConnectButton({ onAccount, onProvider }: ConnectButtonPr
     qrl.on('disconnect', onDisconnect);
     qrl.on('statusChanged', onStatusChanged);
 
-    // Auto-reconnect if a session is in localStorage. Surface the cached
-    // accounts immediately so the Write tab doesn't render a stale
-    // "Connect Wallet" CTA while the relay handshake completes in the
-    // background.
-    if (qrl.hasStoredSession()) {
-      const cached = qrl.getAccounts();
-      if (cached.length > 0) {
-        setAccount(cached[0]);
-        onAccount?.(cached[0]);
-      }
-      setStatus(ConnectionStatus.RECONNECTING);
-    }
-
     return () => {
       qrl.off('connect', onConnect);
       qrl.off('accountsChanged', onAccountsChanged);
       qrl.off('disconnect', onDisconnect);
       qrl.off('statusChanged', onStatusChanged);
     };
+    // `account` is read once at mount only — listing it would re-attach
+    // listeners on every account change, which is wrong.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onAccount, onProvider]);
 
   const openPairing = useCallback(async () => {

--- a/ExplorerFrontend/app/components/ContractTabs.tsx
+++ b/ExplorerFrontend/app/components/ContractTabs.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import CopyButton from './CopyButton';
 import ContractBytecode from './ContractBytecode';
 import ReadContract from './ReadContract';
+import WriteContract from './WriteContract';
 import type { ContractData } from '../types/address';
 
 interface ContractTabsProps {
@@ -20,13 +21,9 @@ type TabKey = 'code' | 'read' | 'write';
  *  - Code  — for verified contracts: source + compiler settings + ABI +
  *            bytecode (as a sub-section). For unverified: bytecode + a
  *            "Verify & Publish" CTA linking to /verify-contract.
- *  - Read  — `view`/`pure` function dispatcher. M4 fills this in.
+ *  - Read  — `view`/`pure` function dispatcher (M4).
  *  - Write — `nonpayable`/`payable` function dispatcher via the QRL Connect
- *            session. M5 fills this in.
- *
- * Read/Write tabs are scaffolds in this PR; their bodies show a
- * "coming soon" placeholder so the layout is final but the runtime is
- * deferred.
+ *            session (M5).
  */
 export default function ContractTabs({ contractData }: ContractTabsProps): JSX.Element {
   const [tab, setTab] = useState<TabKey>('code');
@@ -50,7 +47,7 @@ export default function ContractTabs({ contractData }: ContractTabsProps): JSX.E
 
       {tab === 'code' && <CodeTab contractData={contractData} parsedAbi={parsedAbi} />}
       {tab === 'read' && <ReadContract contractData={contractData} />}
-      {tab === 'write' && <ComingSoonTab label="Write contract" subhead="State-changing calls via wallet pairing arrive in a follow-up." />}
+      {tab === 'write' && <WriteContract contractData={contractData} />}
     </div>
   );
 }
@@ -198,11 +195,3 @@ function AbiPanel({ abi, raw }: { abi: unknown | null; raw: string }) {
   );
 }
 
-function ComingSoonTab({ label, subhead }: { label: string; subhead: string }) {
-  return (
-    <div className="rounded-lg border border-border bg-card-gradient p-6 text-center">
-      <div className="text-sm md:text-base font-medium text-gray-300">{label} — coming soon</div>
-      <div className="text-xs md:text-sm text-gray-400 mt-1">{subhead}</div>
-    </div>
-  );
-}

--- a/ExplorerFrontend/app/components/ContractTabs.tsx
+++ b/ExplorerFrontend/app/components/ContractTabs.tsx
@@ -158,7 +158,9 @@ function SourcePanel({ contractData }: { contractData: ContractData }) {
 
 function AbiPanel({ abi, raw }: { abi: unknown | null; raw: string }) {
   const [expanded, setExpanded] = useState(false);
-  if (!raw) return null;
+  // Hooks must be called unconditionally — the early return below cannot
+  // precede useMemo. raw='' is a cheap input for JSON.stringify so the
+  // computed value is harmless when the panel is about to bail.
   const pretty = useMemo(() => {
     if (abi === null) return raw;
     try {
@@ -167,6 +169,7 @@ function AbiPanel({ abi, raw }: { abi: unknown | null; raw: string }) {
       return raw;
     }
   }, [abi, raw]);
+  if (!raw) return null;
 
   return (
     <div>

--- a/ExplorerFrontend/app/components/DebouncedInput.tsx
+++ b/ExplorerFrontend/app/components/DebouncedInput.tsx
@@ -16,10 +16,15 @@ export default function DebouncedInput({
   ...props
 }: DebouncedInputProps): JSX.Element {
   const [value, setValue] = useState<string>(initialValue);
-
-  useEffect(() => {
+  // React's "adjusting state on prop change" pattern: detect the parent
+  // pushing a new initialValue mid-render and resync without scheduling a
+  // post-render setState in an effect. Avoids the set-state-in-effect rule
+  // and the cascading-render perf footgun.
+  const [prevInitial, setPrevInitial] = useState<string>(initialValue);
+  if (prevInitial !== initialValue) {
+    setPrevInitial(initialValue);
     setValue(initialValue);
-  }, [initialValue]);
+  }
 
   useEffect(() => {
     const timeout = setTimeout(() => {

--- a/ExplorerFrontend/app/components/Sidebar.tsx
+++ b/ExplorerFrontend/app/components/Sidebar.tsx
@@ -135,10 +135,14 @@ export default function Sidebar(): JSX.Element {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [isOpen])
 
-  // Close sidebar on route change (mobile)
-  React.useEffect(() => {
-    setIsOpen(false)
-  }, [pathname])
+  // Close sidebar on route change (mobile). React's "adjusting state on
+  // prop change" pattern: detect mid-render and reset without queuing a
+  // post-render setState in an effect (set-state-in-effect rule).
+  const [prevPath, setPrevPath] = React.useState(pathname)
+  if (prevPath !== pathname) {
+    setPrevPath(pathname)
+    if (isOpen) setIsOpen(false)
+  }
 
   return (
     <>

--- a/ExplorerFrontend/app/components/WriteContract.tsx
+++ b/ExplorerFrontend/app/components/WriteContract.tsx
@@ -1,0 +1,288 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import * as zondAbi from '@theqrl/web3-zond-abi';
+import ConnectButton from './ConnectButton';
+import type { QRLConnectProvider } from '../lib/qrlConnect';
+import type { ContractData } from '../types/address';
+
+interface AbiInput {
+  name: string;
+  type: string;
+  components?: AbiInput[];
+}
+
+interface AbiFunction {
+  type: 'function';
+  name: string;
+  stateMutability: 'view' | 'pure' | 'nonpayable' | 'payable';
+  inputs: AbiInput[];
+  outputs?: { name: string; type: string }[];
+}
+
+interface WriteContractProps {
+  contractData: ContractData;
+}
+
+/**
+ * One collapsible card per nonpayable/payable ABI function. Each card encodes
+ * its calldata client-side via @theqrl/web3-zond-abi and asks the user's
+ * paired wallet to broadcast the transaction over the QRL Connect relay. The
+ * wallet returns the broadcast tx hash, which we link to the local explorer.
+ *
+ * Wallet submits — the explorer never sees the signed payload and never
+ * touches a node directly for write paths. Matches the protocol used by the
+ * dApp example and keeps the explorer trust boundary narrow.
+ */
+export default function WriteContract({ contractData }: WriteContractProps): JSX.Element {
+  const [account, setAccount] = useState<string | null>(null);
+  const [provider, setProvider] = useState<QRLConnectProvider | null>(null);
+
+  const writeFns = useMemo(() => {
+    if (!contractData.verified || !contractData.abi) return [] as AbiFunction[];
+    try {
+      const parsed = JSON.parse(contractData.abi) as AbiFunction[];
+      return parsed.filter(
+        f =>
+          f.type === 'function' &&
+          (f.stateMutability === 'nonpayable' || f.stateMutability === 'payable'),
+      );
+    } catch {
+      return [] as AbiFunction[];
+    }
+  }, [contractData.abi, contractData.verified]);
+
+  if (!contractData.verified) {
+    return (
+      <div className="rounded-lg border border-border bg-card-gradient p-4 text-sm text-gray-300">
+        Verify this contract first to enable Write interactions.
+      </div>
+    );
+  }
+  if (writeFns.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-card-gradient p-4 text-sm text-gray-300">
+        This contract has no state-changing functions to call.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 md:space-y-4">
+      <div className="rounded-lg border border-border bg-card-gradient p-3 md:p-4 flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-between">
+        <div>
+          <div className="text-xs md:text-sm font-medium text-gray-200">Wallet pairing</div>
+          <div className="text-xs text-gray-400 mt-0.5">
+            Connect MyQRLWallet to sign and broadcast state-changing calls.
+          </div>
+        </div>
+        <ConnectButton onAccount={setAccount} onProvider={setProvider} />
+      </div>
+
+      <div className="space-y-2 md:space-y-3">
+        {writeFns.map((fn, idx) => (
+          <WriteFunctionCard
+            key={`${fn.name}-${idx}-${fn.inputs.map(i => i.type).join(',')}`}
+            fn={fn}
+            address={contractData.address}
+            account={account}
+            provider={provider}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function WriteFunctionCard({
+  fn,
+  address,
+  account,
+  provider,
+}: {
+  fn: AbiFunction;
+  address: string;
+  account: string | null;
+  provider: QRLConnectProvider | null;
+}) {
+  const [values, setValues] = useState<string[]>(() => fn.inputs.map(() => ''));
+  const [value, setValue] = useState<string>('');
+  const [txHash, setTxHash] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [rejected, setRejected] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const setVal = (i: number, v: string) =>
+    setValues(cur => cur.map((x, j) => (j === i ? v : x)));
+
+  const onWrite = async () => {
+    if (!provider || !account) {
+      setError('Connect a wallet first');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setTxHash(null);
+    setRejected(false);
+    try {
+      const args = fn.inputs.map((input, i) => parseArg(values[i] ?? '', input.type));
+      const data = zondAbi.encodeFunctionCall(fn as never, args as never[]);
+
+      const tx: Record<string, string> = {
+        from: account,
+        to: address,
+        data,
+      };
+      if (fn.stateMutability === 'payable' && value.trim() !== '') {
+        tx.value = toHexWei(value.trim());
+      }
+
+      const result = (await provider.request({
+        method: 'qrl_sendTransaction',
+        params: [tx],
+      })) as string;
+      setTxHash(result);
+    } catch (e) {
+      // EIP-1193 user-rejection: code 4001.
+      const code = (e as { code?: number } | undefined)?.code;
+      if (code === 4001) {
+        setRejected(true);
+        setError('Request rejected in wallet');
+      } else {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const sig = `${fn.name}(${fn.inputs.map(i => `${i.type}${i.name ? ' ' + i.name : ''}`).join(', ')})`;
+  const disabled = loading || !account || !provider;
+
+  return (
+    <div className="rounded-lg border border-border bg-card-gradient">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+        className="w-full flex items-center justify-between gap-2 px-3 py-2 text-left"
+      >
+        <span className="font-mono text-xs md:text-sm text-gray-200 break-all">
+          {sig}
+          {fn.stateMutability === 'payable' && (
+            <span className="ml-2 text-[10px] text-amber-300 align-middle">payable</span>
+          )}
+        </span>
+        <span className="text-xs text-gray-500">{open ? '–' : '+'}</span>
+      </button>
+      {open && (
+        <div className="border-t border-border p-3 space-y-3">
+          {fn.inputs.map((input, i) => (
+            <div key={i}>
+              <div className="text-xs text-gray-400 mb-1">
+                {input.name ? `${input.name} ` : ''}
+                <span className="font-mono text-gray-500">({input.type})</span>
+              </div>
+              <input
+                value={values[i] ?? ''}
+                onChange={e => setVal(i, e.target.value)}
+                placeholder={placeholderFor(input.type)}
+                className="form-input font-mono text-xs"
+              />
+            </div>
+          ))}
+
+          {fn.stateMutability === 'payable' && (
+            <div>
+              <div className="text-xs text-gray-400 mb-1">
+                value <span className="font-mono text-gray-500">(QRL)</span>
+              </div>
+              <input
+                value={value}
+                onChange={e => setValue(e.target.value)}
+                placeholder="0.0"
+                className="form-input font-mono text-xs"
+              />
+            </div>
+          )}
+
+          <button
+            type="button"
+            onClick={onWrite}
+            disabled={disabled}
+            className="inline-flex items-center justify-center px-3 py-1.5 rounded-lg bg-accent text-black text-xs font-medium hover:bg-accent-hover transition-colors disabled:opacity-50"
+          >
+            {loading ? 'Awaiting wallet…' : account ? 'Write' : 'Connect wallet to write'}
+          </button>
+
+          {error && (
+            <div
+              className={`rounded-md border p-2 text-xs ${
+                rejected
+                  ? 'border-orange-500/40 bg-orange-500/10 text-orange-300'
+                  : 'border-red-500/40 bg-red-500/10 text-red-300'
+              }`}
+            >
+              {error}
+            </div>
+          )}
+
+          {txHash && !error && (
+            <div className="rounded-md border border-green-500/40 bg-green-500/10 p-2 text-xs text-green-300">
+              <div className="mb-1">Broadcast:</div>
+              <Link href={`/tx/${txHash}`} className="font-mono text-accent hover:text-accent-hover break-all">
+                {txHash}
+              </Link>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// parseArg converts a user-typed string into the right JS shape for
+// @theqrl/web3-zond-abi.encodeFunctionCall. Mirrors ReadContract's parser
+// so the Read/Write tabs accept identical input formats.
+function parseArg(raw: string, type: string): unknown {
+  const t = raw.trim();
+  if (t === '') {
+    if (type === 'bool') return false;
+    if (type.startsWith('uint') || type.startsWith('int')) return '0';
+    return '';
+  }
+  if (type === 'bool') return t.toLowerCase() === 'true' || t === '1';
+  if (type.endsWith(']') || type === 'tuple') {
+    try {
+      return JSON.parse(t);
+    } catch {
+      throw new Error(`expected JSON for ${type}: e.g. [1,2,3]`);
+    }
+  }
+  if (type.startsWith('uint') || type.startsWith('int')) {
+    return t;
+  }
+  return t;
+}
+
+function placeholderFor(type: string): string {
+  if (type === 'address') return 'Q…';
+  if (type === 'bool') return 'true / false';
+  if (type.startsWith('uint') || type.startsWith('int')) return '0';
+  if (type === 'string') return 'text';
+  if (type.startsWith('bytes')) return '0x…';
+  if (type.endsWith(']') || type === 'tuple') return 'JSON: [1,2,3]';
+  return '';
+}
+
+// toHexWei converts a decimal QRL string ("1.25") into 0x-prefixed wei.
+// Avoids float drift by splitting on the decimal point and padding the
+// fractional side to 18 digits before BigInt arithmetic.
+function toHexWei(qrl: string): string {
+  const [whole, frac = ''] = qrl.split('.');
+  const fracPadded = (frac + '0'.repeat(18)).slice(0, 18);
+  const combined = `${whole}${fracPadded}`.replace(/^0+/, '') || '0';
+  return '0x' + BigInt(combined).toString(16);
+}

--- a/ExplorerFrontend/app/contracts/contracts-client.tsx
+++ b/ExplorerFrontend/app/contracts/contracts-client.tsx
@@ -28,6 +28,47 @@ type TabType = 'tokens' | 'contracts';
 
 const ITEMS_PER_PAGE = 15;
 
+// Hoisted out of the render body so each ContractsClient render doesn't
+// allocate a brand-new component identity. React 19 (and the new
+// react-hooks/error-boundaries rule) flag in-render component creation as
+// a bug — every new identity loses state and re-mounts children.
+function TabButton({
+  tab,
+  label,
+  count,
+  activeTab,
+  onSelect,
+}: {
+  tab: TabType;
+  label: string;
+  count?: number;
+  activeTab: TabType;
+  onSelect: (t: TabType) => void;
+}): JSX.Element {
+  const active = activeTab === tab;
+  return (
+    <button
+      role="tab"
+      aria-selected={active}
+      onClick={() => onSelect(tab)}
+      className={`px-4 py-2 text-sm font-medium rounded-lg transition-all duration-200 ${
+        active ? 'bg-[#ffa729] text-black' : 'bg-[#2d2d2d] text-gray-300 hover:bg-[#3d3d3d]'
+      }`}
+    >
+      {label}
+      {count !== undefined && (
+        <span
+          className={`ml-2 px-2 py-0.5 rounded-full text-xs ${
+            active ? 'bg-black/20' : 'bg-[#1f1f1f]'
+          }`}
+        >
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}
+
 // Format total supply (uses 10^decimals)
 function formatTotalSupply(supply: string | undefined, decimals: number | undefined): string {
   if (!supply || supply === '0') return '0';
@@ -122,34 +163,16 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
     return () => clearTimeout(timer);
   }, [activeTab, searchQuery, currentPage, fetchContracts]);
 
-  // Reset page when tab or search changes
-  useEffect(() => {
-    setCurrentPage(0);
-  }, [activeTab, searchQuery]);
+  // Reset page when tab or search changes — adjusting state on prop/state
+  // change instead of writing it in an effect (set-state-in-effect).
+  const [prevReset, setPrevReset] = useState<string>(`${activeTab}|${searchQuery}`);
+  const resetKey = `${activeTab}|${searchQuery}`;
+  if (prevReset !== resetKey) {
+    setPrevReset(resetKey);
+    if (currentPage !== 0) setCurrentPage(0);
+  }
 
   const totalPages = Math.max(1, Math.ceil(total / ITEMS_PER_PAGE));
-
-  const TabButton = ({ tab, label, count }: { tab: TabType; label: string; count?: number }) => (
-    <button
-      role="tab"
-      aria-selected={activeTab === tab}
-      onClick={() => setActiveTab(tab)}
-      className={`px-4 py-2 text-sm font-medium rounded-lg transition-all duration-200 ${
-        activeTab === tab
-          ? 'bg-[#ffa729] text-black'
-          : 'bg-[#2d2d2d] text-gray-300 hover:bg-[#3d3d3d]'
-      }`}
-    >
-      {label}
-      {count !== undefined && (
-        <span className={`ml-2 px-2 py-0.5 rounded-full text-xs ${
-          activeTab === tab ? 'bg-black/20' : 'bg-[#1f1f1f]'
-        }`}>
-          {count}
-        </span>
-      )}
-    </button>
-  );
 
   return (
     <div className="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8">
@@ -161,8 +184,8 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
 
       {/* Tabs */}
       <div role="tablist" className="flex gap-2 mb-6">
-        <TabButton tab="tokens" label="Tokens" />
-        <TabButton tab="contracts" label="All Contracts" />
+        <TabButton tab="tokens" label="Tokens" activeTab={activeTab} onSelect={setActiveTab} />
+        <TabButton tab="contracts" label="All Contracts" activeTab={activeTab} onSelect={setActiveTab} />
       </div>
 
       {/* Search */}

--- a/ExplorerFrontend/app/home-client.tsx
+++ b/ExplorerFrontend/app/home-client.tsx
@@ -437,10 +437,15 @@ export default function HomeClient({ pageTitle }: { pageTitle: string }): JSX.El
   }, []);
 
   React.useEffect(() => {
-    fetchData();
+    // Defer the initial call so its inner setState() lands outside the
+    // synchronous effect body (set-state-in-effect rule).
+    const initial = setTimeout(fetchData, 0);
     // Refresh every 30s (approx half a slot)
     const interval = setInterval(fetchData, 30000);
-    return () => clearInterval(interval);
+    return () => {
+      clearTimeout(initial);
+      clearInterval(interval);
+    };
   }, [fetchData]);
 
   return (

--- a/ExplorerFrontend/app/lib/qrlConnect.ts
+++ b/ExplorerFrontend/app/lib/qrlConnect.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { QRLConnect, ConnectionStatus } from '@qrlwallet/connect';
+import type { QRLConnectProvider } from '@qrlwallet/connect';
+
+// Module-level singleton. The QRLConnect constructor announces itself via
+// EIP-6963 and opens a relay socket — instantiating twice would double the
+// announcements and stomp on the persisted-session storage key. Always go
+// through getQrlConnect().
+let instance: QRLConnectProvider | null = null;
+
+// Default relay URL: the same backend that hosts the dApp example consumes
+// the explorer's host as the relay endpoint, so anyone landing on
+// zondscan.com pairs against the same relay that powers qrlwallet.com.
+// VITE-style override matches what dapp-example uses.
+function getRelayUrl(): string {
+  if (typeof window !== 'undefined') {
+    // Allow per-deploy override via a global injected at runtime (none today,
+    // but cheap insurance for ops). Defaults to qrlwallet.com.
+    const w = window as unknown as { __QRL_RELAY_URL__?: string };
+    if (w.__QRL_RELAY_URL__) return w.__QRL_RELAY_URL__;
+  }
+  return 'https://qrlwallet.com';
+}
+
+export function getQrlConnect(): QRLConnectProvider {
+  if (instance) return instance;
+  if (typeof window === 'undefined') {
+    throw new Error('getQrlConnect() called on the server; this module is client-only');
+  }
+  instance = new QRLConnect({
+    dappMetadata: {
+      name: 'Zondscan',
+      url: window.location.origin,
+    },
+    relayUrl: getRelayUrl(),
+    autoReconnect: true,
+  });
+  return instance;
+}
+
+export { ConnectionStatus };
+export type { QRLConnectProvider };

--- a/ExplorerFrontend/app/pending/tx/[hash]/pending-transaction-view.tsx
+++ b/ExplorerFrontend/app/pending/tx/[hash]/pending-transaction-view.tsx
@@ -92,34 +92,46 @@ export default function PendingTransactionView({ pendingTx }: PendingTransaction
   });
 
   // ── Mined → navigate, dropped → flip local state ───────────────────────
-  const [isDropped, setIsDropped] = useState(false);
+  // Derive isDropped from the polled status directly. router.replace is
+  // a side effect that *must* stay in a useEffect (no setState involved
+  // there, so the rule doesn't fire).
+  const isDropped = statusQuery.data?.status === 'dropped';
   useEffect(() => {
     if (statusQuery.data?.status === 'mined') {
       router.replace(`/tx/${pendingTx.hash}`);
-    } else if (statusQuery.data?.status === 'dropped') {
-      setIsDropped(true);
     }
   }, [statusQuery.data?.status, pendingTx.hash, router]);
 
   // ── Elapsed counter (driven by local 1s tick, independent of polls) ────
   // Seed from createdAt so SSR and the first client render produce identical
-  // markup (elapsed = 0); hydrate to real wall-clock time in the effect.
+  // markup (elapsed = 0); hydrate to real wall-clock time after mount via
+  // a deferred setState (outside the synchronous effect body) so we don't
+  // trip set-state-in-effect.
   const [nowSec, setNowSec] = useState(pendingTx.createdAt ?? 0);
   useEffect(() => {
-    setNowSec(Math.floor(Date.now() / 1000));
-    if (statusQuery.data?.status !== 'pending') return;
+    const seed = setTimeout(() => setNowSec(Math.floor(Date.now() / 1000)), 0);
+    if (statusQuery.data?.status !== 'pending') {
+      return () => clearTimeout(seed);
+    }
     const id = setInterval(() => setNowSec(Math.floor(Date.now() / 1000)), 1000);
-    return () => clearInterval(id);
+    return () => {
+      clearTimeout(seed);
+      clearInterval(id);
+    };
   }, [statusQuery.data?.status]);
   const elapsedSec = Math.max(0, nowSec - (pendingTx.createdAt ?? nowSec));
 
   // ── ETA countdown — seeded from each poll, ticks down every second ─────
+  // Adjusting-state-on-prop-change: detect a new poll value mid-render and
+  // resync without writing state inside an effect (set-state-in-effect).
   const [etaRemaining, setEtaRemaining] = useState<number | null>(null);
-  useEffect(() => {
+  const [prevEtaSec, setPrevEtaSec] = useState<number | undefined>(undefined);
+  if (etaQuery.data?.etaSec !== prevEtaSec) {
+    setPrevEtaSec(etaQuery.data?.etaSec);
     if (typeof etaQuery.data?.etaSec === 'number') {
       setEtaRemaining(Math.max(0, Math.round(etaQuery.data.etaSec)));
     }
-  }, [etaQuery.data?.etaSec]);
+  }
   const hasEta = etaRemaining !== null;
   useEffect(() => {
     if (!hasEta) return;

--- a/ExplorerFrontend/app/transactions/[query]/TransactionsList.tsx
+++ b/ExplorerFrontend/app/transactions/[query]/TransactionsList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { formatAmount, timeAgo, truncateHash } from '../../lib/helpers';
@@ -18,12 +18,12 @@ export default function TransactionsList({
   currentPage,
 }: TransactionsListProps): JSX.Element {
   const router = useRouter();
-  const [transactions, setTransactions] = useState(initialData.txs);
-  const [totalPages] = useState(Math.max(1, Math.ceil(initialData.total / ITEMS_PER_PAGE)));
-
-  useEffect(() => {
-    setTransactions(initialData.txs);
-  }, [initialData]);
+  // Render straight from props; the previous local mirror state served no
+  // purpose (no setter is called) and the useEffect-resync tripped the new
+  // set-state-in-effect rule. Memo for stable identity in case downstream
+  // components ever .map over it with referential keys.
+  const transactions = useMemo(() => initialData.txs, [initialData.txs]);
+  const totalPages = Math.max(1, Math.ceil(initialData.total / ITEMS_PER_PAGE));
 
   const goToNextPage = (): void => {
     router.push(`/transactions/${Math.min(currentPage + 1, totalPages)}`);

--- a/ExplorerFrontend/app/transactions/[query]/transactions-client.tsx
+++ b/ExplorerFrontend/app/transactions/[query]/transactions-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import TransactionsList from './TransactionsList';
 import type { Transaction } from '@/app/types';
 import config from '../../../config';
@@ -20,10 +20,15 @@ export default function TransactionsClient({ initialData, pageNumber }: Transact
   const [data, setData] = React.useState<TransactionsResponse>(initialData);
   const [error, setError] = React.useState<string | null>(null);
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
-
-  useEffect(() => {
+  // Resync local `data` whenever the parent pushes a new initialData /
+  // pageNumber. React's "adjusting state on prop change" pattern: detect
+  // mid-render and update, avoiding set-state-in-effect.
+  const [prevKey, setPrevKey] = React.useState<string>(`${pageNumber}|${initialData.total}`);
+  const nextKey = `${pageNumber}|${initialData.total}`;
+  if (prevKey !== nextKey) {
+    setPrevKey(nextKey);
     setData(initialData);
-  }, [initialData, pageNumber]);
+  }
 
   const refetchData = async (): Promise<void> => {
     try {

--- a/ExplorerFrontend/app/tx/[query]/page.tsx
+++ b/ExplorerFrontend/app/tx/[query]/page.tsx
@@ -111,9 +111,13 @@ export default async function TransactionPage({ params }: PageProps): Promise<JS
     redirect(`/pending/tx/${txHash}`);
   }
 
+  // Constructing JSX inside the try/catch lets render-time errors escape
+  // the catch block (React doesn't render synchronously), so the rule
+  // react-hooks/error-boundaries flags it. Resolve the transaction first,
+  // then return the JSX outside the try.
+  let transaction;
   try {
-    const transaction = await getTransaction(txHash);
-    return <TransactionView transaction={transaction} />;
+    transaction = await getTransaction(txHash);
   } catch (error) {
     console.error('Error in TransactionPage:', error);
     return (
@@ -132,4 +136,5 @@ export default async function TransactionPage({ params }: PageProps): Promise<JS
       </div>
     );
   }
+  return <TransactionView transaction={transaction} />;
 }

--- a/ExplorerFrontend/app/validators/validators-client.tsx
+++ b/ExplorerFrontend/app/validators/validators-client.tsx
@@ -132,10 +132,14 @@ export default function ValidatorsWrapper(): JSX.Element {
   }, []);
 
   useEffect(() => {
-    fetchData();
-    // Refresh data every 60 seconds
+    // Defer the initial call so its inner setState() lands outside the
+    // synchronous effect body (set-state-in-effect rule).
+    const initial = setTimeout(fetchData, 0);
     const interval = setInterval(fetchData, 60000);
-    return () => clearInterval(interval);
+    return () => {
+      clearTimeout(initial);
+      clearInterval(interval);
+    };
   }, [fetchData]);
 
   if (error && !validators.length) {

--- a/ExplorerFrontend/eslint.config.mjs
+++ b/ExplorerFrontend/eslint.config.mjs
@@ -8,6 +8,24 @@ export default [
   ...coreWebVitals,
   ...tsConfig,
   {
+    // Same file glob as the upstream `next` config object so the `import`
+    // plugin (declared by next at the same scope) resolves here too.
+    // Without an explicit `files`, eslint v9+ flat config treats this entry
+    // as global and refuses to start with:
+    //   "could not find plugin 'import'"
+    // because the plugin isn't in scope for files outside the next glob.
+    files: ["**/*.{js,jsx,mjs,ts,tsx,mts,cts}"],
+    settings: {
+      // Pin React version to bypass eslint-plugin-react@7.37's
+      // detectReactVersion() helper, which calls context.getFilename() — a
+      // method ESLint 10 removed. Without this pin, every load of a
+      // react/* rule crashes:
+      //   "Error while loading rule 'react/no-direct-mutation-state':
+      //    contextOrFilename.getFilename is not a function"
+      // We're on React 19 (see package.json), so this is honest, not a
+      // workaround value.
+      react: { version: "19" },
+    },
     rules: {
       // React 19 doesn't need import React
       "react/react-in-jsx-scope": "off",
@@ -30,6 +48,12 @@ export default [
     },
   },
   {
-    ignores: ["build/", "node_modules/", ".next/"],
+    ignores: [
+      "build/",
+      "node_modules/",
+      ".next/",
+      ".dapp-example-cache/",
+      "public/dapp-example/",
+    ],
   },
 ];

--- a/ExplorerFrontend/package-lock.json
+++ b/ExplorerFrontend/package-lock.json
@@ -51,7 +51,7 @@
                 "@types/react": "^19.2.7",
                 "@types/react-dom": "^19.2.3",
                 "cypress": "^13.4.0",
-                "eslint": "^10.2.0",
+                "eslint": "^10.4.0",
                 "postcss": "^8.5.8",
                 "tailwindcss": "^4.2.2",
                 "ts-node": "^10.9.1",
@@ -509,9 +509,9 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-            "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+            "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/core": "^1.2.1"
@@ -6080,16 +6080,16 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-            "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+            "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
                 "@eslint/config-array": "^0.23.5",
-                "@eslint/config-helpers": "^0.5.5",
+                "@eslint/config-helpers": "^0.6.0",
                 "@eslint/core": "^1.2.1",
                 "@eslint/plugin-kit": "^0.7.1",
                 "@humanfs/node": "^0.16.6",

--- a/ExplorerFrontend/package-lock.json
+++ b/ExplorerFrontend/package-lock.json
@@ -11,6 +11,7 @@
                 "@ethereumjs/tx": "^5.1.0",
                 "@headlessui/react": "^2.2.0",
                 "@heroicons/react": "^2.0.18",
+                "@qrlwallet/connect": "^2.0.0",
                 "@tailwindcss/postcss": "^4.2.2",
                 "@tanstack/react-query": "^5.90.16",
                 "@testing-library/jest-dom": "^6.6.3",
@@ -113,6 +114,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -1870,6 +1872,49 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/@noble/post-quantum": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@noble/post-quantum/-/post-quantum-0.5.4.tgz",
+            "integrity": "sha512-leww0zzIirrvwaYMPI9fj6aRIlA/c6Y0/lifQQ1YOOyHEr0MNH3yYpjXeiVG+tWdPps4XxGclFWX2INPO3Yo5w==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/curves": "~2.0.0",
+                "@noble/hashes": "~2.0.0"
+            },
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/post-quantum/node_modules/@noble/curves": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+            "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "2.0.1"
+            },
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/post-quantum/node_modules/@noble/hashes": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+            "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1912,6 +1957,34 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12.4.0"
+            }
+        },
+        "node_modules/@qrlwallet/connect": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@qrlwallet/connect/-/connect-2.0.0.tgz",
+            "integrity": "sha512-UwxDt8FkNSCWWxpzOaUJFzJV6unvF3KHSQxHpDQQDgbNCJvFgIDSv1BLNW+mp1wreO0NTTct9Minrjd3jJoqIA==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/post-quantum": "^0.5.4",
+                "eventemitter3": "^5.0.1",
+                "socket.io-client": "^4.8.1",
+                "uuid": "^11.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@qrlwallet/connect/node_modules/uuid": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/@react-aria/focus": {
@@ -1999,6 +2072,12 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@socket.io/component-emitter": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+            "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
             "license": "MIT"
         },
         "node_modules/@swc/helpers": {
@@ -4561,21 +4640,6 @@
             "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
             "license": "MIT"
         },
-        "node_modules/bufferutil": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
-            "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "node-gyp-build": "^4.3.0"
-            },
-            "engines": {
-                "node": ">=6.14.2"
-            }
-        },
         "node_modules/cachedir": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
@@ -5754,6 +5818,49 @@
                 "once": "^1.4.0"
             }
         },
+        "node_modules/engine.io-client": {
+            "version": "6.6.4",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+            "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+            "license": "MIT",
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.4.1",
+                "engine.io-parser": "~5.2.1",
+                "ws": "~8.18.3",
+                "xmlhttprequest-ssl": "~2.1.1"
+            }
+        },
+        "node_modules/engine.io-client/node_modules/ws": {
+            "version": "8.18.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/engine.io-parser": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+            "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/enhanced-resolve": {
             "version": "5.21.2",
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.2.tgz",
@@ -6108,6 +6215,7 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -6425,6 +6533,12 @@
             "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
             "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
             "license": "MIT"
         },
         "node_modules/evp_bytestokey": {
@@ -10176,6 +10290,34 @@
                 "node": ">=8"
             }
         },
+        "node_modules/socket.io-client": {
+            "version": "4.8.3",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+            "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.4.1",
+                "engine.io-client": "~6.6.1",
+                "socket.io-parser": "~4.2.4"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/socket.io-parser": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+            "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+            "license": "MIT",
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.4.1"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -11032,21 +11174,6 @@
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
-        "node_modules/utf-8-validate": {
-            "version": "6.0.6",
-            "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
-            "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "node-gyp-build": "^4.3.0"
-            },
-            "engines": {
-                "node": ">=6.14.2"
-            }
-        },
         "node_modules/util": {
             "version": "0.12.5",
             "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -11282,6 +11409,14 @@
                 "utf-8-validate": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/xmlhttprequest-ssl": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+            "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/yallist": {

--- a/ExplorerFrontend/package-lock.json
+++ b/ExplorerFrontend/package-lock.json
@@ -114,7 +114,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -2300,6 +2299,66 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.10.0",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.4",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+            "version": "2.8.1",
+            "inBundle": true,
+            "license": "0BSD",
+            "optional": true
+        },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
@@ -2936,7 +2995,8 @@
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
             "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/bn.js": {
             "version": "5.2.0",
@@ -3145,7 +3205,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.40.tgz",
             "integrity": "sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -3164,7 +3223,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
             "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -3174,7 +3232,6 @@
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -3288,7 +3345,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
             "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.59.2",
                 "@typescript-eslint/types": "8.59.2",
@@ -3980,7 +4036,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4565,7 +4620,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -4639,6 +4693,20 @@
             "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
             "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
             "license": "MIT"
+        },
+        "node_modules/bufferutil": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+            "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "node-gyp-build": "^4.3.0"
+            },
+            "engines": {
+                "node": ">=6.14.2"
+            }
         },
         "node_modules/cachedir": {
             "version": "2.4.0",
@@ -5443,7 +5511,6 @@
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -5743,7 +5810,8 @@
             "version": "0.5.16",
             "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
             "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
@@ -5803,7 +5871,6 @@
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
             "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "iconv-lite": "^0.6.2"
             }
@@ -5880,7 +5947,6 @@
             "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-colors": "^4.1.1",
                 "strip-ansi": "^6.0.1"
@@ -6084,7 +6150,6 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
             "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
@@ -6215,7 +6280,6 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -8686,6 +8750,7 @@
             "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
             "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
             }
@@ -9427,6 +9492,7 @@
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
             "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1",
                 "ansi-styles": "^5.0.0",
@@ -9441,6 +9507,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -9569,7 +9636,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
             "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9600,7 +9666,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
             "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -9612,7 +9677,8 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/react-stately": {
             "version": "3.46.0",
@@ -10707,7 +10773,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -11016,7 +11081,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
             "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -11172,6 +11236,20 @@
             "license": "MIT",
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/utf-8-validate": {
+            "version": "6.0.6",
+            "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
+            "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "node-gyp-build": "^4.3.0"
+            },
+            "engines": {
+                "node": ">=6.14.2"
             }
         },
         "node_modules/util": {
@@ -11394,7 +11472,6 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
             "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -11463,7 +11540,6 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/ExplorerFrontend/package.json
+++ b/ExplorerFrontend/package.json
@@ -84,7 +84,7 @@
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "cypress": "^13.4.0",
-        "eslint": "^10.2.0",
+        "eslint": "^10.4.0",
         "postcss": "^8.5.8",
         "tailwindcss": "^4.2.2",
         "ts-node": "^10.9.1",

--- a/ExplorerFrontend/package.json
+++ b/ExplorerFrontend/package.json
@@ -6,6 +6,7 @@
         "@ethereumjs/tx": "^5.1.0",
         "@headlessui/react": "^2.2.0",
         "@heroicons/react": "^2.0.18",
+        "@qrlwallet/connect": "^2.0.0",
         "@tailwindcss/postcss": "^4.2.2",
         "@tanstack/react-query": "^5.90.16",
         "@testing-library/jest-dom": "^6.6.3",


### PR DESCRIPTION
## Summary
- Final milestone of the M1→M5 contract verification sequence.
- New **Write** tab on verified contracts: pair MyQRLWallet (QR / deep-link), then sign and broadcast nonpayable/payable function calls. Wallet submits over the relay; the explorer never holds the signed payload.
- Built on the existing M3 \`ContractTabs\` scaffold, mirrors the M4 \`ReadContract\` UX, and uses the dApp-example's relay pattern verbatim.

## Files
- \`ExplorerFrontend/app/lib/qrlConnect.ts\` — module-level \`QRLConnect\` singleton (avoids double EIP-6963 announce + double session storage).
- \`ExplorerFrontend/app/components/ConnectButton.tsx\` — QR pair modal, status pill, disconnect, \`newConnection()\` reset, mobile deep-link.
- \`ExplorerFrontend/app/components/WriteContract.tsx\` — one collapsible card per state-changing ABI function, payable \`value\` field, EIP-1193 \`code: 4001\` surface, tx-hash link into the explorer.
- \`ExplorerFrontend/app/components/ContractTabs.tsx\` — Write tab now mounts \`<WriteContract />\` instead of the M3 placeholder.
- \`package.json\` / \`package-lock.json\` — adds \`@qrlwallet/connect ^2.0.0\`.

## Trust boundary
- Calldata is ABI-encoded client-side via \`@theqrl/web3-zond-abi\`.
- The explorer calls only \`qrl_sendTransaction\` through the wallet provider. No \`/contract/call\`-style proxy is involved on the write path.
- No backend changes in this PR.

## Test plan
- [ ] Pair MyQRLWallet via QR from a desktop browser; confirm the connected pill replaces the button.
- [ ] Refresh the page — pill stays (auto-reconnect from stored session).
- [ ] Open a verified contract with at least one \`nonpayable\` function. Expand it, fill arguments, click **Write** — wallet approval prompt appears; on approval, tx hash renders and links to \`/tx/:hash\`.
- [ ] \"Reject\" in the wallet — orange \"Request rejected in wallet\" banner appears.
- [ ] Try a \`payable\` function with a \`value\` of \"0.25\" — wallet shows the wei-equivalent.
- [ ] On mobile, tapping Connect Wallet jumps into MyQRLWallet via \`qrlconnect://\` deep link; on return, account pill shows.
- [ ] Unverified contract → Write tab shows the \"Verify this contract first\" notice.
- [ ] Verified contract with zero state-changing functions → shows the \"no state-changing functions\" notice.