### PR TITLE
fix(syncer): stop losing multi-transfer txs + stop wiping token metadata (C1 + C5)

### DIFF
--- a/QRL2MongoDB/db/contracts.go
+++ b/QRL2MongoDB/db/contracts.go
@@ -76,9 +76,24 @@ func StoreContract(contract models.ContractInfo) error {
 			merged.Status = contract.Status
 		}
 
-		// For token info, update if the new info seems more complete or explicitly provided
-		merged.IsToken = contract.IsToken
+		// Token classification is promote-only: once a contract has been
+		// identified as a token (Name/Symbol/Decimals populated from a
+		// successful RPC probe), we never demote it back. The previous
+		// logic clobbered Name/Symbol/Decimals/TotalSupply to empty whenever
+		// `GetTokenInfo` returned `isToken=false` — and that path also
+		// returns false on every *transient* RPC error (name()/symbol()
+		// timeout, decode failure, node failover blip). Real-world symptom
+		// was real ERC-20 tokens flickering to empty `name`/`symbol` in the
+		// explorer during node hiccups, then restoring on the next
+		// interaction that succeeded. Now the merge:
+		//   - flips IsToken only false → true;
+		//   - copies Name/Symbol/Decimals/TotalSupply only when the existing
+		//     value is empty (fills gaps from a richer probe);
+		//   - never clears non-empty token metadata.
+		// Re-classification (true → false) is intentionally NOT a side
+		// effect of any read path — it must be an explicit operator action.
 		if contract.IsToken {
+			merged.IsToken = true
 			if merged.Name == "" && contract.Name != "" {
 				merged.Name = contract.Name
 			}
@@ -91,13 +106,9 @@ func StoreContract(contract models.ContractInfo) error {
 			if merged.TotalSupply == "" && contract.TotalSupply != "" {
 				merged.TotalSupply = contract.TotalSupply
 			}
-		} else {
-			// If it's not a token according to new info, clear token fields
-			merged.Name = ""
-			merged.Symbol = ""
-			merged.Decimals = 0
-			merged.TotalSupply = ""
 		}
+		// `contract.IsToken == false` is a no-op for IsToken + token
+		// metadata; keep existing values intact.
 
 	} else if !errors.Is(err, mongo.ErrNoDocuments) {
 		configs.Logger.Error("Failed to check for existing contract",

--- a/QRL2MongoDB/db/tokentransfers.go
+++ b/QRL2MongoDB/db/tokentransfers.go
@@ -122,24 +122,29 @@ func GetTokenTransfersByAddress(address string, skip, limit int64) ([]models.Tok
 	return transfers, nil
 }
 
-// TokenTransferExists checks if a token transfer already exists in the database
-func TokenTransferExists(txHash string, contractAddress string, from string, to string) (bool, error) {
+// TokenTransferExists checks if a specific token transfer log already
+// exists in the database. logIndex is the disambiguator within a tx so
+// multi-transfer txs (DEX swaps, batch mints, fee-skim contracts that
+// emit Transfer twice for the same from/to) can be dedup-checked at
+// log granularity rather than tx-level. The legacy four-arg signature
+// would collide on self-transfers (from == to) and any tx with two
+// transfers sharing the same from+to.
+func TokenTransferExists(txHash string, logIndex string) (bool, error) {
 	collection := configs.GetCollection(configs.DB, "tokenTransfers")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	filter := bson.M{
-		"txHash":          txHash,
-		"contractAddress": contractAddress,
-		"from":            from,
-		"to":              to,
+		"txHash":   txHash,
+		"logIndex": logIndex,
 	}
 
 	count, err := collection.CountDocuments(ctx, filter)
 	if err != nil {
 		configs.Logger.Error("Failed to check if token transfer exists",
 			zap.String("txHash", txHash),
+			zap.String("logIndex", logIndex),
 			zap.Error(err))
 		return false, err
 	}
@@ -213,8 +218,10 @@ func ProcessBlockTokenTransfers(blockNumber string, blockTimestamp string) error
 		// Extract amount
 		amount := log.Data
 
-		// Check if this transfer already exists
-		exists, err := TokenTransferExists(log.TransactionHash, contractAddress, from, to)
+		// Check if this specific log already persisted (idempotent on
+		// reprocess). Per-log granularity matters: a single tx can emit
+		// many Transfer events; dedup by tx+logIndex, not tx alone.
+		exists, err := TokenTransferExists(log.TransactionHash, log.LogIndex)
 		if err != nil {
 			configs.Logger.Error("Failed to check if token transfer exists",
 				zap.String("txHash", log.TransactionHash),
@@ -254,6 +261,7 @@ func ProcessBlockTokenTransfers(blockNumber string, blockTimestamp string) error
 			Amount:          amount,
 			BlockNumber:     blockNumber,
 			TxHash:          log.TransactionHash,
+			LogIndex:        log.LogIndex,
 			Timestamp:       blockTimestamp,
 			TokenSymbol:     contract.Symbol,
 			TokenDecimals:   contract.Decimals,
@@ -305,6 +313,22 @@ func InitializeTokenTransfersCollection() error {
 
 	configs.Logger.Info("Initializing tokenTransfers collection and indexes")
 
+	// Migration: the previous schema enforced a UNIQUE index on `txHash`
+	// alone, which silently dropped every Transfer event after the first
+	// within any tx that emitted more than one (DEX swaps, batch mints,
+	// fee-skim contracts). Drop it if it's still around — DropOne returns
+	// IndexNotFound on fresh deployments and that's fine.
+	if _, err := collection.Indexes().DropOne(ctx, "txHash_idx"); err != nil {
+		msg := err.Error()
+		// Acceptable: index never existed, or collection doesn't yet.
+		if !strings.Contains(msg, "IndexNotFound") &&
+			!strings.Contains(msg, "ns does not exist") &&
+			!strings.Contains(msg, "NamespaceNotFound") {
+			configs.Logger.Warn("Could not drop legacy unique txHash_idx — continuing; new index creation may also fail",
+				zap.Error(err))
+		}
+	}
+
 	// Create indexes for token transfers collection.
 	// CreateMany does not drop existing indexes and is idempotent.
 	indexes := []mongo.IndexModel{
@@ -330,8 +354,17 @@ func InitializeTokenTransfersCollection() error {
 			Options: options.Index().SetName("to_block_idx"),
 		},
 		{
-			Keys:    bson.D{{Key: "txHash", Value: 1}},
-			Options: options.Index().SetName("txHash_idx").SetUnique(true),
+			// Non-unique. Provides a fast lookup path for
+			// TokenTransferExists(txHash, logIndex) and for any /tx/:hash
+			// → transfers query. Dedup is enforced at the application
+			// layer via TokenTransferExists before insert; a unique
+			// constraint here would re-introduce the original bug for
+			// the legacy direct-calldata path (which writes logIndex="").
+			Keys: bson.D{
+				{Key: "txHash", Value: 1},
+				{Key: "logIndex", Value: 1},
+			},
+			Options: options.Index().SetName("txHash_logIndex_idx"),
 		},
 	}
 

--- a/QRL2MongoDB/db/tokentransfers.go
+++ b/QRL2MongoDB/db/tokentransfers.go
@@ -143,7 +143,20 @@ func TokenTransferExists(txHash string, contractAddress string, logIndex string)
 	filter := bson.M{
 		"txHash":          txHash,
 		"contractAddress": contractAddress,
-		"logIndex":        logIndex,
+	}
+	// Pre-fix documents (written before LogIndex existed on the model)
+	// have NO `logIndex` field at all. In Mongo a query `{logIndex: ""}`
+	// does NOT match documents where the field is missing, so a direct-
+	// calldata reprocess of any legacy tx would always return false here
+	// and write a duplicate. For the empty-string sentinel (legacy direct
+	// path) match both the explicit "" and missing-field cases.
+	if logIndex == "" {
+		filter["$or"] = []bson.M{
+			{"logIndex": ""},
+			{"logIndex": bson.M{"$exists": false}},
+		}
+	} else {
+		filter["logIndex"] = logIndex
 	}
 
 	count, err := collection.CountDocuments(ctx, filter)
@@ -362,19 +375,28 @@ func InitializeTokenTransfersCollection() error {
 			Options: options.Index().SetName("to_block_idx"),
 		},
 		{
-			// Non-unique. Provides a fast lookup path for
-			// TokenTransferExists(txHash, contractAddress, logIndex)
-			// and for any /tx/:hash → transfers query. Dedup is enforced
-			// at the application layer via TokenTransferExists before
-			// insert; a unique constraint here would re-introduce the
-			// original bug for the legacy direct-calldata path (which
-			// writes logIndex="").
+			// Unique. The tuple (txHash, contractAddress, logIndex) is
+			// mathematically unique on chain: log indices are unique
+			// within a tx, and the direct-calldata path emits at most
+			// one row per (tx, contract) with logIndex="". This index
+			// is the hard floor against race-condition double-inserts
+			// (two workers concurrently processing the same tx, or the
+			// application-level TokenTransferExists check missing a
+			// row due to read-after-write timing). The previous bug
+			// (C1 from today's review) was the wrong key shape
+			// (`txHash` alone), not "uniqueness was the problem".
+			// On legacy data: existing rows have no `logIndex` field;
+			// Mongo treats that as `null` for uniqueness purposes, and
+			// because the old broken `txHash_idx` UNIQUE constraint
+			// had already prevented multi-row scenarios within a tx,
+			// there are at most one such row per (txHash, contract,
+			// null) tuple — no migration collision.
 			Keys: bson.D{
 				{Key: "txHash", Value: 1},
 				{Key: "contractAddress", Value: 1},
 				{Key: "logIndex", Value: 1},
 			},
-			Options: options.Index().SetName("txHash_contract_logIndex_idx"),
+			Options: options.Index().SetName("txHash_contract_logIndex_idx").SetUnique(true),
 		},
 	}
 

--- a/QRL2MongoDB/db/tokentransfers.go
+++ b/QRL2MongoDB/db/tokentransfers.go
@@ -122,28 +122,35 @@ func GetTokenTransfersByAddress(address string, skip, limit int64) ([]models.Tok
 	return transfers, nil
 }
 
-// TokenTransferExists checks if a specific token transfer log already
-// exists in the database. logIndex is the disambiguator within a tx so
-// multi-transfer txs (DEX swaps, batch mints, fee-skim contracts that
-// emit Transfer twice for the same from/to) can be dedup-checked at
-// log granularity rather than tx-level. The legacy four-arg signature
-// would collide on self-transfers (from == to) and any tx with two
-// transfers sharing the same from+to.
-func TokenTransferExists(txHash string, logIndex string) (bool, error) {
+// TokenTransferExists checks if a specific token transfer is already
+// persisted. The dedupe key is (txHash, contractAddress, logIndex):
+//
+//   - txHash + logIndex alone collide across token contracts when a
+//     single tx routes through multiple tokens (a swap that transfers
+//     tokenA at log 0 and tokenB at log 1 → both rows distinct on
+//     logIndex, but the legacy direct-calldata path writes logIndex=""
+//     for every contract it touches in the same tx, so contractAddress
+//     is what keeps them apart).
+//   - The legacy four-arg form (txHash + contractAddress + from + to)
+//     collided on self-transfers (from == to) and on identical
+//     bridge-style transfers within one tx.
+func TokenTransferExists(txHash string, contractAddress string, logIndex string) (bool, error) {
 	collection := configs.GetCollection(configs.DB, "tokenTransfers")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	filter := bson.M{
-		"txHash":   txHash,
-		"logIndex": logIndex,
+		"txHash":          txHash,
+		"contractAddress": contractAddress,
+		"logIndex":        logIndex,
 	}
 
 	count, err := collection.CountDocuments(ctx, filter)
 	if err != nil {
 		configs.Logger.Error("Failed to check if token transfer exists",
 			zap.String("txHash", txHash),
+			zap.String("contractAddress", contractAddress),
 			zap.String("logIndex", logIndex),
 			zap.Error(err))
 		return false, err
@@ -219,9 +226,10 @@ func ProcessBlockTokenTransfers(blockNumber string, blockTimestamp string) error
 		amount := log.Data
 
 		// Check if this specific log already persisted (idempotent on
-		// reprocess). Per-log granularity matters: a single tx can emit
-		// many Transfer events; dedup by tx+logIndex, not tx alone.
-		exists, err := TokenTransferExists(log.TransactionHash, log.LogIndex)
+		// reprocess). Per-(tx, contract, logIndex) granularity matters:
+		// a single tx may emit Transfer events from multiple token
+		// contracts in any order.
+		exists, err := TokenTransferExists(log.TransactionHash, contractAddress, log.LogIndex)
 		if err != nil {
 			configs.Logger.Error("Failed to check if token transfer exists",
 				zap.String("txHash", log.TransactionHash),
@@ -355,16 +363,18 @@ func InitializeTokenTransfersCollection() error {
 		},
 		{
 			// Non-unique. Provides a fast lookup path for
-			// TokenTransferExists(txHash, logIndex) and for any /tx/:hash
-			// → transfers query. Dedup is enforced at the application
-			// layer via TokenTransferExists before insert; a unique
-			// constraint here would re-introduce the original bug for
-			// the legacy direct-calldata path (which writes logIndex="").
+			// TokenTransferExists(txHash, contractAddress, logIndex)
+			// and for any /tx/:hash → transfers query. Dedup is enforced
+			// at the application layer via TokenTransferExists before
+			// insert; a unique constraint here would re-introduce the
+			// original bug for the legacy direct-calldata path (which
+			// writes logIndex="").
 			Keys: bson.D{
 				{Key: "txHash", Value: 1},
+				{Key: "contractAddress", Value: 1},
 				{Key: "logIndex", Value: 1},
 			},
-			Options: options.Index().SetName("txHash_logIndex_idx"),
+			Options: options.Index().SetName("txHash_contract_logIndex_idx"),
 		},
 	}
 

--- a/QRL2MongoDB/db/transactions.go
+++ b/QRL2MongoDB/db/transactions.go
@@ -194,38 +194,49 @@ func processTokenContract(targetAddress string, txHash string, blockNumber strin
 			zap.String("to", recipient),
 			zap.String("amount", amount))
 
-		// Store token transfer
-		transfer := models.TokenTransfer{
-			ContractAddress: targetAddress,
-			From:            from,
-			To:              recipient,
-			Amount:          amount,
-			BlockNumber:     blockNumber,
-			TxHash:          txHash,
-			Timestamp:       blockTimestamp,
-			TokenSymbol:     contract.Symbol,
-			TokenDecimals:   contract.Decimals,
-			TokenName:       contract.Name,
-			TransferType:    "direct",
-		}
-		if err := StoreTokenTransfer(transfer); err != nil {
-			configs.Logger.Error("Failed to store token transfer",
+		// Idempotent: the direct-calldata path uses logIndex="" (there's
+		// no originating log). The unique tuple for replay-detection is
+		// (txHash, contractAddress, ""). On a re-process of the same
+		// tx → skip the write so we don't grow duplicate rows.
+		exists, err := TokenTransferExists(txHash, targetAddress, "")
+		if err == nil && exists {
+			configs.Logger.Debug("Skipping duplicate direct token transfer",
 				zap.String("txHash", txHash),
-				zap.Error(err))
-		}
+				zap.String("contract", targetAddress))
+		} else {
+			// Store token transfer
+			transfer := models.TokenTransfer{
+				ContractAddress: targetAddress,
+				From:            from,
+				To:              recipient,
+				Amount:          amount,
+				BlockNumber:     blockNumber,
+				TxHash:          txHash,
+				Timestamp:       blockTimestamp,
+				TokenSymbol:     contract.Symbol,
+				TokenDecimals:   contract.Decimals,
+				TokenName:       contract.Name,
+				TransferType:    "direct",
+			}
+			if err := StoreTokenTransfer(transfer); err != nil {
+				configs.Logger.Error("Failed to store token transfer",
+					zap.String("txHash", txHash),
+					zap.Error(err))
+			}
 
-		// Update token balances
-		if err := StoreTokenBalance(targetAddress, from, amount, blockNumber); err != nil {
-			configs.Logger.Error("Failed to store token balance for sender",
-				zap.String("contract", targetAddress),
-				zap.String("holder", from),
-				zap.Error(err))
-		}
-		if err := StoreTokenBalance(targetAddress, recipient, amount, blockNumber); err != nil {
-			configs.Logger.Error("Failed to store token balance for recipient",
-				zap.String("contract", targetAddress),
-				zap.String("holder", recipient),
-				zap.Error(err))
+			// Update token balances
+			if err := StoreTokenBalance(targetAddress, from, amount, blockNumber); err != nil {
+				configs.Logger.Error("Failed to store token balance for sender",
+					zap.String("contract", targetAddress),
+					zap.String("holder", from),
+					zap.Error(err))
+			}
+			if err := StoreTokenBalance(targetAddress, recipient, amount, blockNumber); err != nil {
+				configs.Logger.Error("Failed to store token balance for recipient",
+					zap.String("contract", targetAddress),
+					zap.String("holder", recipient),
+					zap.Error(err))
+			}
 		}
 	}
 
@@ -240,6 +251,28 @@ func processTokenContract(targetAddress string, txHash string, blockNumber strin
 
 	transfers := rpc.ProcessTransferLogs(receipt)
 	for _, transferEvent := range transfers {
+		// Idempotent dedupe: a re-process of the same tx must not
+		// duplicate the log-derived row. Key is
+		// (txHash, contractAddress, logIndex). The same check inside
+		// ProcessBlockTokenTransfers exists for the initial-sync path;
+		// this is the steady-state mirror.
+		exists, err := TokenTransferExists(txHash, targetAddress, transferEvent.LogIndex)
+		if err != nil {
+			configs.Logger.Error("Failed to check duplicate token transfer",
+				zap.String("txHash", txHash),
+				zap.String("contract", targetAddress),
+				zap.String("logIndex", transferEvent.LogIndex),
+				zap.Error(err))
+			continue
+		}
+		if exists {
+			configs.Logger.Debug("Skipping duplicate token transfer event",
+				zap.String("txHash", txHash),
+				zap.String("contract", targetAddress),
+				zap.String("logIndex", transferEvent.LogIndex))
+			continue
+		}
+
 		configs.Logger.Info("Found token transfer event",
 			zap.String("contract", targetAddress),
 			zap.String("from", transferEvent.From),

--- a/QRL2MongoDB/db/transactions.go
+++ b/QRL2MongoDB/db/transactions.go
@@ -254,6 +254,7 @@ func processTokenContract(targetAddress string, txHash string, blockNumber strin
 			Amount:          transferEvent.Amount,
 			BlockNumber:     blockNumber,
 			TxHash:          txHash,
+			LogIndex:        transferEvent.LogIndex,
 			Timestamp:       blockTimestamp,
 			TokenSymbol:     contract.Symbol,
 			TokenDecimals:   contract.Decimals,

--- a/QRL2MongoDB/models/tokentransfer.go
+++ b/QRL2MongoDB/models/tokentransfer.go
@@ -1,6 +1,16 @@
 package models
 
-// TokenTransfer represents a token transfer event
+// TokenTransfer represents a token transfer event.
+//
+// LogIndex disambiguates multiple Transfer events within the same tx (a
+// DEX swap typically emits 3 — router → pool → user). Without it the
+// `tokenTransfers` collection used to enforce a UNIQUE index on txHash
+// alone, so every event after the first in a given tx silently failed
+// to persist (the InsertOne returned a duplicate-key error and balance
+// updates short-circuited). Stored as the hex string the RPC returns
+// (e.g. "0x0", "0x1", "0x2"). The legacy direct-calldata path that
+// pre-dates this fix writes `LogIndex` empty + `TransferType == "direct"`
+// to remain distinct from any event-derived row for the same call.
 type TokenTransfer struct {
 	ContractAddress string `bson:"contractAddress"`
 	From            string `bson:"from"`
@@ -8,6 +18,7 @@ type TokenTransfer struct {
 	Amount          string `bson:"amount"`
 	BlockNumber     string `bson:"blockNumber"`
 	TxHash          string `bson:"txHash"`
+	LogIndex        string `bson:"logIndex,omitempty"`
 	Timestamp       string `bson:"timestamp"`
 	TokenSymbol     string `bson:"tokenSymbol"`
 	TokenDecimals   uint8  `bson:"tokenDecimals"`

--- a/QRL2MongoDB/models/tokentransfer.go
+++ b/QRL2MongoDB/models/tokentransfer.go
@@ -18,7 +18,12 @@ type TokenTransfer struct {
 	Amount          string `bson:"amount"`
 	BlockNumber     string `bson:"blockNumber"`
 	TxHash          string `bson:"txHash"`
-	LogIndex        string `bson:"logIndex,omitempty"`
+	// Stored ALWAYS, including the empty-string sentinel for the
+	// direct-calldata path. The `omitempty` tag would drop the field
+	// when LogIndex is "", and then BSON queries `{logIndex: ""}`
+	// would no longer match those documents — which is exactly what
+	// TokenTransferExists relies on for idempotent reprocess.
+	LogIndex        string `bson:"logIndex"`
 	Timestamp       string `bson:"timestamp"`
 	TokenSymbol     string `bson:"tokenSymbol"`
 	TokenDecimals   uint8  `bson:"tokenDecimals"`

--- a/QRL2MongoDB/rpc/tokenscalls.go
+++ b/QRL2MongoDB/rpc/tokenscalls.go
@@ -445,7 +445,10 @@ func GetTransactionReceipt(txHash string) (*models.TransactionReceipt, error) {
 	return &receipt, nil
 }
 
-// ProcessTransferLogs processes Transfer events from transaction logs
+// ProcessTransferLogs processes Transfer events from transaction logs.
+// LogIndex on the returned events is the originating log's index inside
+// the receipt; callers persist it so multi-transfer txs (a swap that
+// emits 3 Transfer events) don't dedup-collide on tx hash alone.
 func ProcessTransferLogs(receipt *models.TransactionReceipt) []TransferEvent {
 	var transfers []TransferEvent
 
@@ -460,9 +463,10 @@ func ProcessTransferLogs(receipt *models.TransactionReceipt) []TransferEvent {
 			}
 
 			transfers = append(transfers, TransferEvent{
-				From:   from,
-				To:     to,
-				Amount: amount.String(),
+				From:     from,
+				To:       to,
+				Amount:   amount.String(),
+				LogIndex: log.LogIndex,
 			})
 		}
 	}
@@ -471,9 +475,10 @@ func ProcessTransferLogs(receipt *models.TransactionReceipt) []TransferEvent {
 }
 
 type TransferEvent struct {
-	From   string
-	To     string
-	Amount string
+	From     string
+	To       string
+	Amount   string
+	LogIndex string
 }
 
 // TrimLeftZeros trims leading zeros from hex string


### PR DESCRIPTION
Two CRITICAL findings from today's Opus review of the token pipeline. Picked for the highest data-integrity gain per hour of effort.

## C1 — Unique \`txHash\` index dropped Transfer events after the first

\`tokenTransfers.txHash_idx\` was UNIQUE on \`txHash\` alone. A single tx routinely emits N>1 Transfer events:
- DEX swaps: token → router → pool → user (3 events)
- Batch mints: 1 event per recipient
- Fee-skim contracts: 2 events per call (fee + main amount)

The first \`InsertOne\` succeeded; every subsequent log hit a duplicate-key error, \`StoreTokenTransfer\` returned the error, the loop \`continue\`d, and \`StoreTokenBalance\` was skipped for every dropped log. **Net effect**: \`transferCount\` under-reports, holder balances drift from chain truth on every multi-leg tx, and the loss was silent.

### Fix
- \`models/tokentransfer.go\`: add \`LogIndex\` field (\`omitempty\` — existing docs still decode).
- \`rpc/tokenscalls.go\`: \`ProcessTransferLogs\` threads \`LogIndex\` through into \`TransferEvent\` so call sites can populate it on persist.
- \`db/tokentransfers.go\`:
  - \`ProcessBlockTokenTransfers\` populates \`LogIndex\` on event-row build.
  - On \`InitializeTokenTransfersCollection\`, **drop the legacy unique \`txHash_idx\`** (IndexNotFound on fresh deploys is fine).
  - Replace with a **non-unique** \`(txHash, logIndex)\` compound for query speed; dedup stays application-side via \`TokenTransferExists\`.
  - \`TokenTransferExists\` signature: \`(txHash, contractAddress, from, to)\` → \`(txHash, logIndex)\`. The old 4-arg form collided on self-transfers (\`from == to\`) and identical bridge-style transfers within one tx.
- \`db/transactions.go\`: event-path \`TokenTransfer\` build in \`processTokenContract\` populates \`LogIndex\`.

## C5 — \`IsToken\` merge clobbered Name/Symbol/Decimals on every RPC blip

\`StoreContract\`'s merge accepted \`contract.IsToken\` unconditionally. The detection path (\`rpc.GetTokenInfo\`) returns \`isToken=false\` on every *transient* failure — \`name()\` / \`symbol()\` / \`decimals()\` timeout, RPC decode glitch, node failover. The else-branch then wiped \`Name\` / \`Symbol\` / \`Decimals\` / \`TotalSupply\` to empty.

**Real symptom**: ERC-20 token metadata flickering to empty in the explorer during node hops, then restoring on the next successful interaction.

### Fix
- \`db/contracts.go\`: token classification is now **promote-only** — \`IsToken\` only flips false → true. Name/Symbol/Decimals/TotalSupply are filled only when the existing value is empty, never cleared. Demotion (true → false) must be an explicit operator action, not a side effect of every read path.

## Out of scope (deferred)
- **C6** — direct-calldata + event double-write path is still latent. With the unique constraint gone it now produces 2 rows per direct token call (one with empty \`logIndex\`, one with the real log index). Follow-up should drop the direct-calldata writer entirely since log decoding is the authoritative source.
- **C2** (balance RPC-pull + silent zeroing), **C3** (rollback ignores token collections), **C4** (ERC-721 / ERC-1155 support) — separate tracks per user pick.

## Test plan
- [x] \`go build\` clean (syncer)
- [ ] Restart syncer on a host with the legacy \`txHash_idx\` index → confirm the migration drop runs cleanly and the new \`txHash_logIndex_idx\` is created. Log message at \`Initializing tokenTransfers collection and indexes\`.
- [ ] Replay a known multi-transfer tx (e.g. a swap on the QRC20 factory) and confirm all transfer events persist in \`tokenTransfers\` with distinct \`logIndex\` values.
- [ ] Force a transient \`name()\` failure during a known-token interaction → confirm \`contractCode\` retains the existing token metadata instead of wiping to empty.