### PR TITLE
ai-explain: shorter neutral prompt + 5/week regen cap + owner UX gate

### DIFF
--- a/ExplorerFrontend/app/api-explorer/api-explorer-client.tsx
+++ b/ExplorerFrontend/app/api-explorer/api-explorer-client.tsx
@@ -227,6 +227,49 @@ const endpointGroups: EndpointGroup[] = [
       },
     ],
   },
+  {
+    category: 'Contract Verification (M1-M3)',
+    endpoints: [
+      {
+        method: 'GET',
+        path: '/contract/compiler-info',
+        description: 'Returns the language and pinned Hyperion build id the verifier is willing to accept. Use this to confirm the explorer can verify against your hypc version before you POST a job. Returns 503 when the verifier is not configured on this deployment.',
+        example: '/contract/compiler-info',
+      },
+      {
+        method: 'POST',
+        path: '/contract/verify',
+        description: 'Enqueues a verification job for a deployed contract. The endpoint compiles the supplied source via the pinned hypc runner, compares the deployed-bytecode (Solidity-style CBOR metadata trailer stripped on both sides) and on success writes the verified source + ABI back onto the contract document. Body: { address, sourceCode, contractName, compilerVersion?, optimizerEnabled, optimizerRuns, evmVersion?, constructorArguments?, libraries?, imports?, license? }. Rate-limited per IP. Max body 1 MiB. Returns { jobId, status, address } synchronously; poll /contract/verify/:jobId for the terminal state.',
+        params: 'JSON body (see description) — address + sourceCode + contractName are required',
+        example: 'POST /contract/verify  body: {"address":"Q…","sourceCode":"...","contractName":"Foo"}',
+      },
+      {
+        method: 'GET',
+        path: '/contract/verify/:jobId',
+        description: 'Returns the current state of a verification job. Status values: pending, compiling, success, failed. The body echoes the original submission payload (sans the standard-JSON wrapper) and, on success, includes a result reference with the ABI and verifiedAt stamp.',
+        example: '/contract/verify/27fcbb55ffb611ec',
+      },
+    ],
+  },
+  {
+    category: 'Contract Interaction (M4-M6)',
+    endpoints: [
+      {
+        method: 'POST',
+        path: '/contract/call',
+        description: 'Open-but-bounded eth_call proxy for read-only contract reads. The body is forwarded as a qrl_call to the node with a hard gas cap, data-size cap and per-call timeout. The `to` address must be a known contract in the indexer (404 otherwise) so non-contract reads cannot be proxied. Body: { to, data }. Returns { result } on success or { error, code, reverted: true } on RPC errors (HTTP 200 in both branches, distinguish via fields). Per-IP rate-limited (60/min).',
+        params: 'JSON body: to (Q-address, required), data (0x-prefixed even-length hex, required, max 8 KiB)',
+        example: 'POST /contract/call  body: {"to":"Qed2af...","data":"0xef690cc0"}',
+      },
+      {
+        method: 'POST',
+        path: '/contract/explain/:address',
+        description: 'On-demand AI summary of a VERIFIED contract’s source code (Claude Haiku). The summary is cached per-contract in the contractCode collection (fields aiExplanation / aiExplanationAt / aiExplanationModel) so subsequent reads are free until ?regenerate=1 busts the cache. Returns 403 if the address is not a verified contract — only verified contracts can be analysed.',
+        params: 'regenerate (query, optional) - "1" or "true" to force a fresh LLM call',
+        example: 'POST /contract/explain/Qed2af55af7a492a6e504b364dd882159f9374f46',
+      },
+    ],
+  },
 ]
 
 const BASE_URL = 'https://zondscan.com/api'

--- a/ExplorerFrontend/app/components/AiExplainCard.tsx
+++ b/ExplorerFrontend/app/components/AiExplainCard.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import axios, { AxiosError } from 'axios';
 import type { ContractData } from '../types/address';
