### PR TITLE
fix(verifier): strip CBOR metadata trailer before bytecode match

### DIFF
--- a/backendAPI/verification/match.go
+++ b/backendAPI/verification/match.go
@@ -99,11 +99,16 @@ func FetchOnChainCode(ctx context.Context, address string) (string, error) {
 // on-chain runtime code, masking any `immutable`-backed byte ranges in
 // both before comparing.
 //
-// Per the M2.0 spike, Hyperion v0.0.2 does NOT emit a Solidity-style
-// CBOR metadata trailer, so there's no trailer to strip — the masked
-// bytes simply have to match exactly. If a future hypc build starts
-// emitting a trailer, extend this function with a strip step *before*
-// the length / equal compare.
+// Hyperion v0.0.2 emits a Solidity-style CBOR metadata trailer at the end
+// of the deployed bytecode (last 2 bytes = trailer length, preceding that
+// length is a CBOR map carrying the IPFS hash of source metadata + the
+// hypc build id). The trailer's IPFS hash mixes in the source file path
+// used at compile time, so a verifier that compiles via "Foo.hyp" cannot
+// recover the same hash as a deployer that compiled via "contract.hyp"
+// even when the source content is byte-identical. We strip the trailer
+// from both sides before comparing — the masking step that follows then
+// gives us a byte-equal compare of the code body, which is the security-
+// relevant payload.
 func Match(compiledHex, onChainHex string, immRefs map[string][]ImmutableRange) (MatchOutcome, error) {
 	compiledHex = strings.ToLower(strings.TrimPrefix(compiledHex, "0x"))
 	onChainHex = strings.ToLower(strings.TrimPrefix(onChainHex, "0x"))
@@ -128,6 +133,9 @@ func Match(compiledHex, onChainHex string, immRefs map[string][]ImmutableRange) 
 	if err != nil {
 		return out, fmt.Errorf("decode on-chain hex: %w", err)
 	}
+
+	cb = stripCBORTrailer(cb)
+	ob = stripCBORTrailer(ob)
 
 	immutablesCount := 0
 	for _, ranges := range immRefs {
@@ -189,4 +197,24 @@ func Match(compiledHex, onChainHex string, immRefs map[string][]ImmutableRange) 
 		}
 	}
 	return out, errors.New("byte slices unequal but no diff found")
+}
+
+// stripCBORTrailer removes the Solidity/Hyperion-style metadata trailer
+// from the end of deployed bytecode. The convention: the LAST 2 bytes are
+// a big-endian uint16 length of the preceding CBOR map; we strip those
+// length bytes + the map. Returns the input unchanged if the encoding
+// looks malformed (length too large, runaway), so corrupt input never
+// over-strips the code body.
+func stripCBORTrailer(b []byte) []byte {
+	if len(b) < 2 {
+		return b
+	}
+	cborLen := int(b[len(b)-2])<<8 | int(b[len(b)-1])
+	// Sanity: a real CBOR metadata blob is rarely more than ~100 bytes;
+	// cap at len-2 and ignore obviously-wrong values to avoid stripping
+	// the entire code on garbage tails.
+	if cborLen <= 0 || cborLen+2 > len(b) {
+		return b
+	}
+	return b[:len(b)-cborLen-2]
 }


### PR DESCRIPTION
## Summary
Hyperion v0.0.2 emits a Solidity-style CBOR metadata trailer at the end of deployed bytecode. The M2 comment in \`match.go\` claimed otherwise — empirical proof from a live testnet v2 deployment:

\`\`\`
qrl_getCode → ...8797063430000020033
                  ^^^^^^^^^ ^^^^
                  trailer   uint16 length (0x0033 = 51 B)
\`\`\`

The trailer's IPFS hash mixes in the source file path used at compile time. The verifier compiles under \`<ContractName>.hyp\`; many deployers will have compiled the same source under a different file key (\`contract.hyp\`, \`sources/Foo.hyp\`, …) and the CBOR hash diverges even when the source bytes are byte-identical. End result pre-fix: every cross-tooling deploy fails verification with \`diff@byte=~N-43\` — purely cosmetic mismatch in the trailer.

## Fix
\`stripCBORTrailer()\` reads the last 2 bytes as a big-endian uint16, strips that many bytes plus the length field, and bails on obviously-malformed encodings (length larger than the bytecode itself). Strips both compiled and on-chain sides before the existing length+masked equal compare. The security-relevant payload (the code body) still has to match exactly.

## E2E proof
- Deployed \`HelloZondscan\` (constructor takes a string) on testnet v2 via the funded operator seed: \`Qed2af55af7a492a6e504b364dd882159f9374f46\`.
- Pre-fix: \`POST /contract/verify\` → \`status: failed\`, \`error: bytecode mismatch (compiled=2280 B, on-chain=2280 B, diff@byte=2237)\` — i.e. the diff is exactly in the trailer region.
- Post-fix: \`POST /contract/verify\` → \`status: success\`. Public address API now returns \`verified: true\` with source + abi + compiler-version. Read tab successfully decodes \`greeting()\` → \"Hello from zondscan E2E\".

## Test plan
- [x] go build clean
- [x] Pre/post-fix re-verify against the same deployed contract
- [x] /contract/call still works after restart
- [x] Address page renders Verified badge + Code/Read tabs with the verified ABI

## Risk
- Stripping more than the trailer would mask a real difference. The length sanity check (\`cborLen+2 > len(b)\` bails) prevents the obvious failure mode; corrupt input passes through unchanged so the existing equal-compare still catches real differences.