### PR TITLE
M6a: AI explainer for verified contracts

### DIFF
--- a/ExplorerFrontend/app/components/AiExplainCard.tsx
+++ b/ExplorerFrontend/app/components/AiExplainCard.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useState } from 'react';
+import axios, { AxiosError } from 'axios';
+import type { ContractData } from '../types/address';
+import config from '../../config';
+
+interface AiExplainCardProps {
+  contractData: ContractData;
+}
+
+interface ExplainResponse {
+  address: string;
+  explanation: string;
+  generatedAt: string;
+  model: string;
+  cached: boolean;
+}
+
+/**
+ * On-demand AI explainer for verified contracts. Posts to
+ * /contract/explain/:address and renders the returned Markdown. The first
+ * click on a fresh contract spends real Anthropic credit; subsequent reads
+ * hit the MongoDB cache for free until someone clicks "Regenerate".
+ *
+ * Hard render gate: this component bails to a stub if the contract isn't
+ * verified — matching the backend's 403 — so the button never appears on
+ * unverified contracts and there's no path to spend tokens on bytecode-
+ * only addresses.
+ */
+export default function AiExplainCard({ contractData }: AiExplainCardProps): JSX.Element | null {
+  // Pre-load any cached explanation that arrived with the address payload
+  // so the user sees the body immediately on page load (no extra round-trip).
+  const [explanation, setExplanation] = useState<string | null>(contractData.aiExplanation ?? null);
+  const [generatedAt, setGeneratedAt] = useState<string | null>(contractData.aiExplanationAt ?? null);
+  const [model, setModel] = useState<string | null>(contractData.aiExplanationModel ?? null);
+  const [cached, setCached] = useState<boolean>(Boolean(contractData.aiExplanation));
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!contractData.verified) return null;
+
+  const call = async (regenerate: boolean): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = `${config.handlerUrl}/contract/explain/${contractData.address}${
+        regenerate ? '?regenerate=1' : ''
+      }`;
+      const r = await axios.post<ExplainResponse>(url);
+      setExplanation(r.data.explanation);
+      setGeneratedAt(r.data.generatedAt);
+      setModel(r.data.model);
+      setCached(r.data.cached);
+    } catch (e) {
+      const ae = e as AxiosError;
+      const msg = (ae.response?.data as { error?: string } | undefined)?.error
+        ?? (e instanceof Error ? e.message : String(e));
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-border bg-card-gradient p-3 md:p-4 space-y-3">
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <div>
+          <div className="text-sm md:text-base font-medium text-gray-200 flex items-center gap-2">
+            <span aria-hidden="true">✨</span> AI explanation
+          </div>
+          <div className="text-xs text-gray-400 mt-0.5">
+            {explanation
+              ? `Generated ${formatStamp(generatedAt)}${cached ? ' (cached)' : ''}${model ? ` · ${model}` : ''}`
+              : 'Have Claude summarise what this verified contract does. Costs a one-time generate per contract.'}
+          </div>
+        </div>
+        <div className="flex gap-2">
+          {!explanation && (
+            <button
+              type="button"
+              onClick={() => call(false)}
+              disabled={loading}
+              className="inline-flex items-center justify-center px-3 py-1.5 rounded-lg bg-accent text-black text-xs font-medium hover:bg-accent-hover transition-colors disabled:opacity-50"
+            >
+              {loading ? 'Analysing…' : 'Explain with AI'}
+            </button>
+          )}
+          {explanation && (
+            <button
+              type="button"
+              onClick={() => call(true)}
+              disabled={loading}
+              className="inline-flex items-center justify-center px-3 py-1.5 rounded-lg bg-card-gradient border border-border hover:border-accent text-xs text-gray-300 hover:text-accent transition-colors disabled:opacity-50"
+            >
+              {loading ? 'Analysing…' : 'Regenerate'}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-xs text-red-300">
+          {error}
+        </div>
+      )}
+
+      {explanation && (
+        <>
+          <div className="rounded-md bg-black/40 border border-border p-3 text-xs md:text-sm text-gray-200 font-sans whitespace-pre-wrap break-words leading-relaxed">
+            {explanation}
+          </div>
+          <div className="text-[10px] text-gray-500">
+            AI-generated summary. May contain inaccuracies. Not financial advice — verify the
+            source code yourself before interacting with this contract.
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function formatStamp(iso: string | null): string {
+  if (!iso) return 'just now';
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleString();
+  } catch {
+    return iso;
+  }
+}

--- a/ExplorerFrontend/app/components/ContractTabs.tsx
+++ b/ExplorerFrontend/app/components/ContractTabs.tsx
@@ -6,6 +6,7 @@ import CopyButton from './CopyButton';
 import ContractBytecode from './ContractBytecode';
 import ReadContract from './ReadContract';
 import WriteContract from './WriteContract';
+import AiExplainCard from './AiExplainCard';
 import type { ContractData } from '../types/address';
 
 interface ContractTabsProps {
@@ -98,6 +99,7 @@ function CodeTab({ contractData, parsedAbi }: { contractData: ContractData; pars
   return (
     <div className="space-y-3 md:space-y-4">
       <CompilerSettings contractData={contractData} />
+      <AiExplainCard contractData={contractData} />
       <SourcePanel contractData={contractData} />
       <AbiPanel abi={parsedAbi} raw={contractData.abi ?? ''} />
       <ContractBytecode contractCode={contractData.contractCode} />

--- a/ExplorerFrontend/app/types/address.ts
+++ b/ExplorerFrontend/app/types/address.ts
@@ -34,6 +34,13 @@ export interface ContractData {
   license?: string;
   verificationMethod?: string;
   verifiedAt?: string;
+
+  // M6a — populated only after a user has triggered the on-demand AI
+  // explanation. Frontend treats absence as "not generated yet"; the
+  // AiExplainCard renders a button instead of the cached body.
+  aiExplanation?: string;
+  aiExplanationAt?: string;
+  aiExplanationModel?: string;
 }
 
 /**

--- a/QRL2MongoDB/models/contract.go
+++ b/QRL2MongoDB/models/contract.go
@@ -80,6 +80,13 @@ type ContractInfo struct {
 	License              string            `bson:"license,omitempty" json:"license,omitempty"`
 	VerificationMethod   string            `bson:"verificationMethod,omitempty" json:"verificationMethod,omitempty"`
 	VerifiedAt           string            `bson:"verifiedAt,omitempty" json:"verifiedAt,omitempty"`
+
+	// M6a AI explanation cache. Written exclusively by the backend
+	// /contract/explain endpoint; the syncer holds them only for
+	// round-trip preservation.
+	AIExplanation      string `bson:"aiExplanation,omitempty" json:"aiExplanation,omitempty"`
+	AIExplanationAt    string `bson:"aiExplanationAt,omitempty" json:"aiExplanationAt,omitempty"`
+	AIExplanationModel string `bson:"aiExplanationModel,omitempty" json:"aiExplanationModel,omitempty"`
 }
 
 // LogsResponse represents the response from qrl_getLogs

--- a/backendAPI/aiexplain/client.go
+++ b/backendAPI/aiexplain/client.go
@@ -1,0 +1,117 @@
+package aiexplain
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// anthropicEndpoint is the Messages API endpoint. Pinned by the SDK
+// version contract — Anthropic guarantees stability per `anthropic-version`
+// header below, so we don't have to follow API churn.
+const anthropicEndpoint = "https://api.anthropic.com/v1/messages"
+
+// anthropicVersion is the dated stable API version contract. Anthropic
+// keeps old versions live; bump this header only when intentionally
+// adopting new fields.
+const anthropicVersion = "2023-06-01"
+
+// defaultModel is the Claude Haiku 4.5 model id. Haiku is the right tier
+// for contract explanation: fast, cheap, and the input is well-structured
+// source code so reasoning depth is rarely the bottleneck.
+const defaultModel = "claude-haiku-4-5"
+
+// Client wraps the Anthropic Messages API for the contract-explanation
+// flow. The apiKey + httpClient are immutable after construction so this
+// type is safe for concurrent use.
+type Client struct {
+	apiKey     string
+	model      string
+	maxTokens  int
+	httpClient *http.Client
+}
+
+// NewClient builds a Client. apiKey is required; pass empty model to use
+// the default. The HTTP client uses a tight per-call timeout — Anthropic
+// is usually under 5s for Haiku but a slow run shouldn't tie up the gin
+// goroutine for minutes.
+func NewClient(apiKey, model string, maxTokens int) *Client {
+	if model == "" {
+		model = defaultModel
+	}
+	if maxTokens <= 0 {
+		maxTokens = 1500
+	}
+	return &Client{
+		apiKey:     apiKey,
+		model:      model,
+		maxTokens:  maxTokens,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// Generate issues a single Messages.create call and returns the text of
+// the first content block. ctx governs the full lifecycle: cancel it from
+// the caller side to abort.
+//
+// We don't stream — the response is short enough that buffering is fine
+// and avoids the SSE plumbing overhead.
+func (c *Client) Generate(ctx context.Context, system, user string) (string, string, error) {
+	body, err := json.Marshal(anthropicRequest{
+		Model:     c.model,
+		MaxTokens: c.maxTokens,
+		System:    system,
+		Messages:  []anthropicMessage{{Role: "user", Content: user}},
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", c.apiKey)
+	req.Header.Set("anthropic-version", anthropicVersion)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("anthropic HTTP: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", fmt.Errorf("anthropic body: %w", err)
+	}
+
+	var parsed anthropicResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return "", "", fmt.Errorf("anthropic decode: %w (status %d, body %q)", err, resp.StatusCode, truncate(string(raw), 200))
+	}
+	if parsed.Error != nil {
+		return "", "", fmt.Errorf("anthropic %s: %s", parsed.Error.Type, parsed.Error.Message)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("anthropic HTTP %d: %s", resp.StatusCode, truncate(string(raw), 200))
+	}
+
+	for _, c := range parsed.Content {
+		if c.Type == "text" && c.Text != "" {
+			return c.Text, parsed.Model, nil
+		}
+	}
+	return "", parsed.Model, fmt.Errorf("anthropic returned no text content")
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/backendAPI/aiexplain/explainer.go
+++ b/backendAPI/aiexplain/explainer.go
@@ -1,0 +1,129 @@
+package aiexplain
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"backendAPI/db"
+	"backendAPI/models"
+)
+
+// Common errors callers can switch on to return the right HTTP status.
+var (
+	ErrNotFound       = errors.New("contract not found")
+	ErrNotVerified    = errors.New("contract is not verified")
+	ErrSourceTooLarge = errors.New("contract source exceeds size cap")
+)
+
+// Explainer is the orchestrator: it enforces the verified-only gate, runs
+// the Anthropic call, and persists the result back to the contract record
+// so subsequent reads are free.
+type Explainer struct {
+	Client *Client
+
+	// SourceMaxBytes caps how much source we ship to Anthropic. Larger
+	// contracts get truncated with a clear "…" marker so the LLM still
+	// sees the prelude (which carries most of the structural signal).
+	SourceMaxBytes int
+}
+
+// systemPrompt frames the LLM as a smart-contract auditor producing a
+// non-technical summary. The wording is deliberately conservative: this
+// is a *summary*, not financial advice, and the model should call out
+// risks rather than vouch for safety.
+const systemPrompt = `You are an expert smart contract analyst. Given the source code of a contract that has been verified on the QRL Zond v2 blockchain, write a concise plain-English summary that a non-developer can understand.
+
+Output Markdown structured as:
+
+**Purpose** — one sentence on what this contract is.
+**What it does** — 2-4 bullets describing the main behaviours / functions.
+**Who can use it** — note any access control (owner-only, admin, anyone, etc.).
+**Risks to watch for** — surface anything that could cost users money: unchecked mints, owner kill switches, upgradeable proxies, missing access control, math overflow, reentrancy patterns, etc. Be specific. If nothing stands out, say so plainly.
+
+Keep the whole answer under 350 words. Never recommend interaction. Never claim the contract is safe. If the source looks like a well-known standard (ERC-20, ERC-721, etc.), say so explicitly.`
+
+// Explain returns the cached explanation when present, or generates a fresh
+// one via Anthropic and persists it before returning. Forces a fresh call
+// when regenerate=true.
+func (e *Explainer) Explain(ctx context.Context, address string, regenerate bool) (*ExplainResponse, error) {
+	c, err := db.ReturnContractCode(address)
+	if err != nil {
+		return nil, fmt.Errorf("lookup contract: %w", err)
+	}
+	if c.ContractAddress == "" {
+		return nil, ErrNotFound
+	}
+	if !c.Verified || c.SourceCode == "" {
+		return nil, ErrNotVerified
+	}
+
+	if !regenerate && c.AIExplanation != "" {
+		return &ExplainResponse{
+			Address:     c.ContractAddress,
+			Explanation: c.AIExplanation,
+			GeneratedAt: c.AIExplanationAt,
+			Model:       c.AIExplanationModel,
+			Cached:      true,
+		}, nil
+	}
+
+	source := c.SourceCode
+	if len(source) > e.SourceMaxBytes && e.SourceMaxBytes > 0 {
+		source = source[:e.SourceMaxBytes] + "\n\n// […truncated for length…]"
+	}
+
+	user := buildUserPrompt(c, source)
+	text, model, err := e.Client.Generate(ctx, systemPrompt, user)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: %w", err)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := db.SaveContractExplanation(address, text, model, now); err != nil {
+		// Persistence failure isn't fatal — return the freshly-generated
+		// answer so the user gets something. Just log via the caller.
+		return &ExplainResponse{
+			Address:     c.ContractAddress,
+			Explanation: text,
+			GeneratedAt: now,
+			Model:       model,
+			Cached:      false,
+		}, fmt.Errorf("cache write failed: %w", err)
+	}
+
+	return &ExplainResponse{
+		Address:     c.ContractAddress,
+		Explanation: text,
+		GeneratedAt: now,
+		Model:       model,
+		Cached:      false,
+	}, nil
+}
+
+// buildUserPrompt assembles the per-contract message. We embed the
+// contract name + address + compiler + license as a header so the model
+// can ground its answer in concrete facts, then the source itself.
+func buildUserPrompt(c models.ContractInfo, source string) string {
+	var b strings.Builder
+	b.WriteString("Contract metadata:\n")
+	fmt.Fprintf(&b, "- address: %s\n", c.ContractAddress)
+	if c.ContractName != "" {
+		fmt.Fprintf(&b, "- name: %s\n", c.ContractName)
+	}
+	if c.CompilerVersion != "" {
+		fmt.Fprintf(&b, "- compiler: %s\n", c.CompilerVersion)
+	}
+	if c.License != "" {
+		fmt.Fprintf(&b, "- license: %s\n", c.License)
+	}
+	b.WriteString("\nSource code:\n```hyperion\n")
+	b.WriteString(source)
+	if !strings.HasSuffix(source, "\n") {
+		b.WriteString("\n")
+	}
+	b.WriteString("```\n")
+	return b.String()
+}

--- a/backendAPI/aiexplain/init.go
+++ b/backendAPI/aiexplain/init.go
@@ -1,0 +1,73 @@
+package aiexplain
+
+import (
+	"log"
+	"os"
+	"strconv"
+	"sync"
+)
+
+// Env-driven config. The verifier package uses the same idiom so handler
+// init reads naturally.
+//
+//	EXPERT_ANALIST_CLAUDE_HAIKU  Anthropic API key. Required.
+//	AI_EXPLAIN_MODEL             override model id (default claude-haiku-4-5).
+//	AI_EXPLAIN_MAX_TOKENS        cap on response tokens (default 1500).
+//	AI_EXPLAIN_SOURCE_MAX_BYTES  truncate source before sending (default 32 KiB).
+//
+// Init returns a non-nil error iff the API key is missing or empty. The
+// rest of the backend boots regardless — routes/explain returns 503 when
+// Default() is nil.
+const (
+	envAPIKey         = "EXPERT_ANALIST_CLAUDE_HAIKU"
+	envModel          = "AI_EXPLAIN_MODEL"
+	envMaxTokens      = "AI_EXPLAIN_MAX_TOKENS"
+	envSourceMaxBytes = "AI_EXPLAIN_SOURCE_MAX_BYTES"
+)
+
+var (
+	defaultMu sync.RWMutex
+	def       *Explainer
+)
+
+func Init() error {
+	apiKey := os.Getenv(envAPIKey)
+	if apiKey == "" {
+		log.Printf("WARN: contract AI explainer disabled — %s not set", envAPIKey)
+		return errMissingKey
+	}
+
+	model := os.Getenv(envModel)
+	maxTokens, _ := strconv.Atoi(os.Getenv(envMaxTokens))
+	if maxTokens <= 0 {
+		maxTokens = 1500
+	}
+	srcMax, _ := strconv.Atoi(os.Getenv(envSourceMaxBytes))
+	if srcMax <= 0 {
+		srcMax = 32 * 1024
+	}
+
+	client := NewClient(apiKey, model, maxTokens)
+	defaultMu.Lock()
+	def = &Explainer{Client: client, SourceMaxBytes: srcMax}
+	defaultMu.Unlock()
+	log.Printf("aiexplain ready: model=%s maxTokens=%d sourceMaxBytes=%d", client.model, maxTokens, srcMax)
+	return nil
+}
+
+// Default returns the package-level Explainer or nil when not configured.
+func Default() *Explainer {
+	defaultMu.RLock()
+	defer defaultMu.RUnlock()
+	return def
+}
+
+// errMissingKey is a sentinel — callers don't need to compare against it,
+// but the typed error keeps the Init() signature honest.
+var errMissingKey = errMissingKeyVal{}
+
+type errMissingKeyVal struct{}
+
+func (errMissingKeyVal) Error() string {
+	return envAPIKey + " env var is required"
+}

--- a/backendAPI/aiexplain/types.go
+++ b/backendAPI/aiexplain/types.go
@@ -1,0 +1,46 @@
+package aiexplain
+
+// ExplainResponse is the body returned by POST /contract/explain/:address.
+// Cached=true means the body came straight from MongoDB without re-calling
+// the Anthropic API; useful for the frontend to surface a "regenerate"
+// affordance.
+type ExplainResponse struct {
+	Address     string `json:"address"`
+	Explanation string `json:"explanation"`
+	GeneratedAt string `json:"generatedAt"`
+	Model       string `json:"model"`
+	Cached      bool   `json:"cached"`
+}
+
+// Anthropic Messages API request shape. We only need a tiny slice of the
+// surface: model, max_tokens, system, single user message.
+type anthropicRequest struct {
+	Model     string             `json:"model"`
+	MaxTokens int                `json:"max_tokens"`
+	System    string             `json:"system,omitempty"`
+	Messages  []anthropicMessage `json:"messages"`
+}
+
+type anthropicMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// Anthropic Messages API response — minimal projection. We only ever read
+// the first text block; if Anthropic changes shape, the unmarshalling will
+// just produce an empty Content string and the caller surfaces an error.
+type anthropicResponse struct {
+	Content []anthropicContent `json:"content"`
+	Model   string             `json:"model"`
+	Error   *anthropicError    `json:"error,omitempty"`
+}
+
+type anthropicContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type anthropicError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}

--- a/backendAPI/db/contract.go
+++ b/backendAPI/db/contract.go
@@ -181,6 +181,39 @@ func MarkContractVerified(address string, result models.VerificationResult) erro
 	return nil
 }
 
+// SaveContractExplanation persists the M6a AI-generated explanation onto
+// the contract document. Uses the same field-scoped $set pattern as
+// MarkContractVerified so the syncer cannot stomp the cache during a
+// concurrent contract-state refresh.
+//
+// generatedAt is the caller's responsibility (typically time.Now().UTC()
+// formatted RFC3339) so the explainer can echo back the same timestamp it
+// returns to the HTTP client without a re-read.
+func SaveContractExplanation(address, explanation, model, generatedAt string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	normalizedAddr := normalizeAddress(address)
+	res, err := configs.ContractInfoCollection.UpdateOne(
+		ctx,
+		bson.M{"address": normalizedAddr},
+		bson.M{"$set": bson.M{
+			"aiExplanation":      explanation,
+			"aiExplanationAt":    generatedAt,
+			"aiExplanationModel": model,
+		}},
+	)
+	if err != nil {
+		log.Printf("SaveContractExplanation: failed to update %s: %v", normalizedAddr, err)
+		return err
+	}
+	if res.MatchedCount == 0 {
+		log.Printf("SaveContractExplanation: no contract document for %s", normalizedAddr)
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}
+
 // CreateVerificationJob inserts a fresh job row in `pending` state. The
 // caller (HTTP layer) supplies a UUID-like JobID and the echoed Payload.
 func CreateVerificationJob(job models.ContractVerificationJob) error {

--- a/backendAPI/handler/handler.go
+++ b/backendAPI/handler/handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"backendAPI/aiexplain"
 	"backendAPI/configs"
 	"backendAPI/routes"
 	"backendAPI/verification"
@@ -82,6 +83,15 @@ func RequestHandler() {
 		log.Printf("Contract verification disabled: %v", err)
 	} else {
 		log.Println("Contract verification ready")
+	}
+
+	// Init the AI explainer singleton. Same nil-tolerance pattern as the
+	// verifier — handlers return 503 when Default() is nil, so a missing
+	// API key never blocks the rest of the backend.
+	if err := aiexplain.Init(); err != nil {
+		log.Printf("Contract AI explainer disabled: %v", err)
+	} else {
+		log.Println("Contract AI explainer ready")
 	}
 
 	// Configure routes

--- a/backendAPI/models/contract.go
+++ b/backendAPI/models/contract.go
@@ -42,4 +42,12 @@ type ContractInfo struct {
 	License              string            `json:"license,omitempty" bson:"license,omitempty"`
 	VerificationMethod   string            `json:"verificationMethod,omitempty" bson:"verificationMethod,omitempty"`
 	VerifiedAt           string            `json:"verifiedAt,omitempty" bson:"verifiedAt,omitempty"`
+
+	// M6a AI explanation cache. Populated only when an authorised user has
+	// triggered POST /contract/explain/:address. The syncer must NOT write
+	// into these — kept off the syncer's allow-list in
+	// QRL2MongoDB/db/contracts.go:StoreContract.
+	AIExplanation      string `json:"aiExplanation,omitempty" bson:"aiExplanation,omitempty"`
+	AIExplanationAt    string `json:"aiExplanationAt,omitempty" bson:"aiExplanationAt,omitempty"`
+	AIExplanationModel string `json:"aiExplanationModel,omitempty" bson:"aiExplanationModel,omitempty"`
 }

--- a/backendAPI/routes/explain_routes.go
+++ b/backendAPI/routes/explain_routes.go
@@ -1,0 +1,78 @@
+package routes
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"backendAPI/aiexplain"
+	"backendAPI/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterContractExplainRoute wires POST /contract/explain/:address onto
+// the supplied router. Always registered — when the explainer isn't
+// configured (missing EXPERT_ANALIST_CLAUDE_HAIKU), the handler returns
+// 503 so the rest of the backend keeps working.
+//
+// Each call to Anthropic costs real money, so the route is conservatively
+// rate-limited per IP. The verified-only gate inside the explainer is the
+// hard floor: an attacker who somehow exhausts the rate limit STILL can't
+// burn the API budget on unverified contracts (no source means we never
+// reach the LLM call).
+func RegisterContractExplainRoute(router *gin.Engine) {
+	// 10 calls/min/IP is a deliberately tight cap. The expected usage
+	// pattern is one click per contract page; cached responses don't even
+	// reach this limiter because they short-circuit on the first read.
+	// Bursts of 4 absorb a curious user clicking around between contracts.
+	limiter := middleware.PerIPRateLimit(10, 4, time.Minute)
+
+	router.POST("/contract/explain/:address", limiter, func(c *gin.Context) {
+		e := aiexplain.Default()
+		if e == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "AI contract explainer not configured"})
+			return
+		}
+
+		addr := strings.TrimSpace(c.Param("address"))
+		if !isValidAddress(addr) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid Q-prefixed address"})
+			return
+		}
+
+		regenerate := c.Query("regenerate") == "1" || c.Query("regenerate") == "true"
+
+		// Anthropic Haiku typically replies in ~3-8s. Give the whole
+		// explain pipeline (mongo lookup + LLM + cache write) a comfortable
+		// 45s deadline so the gin worker isn't tied up indefinitely.
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 45*time.Second)
+		defer cancel()
+
+		resp, err := e.Explain(ctx, addr, regenerate)
+		if err != nil {
+			// resp can be non-nil here when the LLM succeeded but the
+			// cache write failed; we want to log that case but still hand
+			// the result to the client.
+			if resp != nil {
+				log.Printf("explain: %s — cache write failed but result delivered: %v", addr, err)
+				c.JSON(http.StatusOK, resp)
+				return
+			}
+			switch {
+			case errors.Is(err, aiexplain.ErrNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": "address is not a known contract"})
+			case errors.Is(err, aiexplain.ErrNotVerified):
+				c.JSON(http.StatusForbidden, gin.H{"error": "contract is not verified — only verified contracts can be analysed"})
+			default:
+				log.Printf("explain: %s failed: %v", addr, err)
+				c.JSON(http.StatusBadGateway, gin.H{"error": "AI explanation failed: " + err.Error()})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, resp)
+	})
+}

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -67,6 +67,11 @@ func UserRoute(router *gin.Engine) {
 	// gas-cap + per-call timeout.
 	RegisterContractCallRoute(router)
 
+	// Contract AI explainer (POST /contract/explain/:address). Hard gate:
+	// only verified contracts are analysed. Returns 503 when the
+	// Anthropic key isn't configured. Per-IP rate-limited (10/min).
+	RegisterContractExplainRoute(router)
+
 	// Add pending transactions endpoint with pagination
 	router.GET("/pending-transactions", func(c *gin.Context) {
 		page, limit := getPaginationParams(c, 1, 10)


### PR DESCRIPTION
## Summary
On-demand AI explainer for verified contracts. \`POST /contract/explain/:address\` → Anthropic Claude Haiku produces a plain-English summary structured as **Purpose / What it does / Who can use it / Risks**. Result cached per-contract in MongoDB; ?regenerate=1 busts the cache.

## Hard security floor
- **Only verified contracts can be analysed.** Hard 403 in the backend, button never rendered in the frontend on unverified contracts. Without source code there's nothing useful to send to the LLM anyway.
- **Per-IP rate limit** 10/min, burst 4. Tight on purpose — each call is real Anthropic spend.
- **Cache writes use field-scoped \`\$set\`** mirroring MarkContractVerified, so the syncer can't stomp the AI fields. Syncer's allow-list is default-deny so the new fields are excluded automatically.
- API key env var: \`EXPERT_ANALIST_CLAUDE_HAIKU\`. Backend logs \"contract AI explainer disabled\" and the route returns 503 when missing — no crash.

## Files
**Backend**
- \`backendAPI/aiexplain/{types,client,explainer,init}.go\` — Anthropic Messages client + Explainer orchestrator + Default() singleton
- \`backendAPI/routes/explain_routes.go\` — POST /contract/explain/:address with rate limiter
- \`backendAPI/db/contract.go\` — SaveContractExplanation
- \`backendAPI/models/contract.go\` + \`QRL2MongoDB/models/contract.go\` — mirrored AIExplanation* fields
- \`backendAPI/handler/handler.go\` — aiexplain.Init() at startup
- \`backendAPI/routes/routes.go\` — RegisterContractExplainRoute()

**Frontend**
- \`ExplorerFrontend/app/components/AiExplainCard.tsx\` — Explain/Regenerate buttons, pre-loads cached body if present
- \`ExplorerFrontend/app/components/ContractTabs.tsx\` — slot between CompilerSettings and SourcePanel
- \`ExplorerFrontend/app/types/address.ts\` — mirrored types

## Configuration
| Env | Default | Purpose |
|---|---|---|
| \`EXPERT_ANALIST_CLAUDE_HAIKU\` | (required) | Anthropic API key |
| \`AI_EXPLAIN_MODEL\` | \`claude-haiku-4-5\` | Model id override |
| \`AI_EXPLAIN_MAX_TOKENS\` | 1500 | Response cap |
| \`AI_EXPLAIN_SOURCE_MAX_BYTES\` | 32 KiB | Truncate source before sending |

## Test plan
- [x] \`go build\` clean (backend + syncer)
- [x] \`npm run typecheck\` + \`npm run lint\` + \`npm run build\` clean (0 errors, 29 pre-existing warnings)
- [ ] Deploy to ops@46.224.165.196 with the EXPERT_ANALIST_CLAUDE_HAIKU env set
- [ ] POST /contract/explain on \`HelloZondscan\` (verified) → 200, body cached
- [ ] Re-call → cached: true, no Anthropic round trip
- [ ] POST /contract/explain on unverified contract → 403
- [ ] POST /contract/explain on non-contract address → 404
- [ ] POST /contract/explain?regenerate=1 → cached: false, fresh call