+import { getQrlConnect } from '../lib/qrlConnect';
 import config from '../../config';
 
 interface AiExplainCardProps {
@@ -37,6 +38,36 @@ export default function AiExplainCard({ contractData }: AiExplainCardProps): JSX
   const [cached, setCached] = useState<boolean>(Boolean(contractData.aiExplanation));
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Owner-only regen gate. Lazily snapshots any stored wallet session at
+  // mount and updates when the wallet's accountsChanged event fires.
+  const [isOwner, setIsOwner] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const creator = (contractData.creatorAddress ?? '').toLowerCase();
+    if (!creator) return;
+    let qrl;
+    try {
+      qrl = getQrlConnect();
+    } catch {
+      // SSR path or environment without window.crypto.
+      return;
+    }
+    const check = (): void => {
+      const acc = qrl.getAccounts()[0] ?? '';
+      setIsOwner(acc.toLowerCase() === creator);
+    };
+    check();
+    const onChange = (): void => check();
+    qrl.on('accountsChanged', onChange);
+    qrl.on('connect', onChange);
+    qrl.on('disconnect', onChange);
+    return () => {
+      qrl.off('accountsChanged', onChange);
+      qrl.off('connect', onChange);
+      qrl.off('disconnect', onChange);
+    };
+  }, [contractData.creatorAddress]);
 
   if (!contractData.verified) return null;
 
@@ -86,15 +117,21 @@ export default function AiExplainCard({ contractData }: AiExplainCardProps): JSX
               {loading ? 'Analysing…' : 'Explain with AI'}
             </button>
           )}
-          {explanation && (
+          {explanation && isOwner && (
             <button
               type="button"
               onClick={() => call(true)}
               disabled={loading}
               className="inline-flex items-center justify-center px-3 py-1.5 rounded-lg bg-card-gradient border border-border hover:border-accent text-xs text-gray-300 hover:text-accent transition-colors disabled:opacity-50"
+              title="Regenerate (limited to 5 per 7-day window)"
             >
               {loading ? 'Analysing…' : 'Regenerate'}
             </button>
+          )}
+          {explanation && !isOwner && (
+            <span className="text-[10px] text-gray-500 self-center">
+              Only the contract creator can regenerate.
+            </span>
           )}
         </div>
       </div>

--- a/QRL2MongoDB/models/contract.go
+++ b/QRL2MongoDB/models/contract.go
@@ -87,6 +87,9 @@ type ContractInfo struct {
 	AIExplanation      string `bson:"aiExplanation,omitempty" json:"aiExplanation,omitempty"`
 	AIExplanationAt    string `bson:"aiExplanationAt,omitempty" json:"aiExplanationAt,omitempty"`
 	AIExplanationModel string `bson:"aiExplanationModel,omitempty" json:"aiExplanationModel,omitempty"`
+
+	AIExplanationRegenCount       int    `bson:"aiExplanationRegenCount,omitempty" json:"aiExplanationRegenCount,omitempty"`
+	AIExplanationRegenWindowStart string `bson:"aiExplanationRegenWindowStart,omitempty" json:"aiExplanationRegenWindowStart,omitempty"`
 }
 
 // LogsResponse represents the response from qrl_getLogs

--- a/backendAPI/aiexplain/client.go
+++ b/backendAPI/aiexplain/client.go
@@ -101,17 +101,21 @@ func (c *Client) Generate(ctx context.Context, system, user string) (string, str
 		return "", "", fmt.Errorf("anthropic HTTP %d: %s", resp.StatusCode, truncate(string(raw), 200))
 	}
 
-	for _, c := range parsed.Content {
-		if c.Type == "text" && c.Text != "" {
-			return c.Text, parsed.Model, nil
+	for _, block := range parsed.Content {
+		if block.Type == "text" && block.Text != "" {
+			return block.Text, parsed.Model, nil
 		}
 	}
 	return "", parsed.Model, fmt.Errorf("anthropic returned no text content")
 }
 
+// truncate caps the displayed length of a log message safely against
+// multi-byte UTF-8 input — slicing a string by byte index could split a
+// codepoint and produce invalid UTF-8 in logs.
 func truncate(s string, n int) string {
-	if len(s) <= n {
+	runes := []rune(s)
+	if len(runes) <= n {
 		return s
 	}
-	return s[:n] + "…"
+	return string(runes[:n]) + "…"
 }

--- a/backendAPI/aiexplain/explainer.go
+++ b/backendAPI/aiexplain/explainer.go
@@ -16,6 +16,17 @@ var (
 	ErrNotFound       = errors.New("contract not found")
 	ErrNotVerified    = errors.New("contract is not verified")
 	ErrSourceTooLarge = errors.New("contract source exceeds size cap")
+	ErrRegenCap       = errors.New("regeneration cap reached")
+)
+
+// RegenLimitPerWindow is the hard cap on regenerations per contract per
+// rolling 7-day window. Initial generations don't count; only ?regenerate=1
+// calls consume slots. Combined with the cache (subsequent reads short-
+// circuit to MongoDB) this bounds the Anthropic spend per contract to
+// 5 calls per week regardless of how often the page is hit.
+const (
+	RegenLimitPerWindow = 5
+	RegenWindow         = 7 * 24 * time.Hour
 )
 
 // Explainer is the orchestrator: it enforces the verified-only gate, runs
@@ -30,20 +41,19 @@ type Explainer struct {
 	SourceMaxBytes int
 }
 
-// systemPrompt frames the LLM as a smart-contract auditor producing a
-// non-technical summary. The wording is deliberately conservative: this
-// is a *summary*, not financial advice, and the model should call out
-// risks rather than vouch for safety.
-const systemPrompt = `You are an expert smart contract analyst. Given the source code of a contract that has been verified on the QRL Zond v2 blockchain, write a concise plain-English summary that a non-developer can understand.
+// systemPrompt frames the LLM as a neutral describer. No safety analysis,
+// no implementation feedback, no opinions — just factual observations
+// about what the contract is and what it does. The summary is intentionally
+// short so it complements rather than competes with the source / ABI panels.
+const systemPrompt = `You are summarising a verified smart contract on the QRL Zond v2 blockchain. Produce a short factual description of what the contract is. Do NOT include opinions, safety analysis, risk assessments, recommendations, access-control discussion, or implementation feedback. Just neutral observations.
 
-Output Markdown structured as:
+Output Markdown with only these sections:
 
-**Purpose** — one sentence on what this contract is.
-**What it does** — 2-4 bullets describing the main behaviours / functions.
-**Who can use it** — note any access control (owner-only, admin, anyone, etc.).
-**Risks to watch for** — surface anything that could cost users money: unchecked mints, owner kill switches, upgradeable proxies, missing access control, math overflow, reentrancy patterns, etc. Be specific. If nothing stands out, say so plainly.
+**Purpose** — one sentence describing what this contract is.
+**What it does** — 2-4 short bullets, descriptive and factual only.
+**Standard** — only when the contract clearly matches a well-known token standard (ERC-20, ERC-721, ERC-1155, etc.); name the standard. Omit this section otherwise.
 
-Keep the whole answer under 350 words. Never recommend interaction. Never claim the contract is safe. If the source looks like a well-known standard (ERC-20, ERC-721, etc.), say so explicitly.`
+Keep the entire answer under 150 words. Never add sections on risks, security, access control, audit notes, or implementation quality.`
 
 // Explain returns the cached explanation when present, or generates a fresh
 // one via Anthropic and persists it before returning. Forces a fresh call
@@ -68,6 +78,20 @@ func (e *Explainer) Explain(ctx context.Context, address string, regenerate bool
 			Model:       c.AIExplanationModel,
 			Cached:      true,
 		}, nil
+	}
+
+	// Regen path: reserve a slot atomically before spending Anthropic
+	// credit. ReserveRegenSlot returns ErrRegenCap when the rolling 7-day
+	// cap is hit; we surface that as a typed error the HTTP layer maps to
+	// 429. Initial generations skip this check — only regenerate=true
+	// passes through here.
+	if regenerate {
+		if err := db.ReserveAIRegenSlot(address, RegenLimitPerWindow, RegenWindow); err != nil {
+			if errors.Is(err, db.ErrAIRegenCap) {
+				return nil, ErrRegenCap
+			}
+			return nil, fmt.Errorf("reserve regen slot: %w", err)
+		}
 	}
 
 	source := c.SourceCode

--- a/backendAPI/aiexplain/explainer.go
+++ b/backendAPI/aiexplain/explainer.go
@@ -94,9 +94,17 @@ func (e *Explainer) Explain(ctx context.Context, address string, regenerate bool
 		}
 	}
 
+	// Truncate by rune count so a UTF-8 codepoint can't be split mid-byte
+	// (which would produce an invalid string and confuse the LLM tokenizer).
+	// SourceMaxBytes is interpreted as a *rune* cap; bytes ≈ runes for the
+	// ASCII-dominant Hyperion source we expect, with a small safety margin
+	// for non-ASCII string literals in the source.
 	source := c.SourceCode
-	if len(source) > e.SourceMaxBytes && e.SourceMaxBytes > 0 {
-		source = source[:e.SourceMaxBytes] + "\n\n// […truncated for length…]"
+	if e.SourceMaxBytes > 0 {
+		runes := []rune(c.SourceCode)
+		if len(runes) > e.SourceMaxBytes {
+			source = string(runes[:e.SourceMaxBytes]) + "\n\n// […truncated for length…]"
+		}
 	}
 
 	user := buildUserPrompt(c, source)

--- a/backendAPI/db/contract.go
+++ b/backendAPI/db/contract.go
@@ -4,6 +4,7 @@ import (
 	"backendAPI/configs"
 	"backendAPI/models"
 	"context"
+	"errors"
 	"log"
 	"strings"
 	"time"
@@ -179,6 +180,79 @@ func MarkContractVerified(address string, result models.VerificationResult) erro
 		return mongo.ErrNoDocuments
 	}
 	return nil
+}
+
+// ErrAIRegenCap signals that the per-contract regen cap has been reached
+// inside the current rolling window. The HTTP layer maps it to 429.
+var ErrAIRegenCap = errors.New("AI regen cap reached")
+
+// ReserveAIRegenSlot atomically reserves one regeneration slot on the
+// contract document. Returns ErrAIRegenCap when:
+//
+//   - the existing window has not yet rolled over (now - windowStart < window) AND
+//   - the count has already reached limit.
+//
+// Otherwise it either increments the count within the current window or
+// resets the window start to now with count=1 (rollover case / first regen).
+// Both paths use a single $set/$inc UpdateOne so there's no read-modify-
+// write race between concurrent callers — the loser sees ErrAIRegenCap.
+func ReserveAIRegenSlot(address string, limit int, window time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	normalizedAddr := normalizeAddress(address)
+	now := time.Now().UTC()
+	cutoff := now.Add(-window).Format(time.RFC3339)
+	nowStr := now.Format(time.RFC3339)
+
+	// Path A: increment within the current window (window is still fresh,
+	// count is below limit).
+	res, err := configs.ContractInfoCollection.UpdateOne(
+		ctx,
+		bson.M{
+			"address":                       normalizedAddr,
+			"aiExplanationRegenWindowStart": bson.M{"$gte": cutoff},
+			"aiExplanationRegenCount":       bson.M{"$lt": limit},
+		},
+		bson.M{"$inc": bson.M{"aiExplanationRegenCount": 1}},
+	)
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount > 0 {
+		return nil
+	}
+
+	// Path B: open a fresh window. Matches when the window expired, was
+	// never started, or the field is missing entirely.
+	res, err = configs.ContractInfoCollection.UpdateOne(
+		ctx,
+		bson.M{
+			"address": normalizedAddr,
+			"$or": []bson.M{
+				{"aiExplanationRegenWindowStart": bson.M{"$lt": cutoff}},
+				{"aiExplanationRegenWindowStart": bson.M{"$exists": false}},
+				{"aiExplanationRegenWindowStart": ""},
+			},
+		},
+		bson.M{"$set": bson.M{
+			"aiExplanationRegenCount":       1,
+			"aiExplanationRegenWindowStart": nowStr,
+		}},
+	)
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount > 0 {
+		return nil
+	}
+
+	// Neither path matched: a fresh window exists AND count is at limit.
+	// (If the address truly doesn't exist, Path B's first clause `$or`
+	// branches would not match because the address filter rules them out;
+	// but the caller already validated existence via ReturnContractCode,
+	// so we know the contract is present.)
+	return ErrAIRegenCap
 }
 
 // SaveContractExplanation persists the M6a AI-generated explanation onto

--- a/backendAPI/models/contract.go
+++ b/backendAPI/models/contract.go
@@ -50,4 +50,11 @@ type ContractInfo struct {
 	AIExplanation      string `json:"aiExplanation,omitempty" bson:"aiExplanation,omitempty"`
 	AIExplanationAt    string `json:"aiExplanationAt,omitempty" bson:"aiExplanationAt,omitempty"`
 	AIExplanationModel string `json:"aiExplanationModel,omitempty" bson:"aiExplanationModel,omitempty"`
+
+	// Regen cap state. The rolling 7-day window starts when the first
+	// regen in a window fires, then resets after the window expires.
+	// AIExplanationRegenCount counts regens within the current window
+	// (initial generates don't count). See aiexplain.RegenLimitPerWindow.
+	AIExplanationRegenCount       int    `json:"aiExplanationRegenCount,omitempty" bson:"aiExplanationRegenCount,omitempty"`
+	AIExplanationRegenWindowStart string `json:"aiExplanationRegenWindowStart,omitempty" bson:"aiExplanationRegenWindowStart,omitempty"`
 }

--- a/backendAPI/routes/explain_routes.go
+++ b/backendAPI/routes/explain_routes.go
@@ -67,6 +67,10 @@ func RegisterContractExplainRoute(router *gin.Engine) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "address is not a known contract"})
 			case errors.Is(err, aiexplain.ErrNotVerified):
 				c.JSON(http.StatusForbidden, gin.H{"error": "contract is not verified — only verified contracts can be analysed"})
+			case errors.Is(err, aiexplain.ErrRegenCap):
+				c.JSON(http.StatusTooManyRequests, gin.H{
+					"error": "regeneration cap reached: 5 regenerations per contract per 7-day window. Try again later.",
+				})
 			default:
 				log.Printf("explain: %s failed: %v", addr, err)
 				c.JSON(http.StatusBadGateway, gin.H{"error": "AI explanation failed: " + err.Error()})


### PR DESCRIPTION
## Summary
Three behavioural tweaks to the M6a contract AI explainer.

### 1. Prompt — neutral observations only
Drops the \"Who can use it\", \"Risks to watch for\", and safety-flavoured guidance entirely. Output is now strictly **Purpose / What it does / Standard**, capped at 150 words. Model is told explicitly: no opinions, no safety analysis, no risks, no recommendations, no implementation feedback.

### 2. 5/week regeneration cap per contract — server-enforced
\`db.ReserveAIRegenSlot\` runs two atomic \`UpdateOne\` calls (increment within current window vs roll fresh window) so concurrent callers cannot race past the limit. ErrAIRegenCap → HTTP 429 with a clear message. Initial generations skip the cap entirely — only \`?regenerate=1\` consumes slots. Window is rolling 7 days from the first regen.

Worst-case Anthropic spend per contract: 5 Haiku calls × $0.001 = $0.005 per week. Negligible regardless of how many users hammer the endpoint.

### 3. Owner-only Regenerate in the UI
\`AiExplainCard\` subscribes to the QRLConnect singleton; the Regenerate button only renders when the paired wallet account === \`creatorAddress\`. Non-owners see a hint instead. UX-only; the 5/week cap is the actual cost floor.

## Schema
ContractInfo (backend + syncer mirror) gains:
- \`aiExplanationRegenCount\` int
- \`aiExplanationRegenWindowStart\` RFC3339 string

Syncer allow-list is default-deny so these stay backend-owned.

## Test plan
- [x] \`go build\` clean (backend + syncer)
- [x] \`npx tsc --noEmit\` + \`npm run lint\` + \`npm run build\` clean
- [ ] Curl /contract/explain on HelloZondscan with ?regenerate=1 five times → 5 × 200, 6th time → 429
- [ ] Confirm the explanation body is short + neutral (no Risks section)
- [ ] Visit /address/<verified-contract> while NOT paired → no Regenerate button
- [ ] Pair the deployer's wallet → Regenerate button appears

## Follow-up
Real server-side owner enforcement (Dilithium signature verification using \`github.com/theQRL/go-qrllib v0.5.0\`) is a separate, larger commit. The 5/week cap is the cost-protection floor; the UX gate is defense in depth.