### PR TITLE
feat(syncer): ERC-721 + ERC-1155 NFT support (Phase 1)

### DIFF
--- a/ExplorerFrontend/app/address/[query]/address-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-view.tsx
@@ -161,12 +161,13 @@ export default function AddressView({ addressData, addressSegment }: AddressView
                                     {/* Token / NFT Information */}
                                     {contractData.isToken && (
                                         <>
-                                            {/* Standard label (ERC-20 / ERC-721 / ERC-1155) */}
+                                            {/* Standard label — surfaces the QRC-X branding
+                                                (DB value stays ERC-X). */}
                                             {contractData.tokenStandard && (
                                                 <div>
                                                     <div className="text-xs md:text-sm text-gray-400 mb-1">Token Standard</div>
                                                     <div className="text-xs md:text-sm text-gray-300">
-                                                        {contractData.tokenStandard}
+                                                        {contractData.tokenStandard.replace(/^ERC-/, 'QRC-')}
                                                     </div>
                                                 </div>
                                             )}

--- a/ExplorerFrontend/app/address/[query]/address-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-view.tsx
@@ -133,7 +133,13 @@ export default function AddressView({ addressData, addressSegment }: AddressView
                             <div className="card-simple p-3 md:p-4 lg:p-6 space-y-3 md:space-y-4">
                                 <div className="flex items-center gap-2 flex-wrap">
                                     <h3 className="text-base md:text-lg font-semibold text-accent">
-                                        {contractData.isToken ? 'Token Contract' : 'Contract'} Information
+                                        {contractData.tokenStandard === 'ERC-721'
+                                            ? 'NFT Collection'
+                                            : contractData.tokenStandard === 'ERC-1155'
+                                              ? 'Multi-Token Collection'
+                                              : contractData.isToken
+                                                ? 'Token Contract'
+                                                : 'Contract'} Information
                                     </h3>
                                     {contractData.verified && <VerifiedBadge />}
                                 </div>
@@ -152,32 +158,48 @@ export default function AddressView({ addressData, addressSegment }: AddressView
                                         </div>
                                     </div>
 
-                                    {/* Token Information */}
+                                    {/* Token / NFT Information */}
                                     {contractData.isToken && (
                                         <>
-                                            {/* Token Name */}
+                                            {/* Standard label (ERC-20 / ERC-721 / ERC-1155) */}
+                                            {contractData.tokenStandard && (
+                                                <div>
+                                                    <div className="text-xs md:text-sm text-gray-400 mb-1">Token Standard</div>
+                                                    <div className="text-xs md:text-sm text-gray-300">
+                                                        {contractData.tokenStandard}
+                                                    </div>
+                                                </div>
+                                            )}
+
+                                            {/* Name */}
                                             <div>
-                                                <div className="text-xs md:text-sm text-gray-400 mb-1">Token Name</div>
+                                                <div className="text-xs md:text-sm text-gray-400 mb-1">
+                                                    {contractData.tokenStandard === 'ERC-20' || !contractData.tokenStandard ? 'Token Name' : 'Collection Name'}
+                                                </div>
                                                 <div className="text-xs md:text-sm text-gray-300">
                                                     {contractData.name || 'Unknown'}
                                                 </div>
                                             </div>
 
-                                            {/* Token Symbol */}
+                                            {/* Symbol */}
                                             <div>
-                                                <div className="text-xs md:text-sm text-gray-400 mb-1">Token Symbol</div>
+                                                <div className="text-xs md:text-sm text-gray-400 mb-1">
+                                                    {contractData.tokenStandard === 'ERC-20' || !contractData.tokenStandard ? 'Token Symbol' : 'Collection Symbol'}
+                                                </div>
                                                 <div className="text-xs md:text-sm text-gray-300">
                                                     {contractData.symbol || 'Unknown'}
                                                 </div>
                                             </div>
 
-                                            {/* Token Decimals */}
-                                            <div>
-                                                <div className="text-xs md:text-sm text-gray-400 mb-1">Token Decimals</div>
-                                                <div className="text-xs md:text-sm text-gray-300">
-                                                    {contractData.decimals || '0'}
+                                            {/* Decimals — ERC-20 only */}
+                                            {(contractData.tokenStandard === 'ERC-20' || !contractData.tokenStandard) && (
+                                                <div>
+                                                    <div className="text-xs md:text-sm text-gray-400 mb-1">Token Decimals</div>
+                                                    <div className="text-xs md:text-sm text-gray-300">
+                                                        {contractData.decimals || '0'}
+                                                    </div>
                                                 </div>
-                                            </div>
+                                            )}
                                         </>
                                     )}
 

--- a/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
@@ -314,7 +314,7 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                 {isNFT ? 'Standard' : 'Decimals'}
                             </div>
                             <div className="text-sm md:text-base font-semibold text-white">
-                                {isNFT ? (tokenStandard ?? '-') : decimals}
+                                {isNFT ? (tokenStandard?.replace(/^ERC-/, 'QRC-') ?? '-') : decimals}
                             </div>
                         </div>
                     </div>

--- a/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
@@ -225,6 +225,17 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
     const totalSupply = tokenInfo?.totalSupply ?? contractData.totalSupply ?? '0';
     const creatorAddress = creationTx?.From || tokenInfo?.creatorAddress || contractData.creatorAddress || '';
     const creationTxHash = tokenInfo?.creationTxHash || contractData.creationTransaction || '';
+    const tokenStandard = contractData.tokenStandard;
+    const isNFT = tokenStandard === 'ERC-721' || tokenStandard === 'ERC-1155';
+    const badgeLabel =
+        tokenStandard === 'ERC-721'
+            ? 'QRC-721 NFT'
+            : tokenStandard === 'ERC-1155'
+              ? 'QRC-1155 Multi-Token'
+              : 'QRC-20 Token';
+    const badgeClasses = isNFT
+        ? 'bg-purple-500/20 text-purple-300'
+        : 'bg-green-500/20 text-green-400';
 
     const tabs = [
         { id: 'overview', label: 'Overview' },
@@ -262,17 +273,28 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                 </div>
                             </div>
                         </div>
-                        <div className="px-3 py-1.5 rounded-lg bg-green-500/20 text-green-400 text-sm font-medium self-start">
-                            QRC-20 Token
+                        <div className={`px-3 py-1.5 rounded-lg text-sm font-medium self-start ${badgeClasses}`}>
+                            {badgeLabel}
                         </div>
                     </div>
 
-                    {/* Token Stats Grid */}
+                    {/* Token Stats Grid. Decimals hidden for NFT collections (no
+                        fractional units); for ERC-1155 totalSupply is the
+                        operator's reported aggregate and may not be meaningful
+                        per-id (Phase 2 will surface per-id supply on the holders
+                        endpoint). */}
                     <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                         <div className="bg-black/20 rounded-lg p-3 md:p-4">
-                            <div className="text-xs md:text-sm text-gray-400 mb-1">Total Supply</div>
-                            <div className="text-sm md:text-base font-semibold text-white truncate" title={formatTokenAmount(totalSupply, decimals)}>
-                                {formatTokenAmount(totalSupply, decimals)} {symbol}
+                            <div className="text-xs md:text-sm text-gray-400 mb-1">
+                                {tokenStandard === 'ERC-721' ? 'Total Items' : 'Total Supply'}
+                            </div>
+                            <div
+                                className="text-sm md:text-base font-semibold text-white truncate"
+                                title={isNFT ? totalSupply : formatTokenAmount(totalSupply, decimals)}
+                            >
+                                {isNFT
+                                    ? (totalSupply !== '0' ? `${totalSupply} ${symbol}` : `- ${symbol}`)
+                                    : `${formatTokenAmount(totalSupply, decimals)} ${symbol}`}
                             </div>
                         </div>
                         <div className="bg-black/20 rounded-lg p-3 md:p-4">
@@ -288,9 +310,11 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                             </div>
                         </div>
                         <div className="bg-black/20 rounded-lg p-3 md:p-4">
-                            <div className="text-xs md:text-sm text-gray-400 mb-1">Decimals</div>
+                            <div className="text-xs md:text-sm text-gray-400 mb-1">
+                                {isNFT ? 'Standard' : 'Decimals'}
+                            </div>
                             <div className="text-sm md:text-base font-semibold text-white">
-                                {decimals}
+                                {isNFT ? (tokenStandard ?? '-') : decimals}
                             </div>
                         </div>
                     </div>

--- a/ExplorerFrontend/app/contracts/contracts-client.tsx
+++ b/ExplorerFrontend/app/contracts/contracts-client.tsx
@@ -215,11 +215,12 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
         <p className="text-gray-400">Browse deployed tokens and smart contracts on the QRL Zond network</p>
       </div>
 
-      {/* Tabs */}
+      {/* Tabs — QRC-X is the QRL-branded form of the EIP standards; the
+          underlying tokenStandard string stays "ERC-X" in the DB / API. */}
       <div role="tablist" className="flex flex-wrap gap-2 mb-6">
-        <TabButton tab="erc20" label="ERC-20" activeTab={activeTab} onSelect={setActiveTab} />
-        <TabButton tab="erc721" label="NFTs (ERC-721)" activeTab={activeTab} onSelect={setActiveTab} />
-        <TabButton tab="erc1155" label="Multi-Token (ERC-1155)" activeTab={activeTab} onSelect={setActiveTab} />
+        <TabButton tab="erc20" label="Tokens (QRC-20)" activeTab={activeTab} onSelect={setActiveTab} />
+        <TabButton tab="erc721" label="NFTs (QRC-721)" activeTab={activeTab} onSelect={setActiveTab} />
+        <TabButton tab="erc1155" label="Multi-Token (QRC-1155)" activeTab={activeTab} onSelect={setActiveTab} />
         <TabButton tab="contracts" label="Other Contracts" activeTab={activeTab} onSelect={setActiveTab} />
       </div>
 
@@ -262,15 +263,8 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
             title={TAB_EMPTY_TITLE[activeTab]}
             description="Try adjusting your search or check back later."
           />
-        ) : activeTab === 'contracts' ? (
-          <ContractsTable contracts={contracts} />
-        ) : activeTab === 'erc20' ? (
-          <TokensTable contracts={contracts} />
         ) : (
-          <NFTsTable
-            contracts={contracts}
-            standard={activeTab === 'erc721' ? 'ERC-721' : 'ERC-1155'}
-          />
+          <ContractRowsTable contracts={contracts} variant={activeTab} />
         )}
       </div>
 
@@ -332,140 +326,60 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
   );
 }
 
-// Tokens Table Component
-function TokensTable({ contracts }: { contracts: ContractData[] }) {
-  return (
-    <div className="overflow-x-auto">
-      <table aria-label="Token contracts" className="min-w-full divide-y divide-[#3d3d3d]">
-        <thead className="bg-[#2d2d2d]/50">
-          <tr>
-            <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
-              Token
-            </th>
-            <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
-              Contract Address
-            </th>
-            <th scope="col" className="hidden md:table-cell px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
-              Decimals
-            </th>
-            <th scope="col" className="hidden sm:table-cell px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
-              Total Supply
-            </th>
-            <th scope="col" className="hidden lg:table-cell px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
-              Creator
-            </th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-[#3d3d3d]">
-          {contracts.map((contract, index) => (
-            <tr key={contract._id || index} className="hover:bg-[#2d2d2d]/30">
-              <td className="px-4 py-4 whitespace-nowrap">
-                <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 rounded-full bg-gradient-to-br from-[#ffa729] to-[#ff8c00] flex items-center justify-center text-black font-bold text-sm">
-                    {contract.symbol ? contract.symbol.charAt(0) : '?'}
-                  </div>
-                  <div>
-                    <div className="text-white font-medium">{contract.name || 'Unknown Token'}</div>
-                    <div className="text-gray-500 text-sm">{contract.symbol || '-'}</div>
-                  </div>
-                </div>
-              </td>
-              <td className="px-4 py-4 whitespace-nowrap">
-                <Link
-                  href={`/address/${contract.address}`}
-                  className="text-[#ffa729] hover:underline font-mono text-sm"
-                >
-                  {truncateAddress(contract.address)}
-                </Link>
-              </td>
-              <td className="hidden md:table-cell px-4 py-4 whitespace-nowrap text-gray-300 text-sm">
-                {contract.decimals ?? '-'}
-              </td>
-              <td className="hidden sm:table-cell px-4 py-4 whitespace-nowrap text-gray-300 text-sm font-mono">
-                {formatTotalSupply(contract.totalSupply, contract.decimals)}
-              </td>
-              <td className="hidden lg:table-cell px-4 py-4 whitespace-nowrap">
-                <Link
-                  href={`/address/${contract.creatorAddress}`}
-                  className="text-gray-400 hover:text-[#ffa729] font-mono text-sm"
-                >
-                  {truncateAddress(contract.creatorAddress, 6, 4)}
-                </Link>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
-}
+// Single source of truth for cell chrome so every tab looks like the same
+// table with a different column subset — the original split-into-three
+// approach gave each tab its own visual identity, which read as four
+// different pages stitched together.
+const TH_BASE = 'px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider';
+const TD_BASE = 'px-4 py-4 whitespace-nowrap';
 
-// NFT / Multi-Token Table Component.
-//
-// Shares the visual identity of TokensTable but drops decimals + totalSupply
-// (ERC-20-specific) and surfaces the standard badge inline so a user
-// scanning the page knows whether each row is 721 or 1155.
-function NFTsTable({
+const TAB_TABLE_LABEL: Record<TabType, string> = {
+  erc20: 'Tokens',
+  erc721: 'NFT collections',
+  erc1155: 'Multi-token collections',
+  contracts: 'Smart contracts',
+};
+
+// ContractRowsTable renders all four tabs through the same chrome — same
+// header bar, same divider, same row hover, same identity cell. Per-tab
+// columns toggle on/off via the `variant` prop, but the visual rhythm
+// stays identical across tabs.
+function ContractRowsTable({
   contracts,
-  standard,
+  variant,
 }: {
   contracts: ContractData[];
-  standard: 'ERC-721' | 'ERC-1155';
+  variant: TabType;
 }) {
-  const label = STANDARD_LABEL[standard] ?? standard;
+  const showDecimalsAndSupply = variant === 'erc20';
   return (
     <div className="overflow-x-auto">
-      <table aria-label={`${label} collections`} className="min-w-full divide-y divide-[#3d3d3d]">
+      <table aria-label={TAB_TABLE_LABEL[variant]} className="min-w-full divide-y divide-[#3d3d3d]">
         <thead className="bg-[#2d2d2d]/50">
           <tr>
-            <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
-              Collection
+            <th scope="col" className={TH_BASE}>
+              {variant === 'contracts' ? 'Contract' : variant === 'erc20' ? 'Token' : 'Collection'}
             </th>
-            <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
-              Contract Address
-            </th>
-            <th scope="col" className="hidden sm:table-cell px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
-              Standard
-            </th>
-            <th scope="col" className="hidden lg:table-cell px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
-              Creator
-            </th>
+            <th scope="col" className={TH_BASE}>Contract Address</th>
+            <th scope="col" className={`hidden sm:table-cell ${TH_BASE}`}>Type</th>
+            {showDecimalsAndSupply && (
+              <th scope="col" className={`hidden md:table-cell ${TH_BASE}`}>Decimals</th>
+            )}
+            {showDecimalsAndSupply && (
+              <th scope="col" className={`hidden lg:table-cell ${TH_BASE}`}>Total Supply</th>
+            )}
+            <th scope="col" className={`hidden lg:table-cell ${TH_BASE}`}>Creator</th>
+            <th scope="col" className={`hidden xl:table-cell ${TH_BASE}`}>Created at Block</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-[#3d3d3d]">
-          {contracts.map((contract, index) => (
-            <tr key={contract._id || index} className="hover:bg-[#2d2d2d]/30">
-              <td className="px-4 py-4 whitespace-nowrap">
-                <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 rounded-full bg-gradient-to-br from-[#ffa729] to-[#ff8c00] flex items-center justify-center text-black font-bold text-sm">
-                    {contract.symbol ? contract.symbol.charAt(0) : '?'}
-                  </div>
-                  <div>
-                    <div className="text-white font-medium">{contract.name || 'Unknown Collection'}</div>
-                    <div className="text-gray-500 text-sm">{contract.symbol || '-'}</div>
-                  </div>
-                </div>
-              </td>
-              <td className="px-4 py-4 whitespace-nowrap">
-                <Link
-                  href={`/address/${contract.address}`}
-                  className="text-[#ffa729] hover:underline font-mono text-sm"
-                >
-                  {truncateAddress(contract.address)}
-                </Link>
-              </td>
-              <td className="hidden sm:table-cell px-4 py-4 whitespace-nowrap">
-                <Badge variant="warning">{standard === 'ERC-721' ? 'QRC-721' : 'QRC-1155'}</Badge>
-              </td>
-              <td className="hidden lg:table-cell px-4 py-4 whitespace-nowrap">
-                <Link
-                  href={`/address/${contract.creatorAddress}`}
-                  className="text-gray-400 hover:text-[#ffa729] font-mono text-sm"
-                >
-                  {truncateAddress(contract.creatorAddress, 6, 4)}
-                </Link>
-              </td>
-            </tr>
+          {contracts.map((contract, i) => (
+            <ContractRow
+              key={contract._id || i}
+              contract={contract}
+              variant={variant}
+              showDecimalsAndSupply={showDecimalsAndSupply}
+            />
           ))}
         </tbody>
       </table>
@@ -473,74 +387,104 @@ function NFTsTable({
   );
 }
 
-// All Contracts Table Component
-function ContractsTable({ contracts }: { contracts: ContractData[] }) {
+function ContractRow({
+  contract,
+  variant,
+  showDecimalsAndSupply,
+}: {
+  contract: ContractData;
+  variant: TabType;
+  showDecimalsAndSupply: boolean;
+}) {
+  const isToken = variant !== 'contracts';
+  // Identity cell: avatar + name/symbol stack for tokens; avatar + "Smart
+  // Contract" + truncated address for non-token contracts. Same physical
+  // layout in both cases — only the colour palette + text vary.
+  const avatarSeed = isToken
+    ? (contract.symbol || contract.name || '?')
+    : contract.address.replace(/^Q/i, '');
+  const avatarChar = (avatarSeed.charAt(0) || '?').toUpperCase();
+  const avatarGradient = isToken
+    ? 'from-[#ffa729] to-[#ff8c00]'
+    : 'from-[#5f5f5f] to-[#3d3d3d]';
+  const avatarTextColor = isToken ? 'text-black' : 'text-white';
+
+  const fallbackPrimary =
+    variant === 'erc20' ? 'Unknown Token'
+    : variant === 'erc721' ? 'Unknown Collection'
+    : variant === 'erc1155' ? 'Unknown Collection'
+    : 'Smart Contract';
+  const primary = isToken ? (contract.name || fallbackPrimary) : 'Smart Contract';
+  const secondary = isToken
+    ? (contract.symbol || '-')
+    : truncateAddress(contract.address, 6, 4);
+
+  const typeBadge = (() => {
+    if (variant === 'erc20') return <Badge variant="success">QRC-20</Badge>;
+    if (variant === 'erc721') return <Badge variant="warning">QRC-721 NFT</Badge>;
+    if (variant === 'erc1155') return <Badge variant="warning">QRC-1155</Badge>;
+    return <Badge variant="info">Contract</Badge>;
+  })();
+
   return (
-    <div className="overflow-x-auto">
-      <table aria-label="Smart contracts" className="min-w-full divide-y divide-[#3d3d3d]">
-        <thead className="bg-[#2d2d2d]/50">
-          <tr>
-            <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
-              Contract Address
-            </th>
-            <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
-              Type
-            </th>
-            <th scope="col" className="hidden sm:table-cell px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
-              Creator
-            </th>
-            <th scope="col" className="hidden md:table-cell px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
-              Created at Block
-            </th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-[#3d3d3d]">
-          {contracts.map((contract, index) => (
-            <tr key={contract._id || index} className="hover:bg-[#2d2d2d]/30">
-              <td className="px-4 py-4 whitespace-nowrap">
-                <Link
-                  href={`/address/${contract.address}`}
-                  className="text-[#ffa729] hover:underline font-mono text-sm"
-                >
-                  <span className="hidden sm:inline">{truncateAddress(contract.address, 10, 8)}</span>
-                  <span className="sm:hidden">{truncateAddress(contract.address, 6, 4)}</span>
-                </Link>
-              </td>
-              <td className="px-4 py-4 whitespace-nowrap">
-                {contract.tokenStandard === 'ERC-721' ? (
-                  <Badge variant="warning">NFT (QRC-721){contract.symbol ? ` · ${contract.symbol}` : ''}</Badge>
-                ) : contract.tokenStandard === 'ERC-1155' ? (
-                  <Badge variant="warning">Multi-Token (QRC-1155){contract.symbol ? ` · ${contract.symbol}` : ''}</Badge>
-                ) : contract.isToken ? (
-                  <Badge variant="success">Token (QRC-20){contract.symbol ? ` · ${contract.symbol}` : ''}</Badge>
-                ) : (
-                  <Badge variant="info">Contract</Badge>
-                )}
-              </td>
-              <td className="hidden sm:table-cell px-4 py-4 whitespace-nowrap">
-                <Link
-                  href={`/address/${contract.creatorAddress}`}
-                  className="text-gray-400 hover:text-[#ffa729] font-mono text-sm"
-                >
-                  {truncateAddress(contract.creatorAddress, 6, 4)}
-                </Link>
-              </td>
-              <td className="hidden md:table-cell px-4 py-4 whitespace-nowrap text-gray-300 text-sm font-mono">
-                {contract.creationBlockNumber ? (
-                  <Link
-                    href={`/block/${formatBlockNumber(contract.creationBlockNumber).replace(/,/g, '')}`}
-                    className="text-gray-400 hover:text-[#ffa729]"
-                  >
-                    #{formatBlockNumber(contract.creationBlockNumber)}
-                  </Link>
-                ) : (
-                  '-'
-                )}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <tr className="hover:bg-[#2d2d2d]/30">
+      <td className={TD_BASE}>
+        <div className="flex items-center gap-3">
+          <div
+            className={`w-8 h-8 rounded-full bg-gradient-to-br ${avatarGradient} flex items-center justify-center font-bold text-sm shrink-0 ${avatarTextColor}`}
+          >
+            {avatarChar}
+          </div>
+          <div className="min-w-0">
+            <div className="text-white font-medium truncate">{primary}</div>
+            <div className="text-gray-500 text-sm truncate">{secondary}</div>
+          </div>
+        </div>
+      </td>
+      <td className={TD_BASE}>
+        <Link
+          href={`/address/${contract.address}`}
+          className="text-[#ffa729] hover:underline font-mono text-sm"
+        >
+          <span className="hidden sm:inline">{truncateAddress(contract.address, 10, 8)}</span>
+          <span className="sm:hidden">{truncateAddress(contract.address, 6, 4)}</span>
+        </Link>
+      </td>
+      <td className={`hidden sm:table-cell ${TD_BASE}`}>{typeBadge}</td>
+      {showDecimalsAndSupply && (
+        <td className={`hidden md:table-cell ${TD_BASE} text-gray-300 text-sm`}>
+          {contract.decimals ?? '-'}
+        </td>
+      )}
+      {showDecimalsAndSupply && (
+        <td className={`hidden lg:table-cell ${TD_BASE} text-gray-300 text-sm font-mono`}>
+          {formatTotalSupply(contract.totalSupply, contract.decimals)}
+        </td>
+      )}
+      <td className={`hidden lg:table-cell ${TD_BASE}`}>
+        {contract.creatorAddress ? (
+          <Link
+            href={`/address/${contract.creatorAddress}`}
+            className="text-gray-400 hover:text-[#ffa729] font-mono text-sm"
+          >
+            {truncateAddress(contract.creatorAddress, 6, 4)}
+          </Link>
+        ) : (
+          <span className="text-gray-500 text-sm">-</span>
+        )}
+      </td>
+      <td className={`hidden xl:table-cell ${TD_BASE} text-gray-300 text-sm font-mono`}>
+        {contract.creationBlockNumber ? (
+          <Link
+            href={`/block/${formatBlockNumber(contract.creationBlockNumber).replace(/,/g, '')}`}
+            className="text-gray-400 hover:text-[#ffa729]"
+          >
+            #{formatBlockNumber(contract.creationBlockNumber)}
+          </Link>
+        ) : (
+          '-'
+        )}
+      </td>
+    </tr>
   );
 }

--- a/ExplorerFrontend/app/contracts/contracts-client.tsx
+++ b/ExplorerFrontend/app/contracts/contracts-client.tsx
@@ -17,6 +17,7 @@ interface ContractData {
   totalSupply?: string;
   creationBlockNumber?: string;
   isToken: boolean;
+  tokenStandard?: 'ERC-20' | 'ERC-721' | 'ERC-1155' | string;
 }
 
 interface ContractsClientProps {
@@ -24,7 +25,37 @@ interface ContractsClientProps {
   totalContracts: number;
 }
 
-type TabType = 'tokens' | 'contracts';
+// Per-tab → backend filter mapping. ERC-20/721/1155 use the ?standard= filter
+// added in Phase 1; 'contracts' (other) uses ?isToken=false to surface non-
+// token contracts. 'all' has no filter — useful for search-everything.
+type TabType = 'erc20' | 'erc721' | 'erc1155' | 'contracts';
+
+const TAB_TO_STANDARD: Record<TabType, 'ERC-20' | 'ERC-721' | 'ERC-1155' | null> = {
+  erc20: 'ERC-20',
+  erc721: 'ERC-721',
+  erc1155: 'ERC-1155',
+  contracts: null,
+};
+
+const STANDARD_LABEL: Record<string, string> = {
+  'ERC-20': 'Token',
+  'ERC-721': 'NFT',
+  'ERC-1155': 'Multi-Token',
+};
+
+const TAB_RESULT_NOUN: Record<TabType, string> = {
+  erc20: 'tokens',
+  erc721: 'NFT collections',
+  erc1155: 'multi-token collections',
+  contracts: 'contracts',
+};
+
+const TAB_EMPTY_TITLE: Record<TabType, string> = {
+  erc20: 'No tokens found',
+  erc721: 'No NFT collections found',
+  erc1155: 'No multi-token collections found',
+  contracts: 'No contracts found',
+};
 
 const ITEMS_PER_PAGE = 15;
 
@@ -112,14 +143,14 @@ function truncateAddress(addr: string, start = 8, end = 6): string {
 }
 
 export default function ContractsClient({ initialData, totalContracts }: ContractsClientProps) {
-  const [activeTab, setActiveTab] = useState<TabType>('tokens');
+  const [activeTab, setActiveTab] = useState<TabType>('erc20');
   const [searchQuery, setSearchQuery] = useState('');
   const [currentPage, setCurrentPage] = useState(0);
   const [contracts, setContracts] = useState<ContractData[]>(initialData);
   const [loading, setLoading] = useState(false);
   const [total, setTotal] = useState(totalContracts);
 
-  const fetchContracts = useCallback(async (page: number, search: string, isToken: boolean | null) => {
+  const fetchContracts = useCallback(async (page: number, search: string, tab: TabType) => {
     try {
       setLoading(true);
       const cleanSearch = search ? search.toLowerCase().replace(/^0x/, '') : undefined;
@@ -133,9 +164,12 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
         params.search = cleanSearch;
       }
 
-      // Filter by isToken based on active tab
-      if (isToken !== null) {
-        params.isToken = isToken;
+      const standard = TAB_TO_STANDARD[tab];
+      if (standard !== null) {
+        params.standard = standard;
+      } else {
+        // 'contracts' tab → non-token contracts only.
+        params.isToken = false;
       }
 
       const response = await axios.get(`${config.handlerUrl}/contracts`, { params });
@@ -155,9 +189,8 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
 
   // Fetch when tab, search, or page changes
   useEffect(() => {
-    const isToken = activeTab === 'tokens' ? true : false;
     const timer = setTimeout(() => {
-      fetchContracts(currentPage, searchQuery, isToken);
+      fetchContracts(currentPage, searchQuery, activeTab);
     }, searchQuery ? 300 : 0);
 
     return () => clearTimeout(timer);
@@ -183,9 +216,11 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
       </div>
 
       {/* Tabs */}
-      <div role="tablist" className="flex gap-2 mb-6">
-        <TabButton tab="tokens" label="Tokens" activeTab={activeTab} onSelect={setActiveTab} />
-        <TabButton tab="contracts" label="All Contracts" activeTab={activeTab} onSelect={setActiveTab} />
+      <div role="tablist" className="flex flex-wrap gap-2 mb-6">
+        <TabButton tab="erc20" label="ERC-20" activeTab={activeTab} onSelect={setActiveTab} />
+        <TabButton tab="erc721" label="NFTs (ERC-721)" activeTab={activeTab} onSelect={setActiveTab} />
+        <TabButton tab="erc1155" label="Multi-Token (ERC-1155)" activeTab={activeTab} onSelect={setActiveTab} />
+        <TabButton tab="contracts" label="Other Contracts" activeTab={activeTab} onSelect={setActiveTab} />
       </div>
 
       {/* Search */}
@@ -199,7 +234,7 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
           <input
             type="text"
             aria-label="Search contracts"
-            placeholder={activeTab === 'tokens' ? 'Search by token name or address...' : 'Search by contract address...'}
+            placeholder={activeTab === 'contracts' ? 'Search by contract address...' : 'Search by token name or address...'}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="w-full p-3 pl-10 bg-[#2d2d2d] border border-[#3d3d3d] rounded-lg text-gray-300 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#ffa729] focus:border-transparent"
@@ -209,7 +244,9 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
 
       {/* Results Count */}
       <div className="mb-4 text-sm text-gray-400">
-        {loading ? 'Loading...' : `${total} ${activeTab === 'tokens' ? 'tokens' : 'contracts'} found`}
+        {loading
+          ? 'Loading...'
+          : `${total} ${TAB_RESULT_NOUN[activeTab]} found`}
       </div>
 
       {/* Content */}
@@ -222,13 +259,18 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
           </div>
         ) : contracts.length === 0 ? (
           <EmptyState
-            title={activeTab === 'tokens' ? 'No tokens found' : 'No contracts found'}
+            title={TAB_EMPTY_TITLE[activeTab]}
             description="Try adjusting your search or check back later."
           />
-        ) : activeTab === 'tokens' ? (
+        ) : activeTab === 'contracts' ? (
+          <ContractsTable contracts={contracts} />
+        ) : activeTab === 'erc20' ? (
           <TokensTable contracts={contracts} />
         ) : (
-          <ContractsTable contracts={contracts} />
+          <NFTsTable
+            contracts={contracts}
+            standard={activeTab === 'erc721' ? 'ERC-721' : 'ERC-1155'}
+          />
         )}
       </div>
 
@@ -358,6 +400,79 @@ function TokensTable({ contracts }: { contracts: ContractData[] }) {
   );
 }
 
+// NFT / Multi-Token Table Component.
+//
+// Shares the visual identity of TokensTable but drops decimals + totalSupply
+// (ERC-20-specific) and surfaces the standard badge inline so a user
+// scanning the page knows whether each row is 721 or 1155.
+function NFTsTable({
+  contracts,
+  standard,
+}: {
+  contracts: ContractData[];
+  standard: 'ERC-721' | 'ERC-1155';
+}) {
+  const label = STANDARD_LABEL[standard] ?? standard;
+  return (
+    <div className="overflow-x-auto">
+      <table aria-label={`${label} collections`} className="min-w-full divide-y divide-[#3d3d3d]">
+        <thead className="bg-[#2d2d2d]/50">
+          <tr>
+            <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+              Collection
+            </th>
+            <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+              Contract Address
+            </th>
+            <th scope="col" className="hidden sm:table-cell px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+              Standard
+            </th>
+            <th scope="col" className="hidden lg:table-cell px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+              Creator
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[#3d3d3d]">
+          {contracts.map((contract, index) => (
+            <tr key={contract._id || index} className="hover:bg-[#2d2d2d]/30">
+              <td className="px-4 py-4 whitespace-nowrap">
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-full bg-gradient-to-br from-[#ffa729] to-[#ff8c00] flex items-center justify-center text-black font-bold text-sm">
+                    {contract.symbol ? contract.symbol.charAt(0) : '?'}
+                  </div>
+                  <div>
+                    <div className="text-white font-medium">{contract.name || 'Unknown Collection'}</div>
+                    <div className="text-gray-500 text-sm">{contract.symbol || '-'}</div>
+                  </div>
+                </div>
+              </td>
+              <td className="px-4 py-4 whitespace-nowrap">
+                <Link
+                  href={`/address/${contract.address}`}
+                  className="text-[#ffa729] hover:underline font-mono text-sm"
+                >
+                  {truncateAddress(contract.address)}
+                </Link>
+              </td>
+              <td className="hidden sm:table-cell px-4 py-4 whitespace-nowrap">
+                <Badge variant="warning">{standard === 'ERC-721' ? 'QRC-721' : 'QRC-1155'}</Badge>
+              </td>
+              <td className="hidden lg:table-cell px-4 py-4 whitespace-nowrap">
+                <Link
+                  href={`/address/${contract.creatorAddress}`}
+                  className="text-gray-400 hover:text-[#ffa729] font-mono text-sm"
+                >
+                  {truncateAddress(contract.creatorAddress, 6, 4)}
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 // All Contracts Table Component
 function ContractsTable({ contracts }: { contracts: ContractData[] }) {
   return (
@@ -392,8 +507,12 @@ function ContractsTable({ contracts }: { contracts: ContractData[] }) {
                 </Link>
               </td>
               <td className="px-4 py-4 whitespace-nowrap">
-                {contract.isToken ? (
-                  <Badge variant="success">Token{contract.symbol ? ` (${contract.symbol})` : ''}</Badge>
+                {contract.tokenStandard === 'ERC-721' ? (
+                  <Badge variant="warning">NFT (QRC-721){contract.symbol ? ` · ${contract.symbol}` : ''}</Badge>
+                ) : contract.tokenStandard === 'ERC-1155' ? (
+                  <Badge variant="warning">Multi-Token (QRC-1155){contract.symbol ? ` · ${contract.symbol}` : ''}</Badge>
+                ) : contract.isToken ? (
+                  <Badge variant="success">Token (QRC-20){contract.symbol ? ` · ${contract.symbol}` : ''}</Badge>
                 ) : (
                   <Badge variant="info">Contract</Badge>
                 )}

--- a/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
+++ b/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
@@ -212,70 +212,98 @@ export default function TransactionView({ transaction }: TransactionViewProps): 
       )}
 
       {/* Token Transfer Section */}
-      {transaction.tokenTransfer && (
+      {transaction.tokenTransfer && (() => {
+        const tt = transaction.tokenTransfer;
+        // Per-standard presentation. The header badge reflects the chain
+        // standard (QRC-20 / QRC-721 / QRC-1155); ERC-721 transfers always
+        // move exactly one token, so we surface the tokenID rather than an
+        // ABI-encoded amount.
+        const standard = tt.tokenStandard;
+        const headerLabel =
+          standard === 'ERC-721' ? 'NFT Transfer'
+          : standard === 'ERC-1155' ? 'Multi-Token Transfer'
+          : 'Token Transfer';
+        const badgeText =
+          standard === 'ERC-721' ? 'QRC-721'
+          : standard === 'ERC-1155' ? 'QRC-1155'
+          : 'QRC-20';
+        const isNFT = standard === 'ERC-721' || standard === 'ERC-1155';
+        return (
         <div className="rounded-xl bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f] border border-[#3d3d3d] shadow-xl overflow-hidden mb-6">
           <div className="px-4 sm:px-6 py-4 border-b border-[#3d3d3d]">
             <div className="flex items-center gap-2">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 text-[#ffa729]">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
               </svg>
-              <h2 className="text-[15px] font-semibold text-[#ffa729]">Token Transfer</h2>
-              <Badge variant="brand">QRC-20</Badge>
+              <h2 className="text-[15px] font-semibold text-[#ffa729]">{headerLabel}</h2>
+              <Badge variant={isNFT ? 'warning' : 'brand'}>{badgeText}</Badge>
             </div>
           </div>
           <div className="p-4 sm:p-6">
-            <DetailRow label="Token">
+            <DetailRow label={standard === 'ERC-721' ? 'Collection' : standard === 'ERC-1155' ? 'Collection' : 'Token'}>
               <Link
-                href={`/address/${transaction.tokenTransfer.contractAddress}`}
+                href={`/address/${tt.contractAddress}`}
                 className="text-[#ffa729] hover:text-[#ffb84d] font-medium transition-colors"
               >
-                {transaction.tokenTransfer.tokenName} ({transaction.tokenTransfer.tokenSymbol})
+                {tt.tokenName || tt.tokenSymbol || tt.contractAddress} {tt.tokenSymbol ? `(${tt.tokenSymbol})` : ''}
               </Link>
             </DetailRow>
-            <DetailRow label="Amount">
-              <span className="font-semibold text-white">
-                {formatTokenAmount(transaction.tokenTransfer.amount, transaction.tokenTransfer.tokenDecimals)}
-              </span>
-              <span className="text-[#ffa729] ml-2 text-sm">{transaction.tokenTransfer.tokenSymbol}</span>
-            </DetailRow>
+            {tt.tokenID && (
+              <DetailRow label="Token ID" mono>
+                <span className="font-semibold text-white">#{tt.tokenID}</span>
+              </DetailRow>
+            )}
+            {standard !== 'ERC-721' && (
+              <DetailRow label="Amount">
+                <span className="font-semibold text-white">
+                  {standard === 'ERC-1155'
+                    ? tt.amount
+                    : formatTokenAmount(tt.amount, tt.tokenDecimals)}
+                </span>
+                {tt.tokenSymbol && (
+                  <span className="text-[#ffa729] ml-2 text-sm">{tt.tokenSymbol}</span>
+                )}
+              </DetailRow>
+            )}
             <DetailRow label="From" mono>
-              {isZeroAddress(transaction.tokenTransfer.from) ? (
+              {isZeroAddress(tt.from) ? (
                 <div className="flex items-center gap-2">
                   <Badge variant="success">Mint</Badge>
                   <span className="text-sm text-gray-400">
                     via{' '}
                     <Link
-                      href={`/address/${transaction.tokenTransfer.contractAddress}`}
+                      href={`/address/${tt.contractAddress}`}
                       className="text-[#ffa729] hover:text-[#ffb84d] transition-colors"
                     >
-                      {transaction.tokenTransfer.tokenName} Contract
+                      {tt.tokenName || 'Contract'}
                     </Link>
                   </span>
                 </div>
               ) : (
                 <Link
-                  href={`/address/${transaction.tokenTransfer.from}`}
+                  href={`/address/${tt.from}`}
                   className="text-gray-200 hover:text-[#ffa729] transition-colors break-all"
                 >
-                  {displayAddr(transaction.tokenTransfer.from)}
+                  {displayAddr(tt.from)}
                 </Link>
               )}
             </DetailRow>
             <DetailRow label="To" mono>
-              {isZeroAddress(transaction.tokenTransfer.to) ? (
+              {isZeroAddress(tt.to) ? (
                 <Badge variant="error">Burn</Badge>
               ) : (
                 <Link
-                  href={`/address/${transaction.tokenTransfer.to}`}
+                  href={`/address/${tt.to}`}
                   className="text-gray-200 hover:text-[#ffa729] transition-colors break-all"
                 >
-                  {displayAddr(transaction.tokenTransfer.to)}
+                  {displayAddr(tt.to)}
                 </Link>
               )}
             </DetailRow>
           </div>
         </div>
-      )}
+        );
+      })()}
     </div>
   );
 }

--- a/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
+++ b/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
@@ -245,7 +245,8 @@ export default function TransactionView({ transaction }: TransactionViewProps): 
                 href={`/address/${tt.contractAddress}`}
                 className="text-[#ffa729] hover:text-[#ffb84d] font-medium transition-colors"
               >
-                {tt.tokenName || tt.tokenSymbol || tt.contractAddress} {tt.tokenSymbol ? `(${tt.tokenSymbol})` : ''}
+                {tt.tokenName || tt.tokenSymbol || tt.contractAddress}
+                {tt.tokenName && tt.tokenSymbol && tt.tokenSymbol !== tt.tokenName ? ` (${tt.tokenSymbol})` : ''}
               </Link>
             </DetailRow>
             {tt.tokenID && (

--- a/ExplorerFrontend/app/types/address.ts
+++ b/ExplorerFrontend/app/types/address.ts
@@ -14,6 +14,11 @@ export interface ContractData {
   contractCode: string;
   creationTransaction: string;
   isToken: boolean;
+  /** ERC-20 / ERC-721 / ERC-1155 / empty for unclassified. Drives the
+   *  "Token Contract" / "NFT Collection" / "Multi-Token Collection"
+   *  header in address-view + token-contract-view. */
+  tokenStandard?: 'ERC-20' | 'ERC-721' | 'ERC-1155' | string;
+  hasERC165?: boolean;
   status: string;
   decimals: number;
   name: string;

--- a/ExplorerFrontend/app/types/transaction.ts
+++ b/ExplorerFrontend/app/types/transaction.ts
@@ -78,6 +78,12 @@ interface OptionalInternalTransactionFields {
 export type InternalTransaction = BaseInternalTransaction & OptionalInternalTransactionFields;
 
 /**
+ * Token standard tag persisted on contract + transfer rows. Empty for
+ * legacy un-classified rows; new rows are always one of the three.
+ */
+export type TokenStandard = 'ERC-20' | 'ERC-721' | 'ERC-1155';
+
+/**
  * Token transfer information for a transaction
  */
 export interface TokenTransferInfo {
@@ -88,6 +94,10 @@ export interface TokenTransferInfo {
   tokenName: string;
   tokenSymbol: string;
   tokenDecimals: number;
+  /** ERC-20 | ERC-721 | ERC-1155 — drives the row's badge in transaction-view. */
+  tokenStandard?: TokenStandard | string;
+  /** uint256 decimal string. Populated for ERC-721 + ERC-1155 transfers. */
+  tokenID?: string;
 }
 
 /**
@@ -112,6 +122,7 @@ export interface TransactionDetails {
     name: string;
     symbol: string;
     decimals: number;
+    tokenStandard?: TokenStandard | string;
   };
   tokenTransfer?: TokenTransferInfo;
 }

--- a/QRL2MongoDB/db/contracts.go
+++ b/QRL2MongoDB/db/contracts.go
@@ -110,11 +110,39 @@ func StoreContract(contract models.ContractInfo) error {
 		// `contract.IsToken == false` is a no-op for IsToken + token
 		// metadata; keep existing values intact.
 
+		// TokenStandard promotion ladder: "" → ERC-20 → ERC-721/1155.
+		// Same promote-only rationale as IsToken: a transient RPC blip
+		// must never demote a previously-classified contract. ERC-1155
+		// outranks ERC-721 so dual-impl edge cases (rare) pick the
+		// broader standard. The merge never moves DOWN the ladder.
+		if standardRank(contract.TokenStandard) > standardRank(merged.TokenStandard) {
+			merged.TokenStandard = contract.TokenStandard
+		}
+		// HasERC165 latches true forever — a contract that ever responded
+		// to supportsInterface didn't UN-implement ERC-165 later. Skip the
+		// flag flip on transient probe failures (those return HasERC165=false).
+		if contract.HasERC165 {
+			merged.HasERC165 = true
+		}
+		// BaseURI is gap-fill only (Phase 3 will populate it from tokenURI
+		// / uri probes). Never overwrite or clear.
+		if merged.BaseURI == "" && contract.BaseURI != "" {
+			merged.BaseURI = contract.BaseURI
+		}
 	} else if !errors.Is(err, mongo.ErrNoDocuments) {
 		configs.Logger.Error("Failed to check for existing contract",
 			zap.String("address", contract.Address),
 			zap.Error(err))
 		return err
+	}
+
+	// IsToken back-compat: any classified standard implies isToken=true so
+	// the legacy `?isToken=true` API filter continues to surface NFT
+	// collections alongside ERC-20s. Applied in BOTH the merge and the
+	// fresh-write path — callers that set TokenStandard without IsToken
+	// (e.g. backfill scripts) still produce correct rows.
+	if merged.TokenStandard != "" {
+		merged.IsToken = true
 	}
 
 	// Stamp updatedAt once for both code paths (merge + first-write).
@@ -183,7 +211,36 @@ func syncerOwnedSet(c models.ContractInfo) bson.M {
 	if c.MaxTxLimit != "" {
 		m["maxTxLimit"] = c.MaxTxLimit
 	}
+	// NFT classification — omit when empty/false so the document stays clean
+	// for non-token contracts AND a transient blip that produces zero values
+	// can't clobber a previously-set value (writing `false` would overwrite
+	// `true`; omitting the key leaves the existing value untouched).
+	if c.TokenStandard != "" {
+		m["tokenStandard"] = c.TokenStandard
+	}
+	if c.HasERC165 {
+		m["hasERC165"] = true
+	}
+	if c.BaseURI != "" {
+		m["baseURI"] = c.BaseURI
+	}
 	return m
+}
+
+// standardRank orders TokenStandard values for promote-only merging.
+// Higher rank = stricter / more specific classification. Promotions go
+// up the ladder; demotions are silently dropped.
+func standardRank(s string) int {
+	switch s {
+	case "ERC-1155":
+		return 3
+	case "ERC-721":
+		return 2
+	case "ERC-20":
+		return 1
+	default:
+		return 0
+	}
 }
 
 // GetContract retrieves contract information from the database
@@ -247,29 +304,28 @@ func processContracts(tx *models.Transaction) (string, string, string, bool) {
 					zap.Error(err))
 			}
 
-			// Get token information
-			name, symbol, decimals, isToken := rpc.GetTokenInfo(contractAddress)
-
-			// Get total supply if it's a token
-			var totalSupply string
-			if isToken {
-				totalSupply, err = rpc.GetTokenTotalSupply(contractAddress)
-				if err != nil {
-					configs.Logger.Error("Failed to get token total supply",
-						zap.String("address", contractAddress),
-						zap.Error(err))
-				}
+			// Classify the contract (ERC-20 / ERC-721 / ERC-1155 / unknown).
+			// On transient probe failure the result is zero-valued; the
+			// StoreContract merge's promote-only invariant prevents that
+			// from clobbering a previously-good classification.
+			detection, detErr := rpc.DetectContractType(contractAddress)
+			if detErr != nil {
+				configs.Logger.Warn("Contract type detection failed; storing without classification",
+					zap.String("address", contractAddress),
+					zap.Error(detErr))
 			}
 
 			// Store complete contract information
 			contract := models.ContractInfo{
 				Address:             contractAddress,
 				Status:              statusTx,
-				IsToken:             isToken,
-				Name:                name,
-				Symbol:              symbol,
-				Decimals:            decimals,
-				TotalSupply:         totalSupply,
+				IsToken:             detection.Standard != "",
+				Name:                detection.Name,
+				Symbol:              detection.Symbol,
+				Decimals:            detection.Decimals,
+				TotalSupply:         detection.TotalSupply,
+				TokenStandard:       detection.Standard,
+				HasERC165:           detection.HasERC165,
 				ContractCode:        contractCode,
 				CreatorAddress:      tx.From,
 				CreationTransaction: tx.Hash,
@@ -325,18 +381,14 @@ func IsAddressContract(address string) bool {
 		configs.Logger.Info("Detected existing contract",
 			zap.String("address", address))
 
-		// Get token information
-		name, symbol, decimals, isToken := rpc.GetTokenInfo(address)
-
-		// Get total supply if it's a token
-		var totalSupply string
-		if isToken {
-			totalSupply, err = rpc.GetTokenTotalSupply(address)
-			if err != nil {
-				configs.Logger.Error("Failed to get token total supply",
-					zap.String("address", address),
-					zap.Error(err))
-			}
+		// Classify (ERC-20 / 721 / 1155 / unknown). Transient probe
+		// failures are logged but non-fatal — StoreContract preserves
+		// any previously-good classification through its merge.
+		detection, detErr := rpc.DetectContractType(address)
+		if detErr != nil {
+			configs.Logger.Warn("Contract type detection failed; storing without classification",
+				zap.String("address", address),
+				zap.Error(detErr))
 		}
 
 		// First try to get existing contract from both collections to preserve creation data
@@ -344,15 +396,17 @@ func IsAddressContract(address string) bool {
 
 		// Create base contract info
 		contract := models.ContractInfo{
-			Address:      address,
-			Status:       "0x1", // Assume successful
-			IsToken:      isToken,
-			Name:         name,
-			Symbol:       symbol,
-			Decimals:     decimals,
-			TotalSupply:  totalSupply,
-			ContractCode: code,
-			UpdatedAt:    time.Now().UTC().Format(time.RFC3339),
+			Address:       address,
+			Status:        "0x1", // Assume successful
+			IsToken:       detection.Standard != "",
+			Name:          detection.Name,
+			Symbol:        detection.Symbol,
+			Decimals:      detection.Decimals,
+			TotalSupply:   detection.TotalSupply,
+			TokenStandard: detection.Standard,
+			HasERC165:     detection.HasERC165,
+			ContractCode:  code,
+			UpdatedAt:     time.Now().UTC().Format(time.RFC3339),
 		}
 
 		// If we have existing contract data, preserve the creation information
@@ -452,24 +506,24 @@ func ReprocessIncompleteContracts() error {
 			}
 		}
 
-		// Get token information if missing
+		// Get token information if missing. ReprocessIncompleteContracts
+		// is the hourly self-heal pass — a fresh DetectContractType probe
+		// also picks up NFT contracts we previously couldn't classify
+		// (`tokenStandard` migration of legacy rows).
 		if !contract.IsToken && contract.Name == "" && contract.Symbol == "" {
-			name, symbol, decimals, isToken := rpc.GetTokenInfo(contract.Address)
-			if isToken {
-				contract.IsToken = isToken
-				contract.Name = name
-				contract.Symbol = symbol
-				contract.Decimals = decimals
-
-				// Get total supply for new tokens
-				totalSupply, err := rpc.GetTokenTotalSupply(contract.Address)
-				if err != nil {
-					configs.Logger.Error("Failed to get token total supply",
-						zap.String("address", contract.Address),
-						zap.Error(err))
-				} else {
-					contract.TotalSupply = totalSupply
-				}
+			detection, detErr := rpc.DetectContractType(contract.Address)
+			if detErr != nil {
+				configs.Logger.Debug("Contract type detection failed during reprocess; skipping",
+					zap.String("address", contract.Address),
+					zap.Error(detErr))
+			} else if detection.Standard != "" {
+				contract.IsToken = true
+				contract.Name = detection.Name
+				contract.Symbol = detection.Symbol
+				contract.Decimals = detection.Decimals
+				contract.TotalSupply = detection.TotalSupply
+				contract.TokenStandard = detection.Standard
+				contract.HasERC165 = detection.HasERC165
 			}
 		} else if contract.IsToken && contract.TotalSupply == "" {
 			// Get total supply for token with missing supply

--- a/QRL2MongoDB/db/token_detection.go
+++ b/QRL2MongoDB/db/token_detection.go
@@ -9,15 +9,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// TokenDetectionResult holds the result of token detection
-type TokenDetectionResult struct {
-	IsToken     bool
-	Name        string
-	Symbol      string
-	Decimals    uint8
-	TotalSupply string
-}
-
 // preserveCreationInfo copies creation metadata from an existing contract to a new contract info.
 // This ensures we don't lose historical data like creator address and creation transaction.
 func preserveCreationInfo(contractInfo *models.ContractInfo, existingContract *models.ContractInfo) {
@@ -30,77 +21,70 @@ func preserveCreationInfo(contractInfo *models.ContractInfo, existingContract *m
 	contractInfo.ContractCode = existingContract.ContractCode
 }
 
-// DetectToken checks if a contract address is a valid ERC20 token
-// by calling the standard ERC20 methods (name, symbol, decimals)
-func DetectToken(contractAddress string) TokenDetectionResult {
-	name, symbol, decimals, isToken := rpc.GetTokenInfo(contractAddress)
-	if !isToken {
-		return TokenDetectionResult{IsToken: false}
-	}
-
-	// Get total supply if it's a token
-	totalSupply, err := rpc.GetTokenTotalSupply(contractAddress)
-	if err != nil {
-		configs.Logger.Debug("Failed to get token total supply",
+// EnsureContractClassified looks the contract up via DetectContractType and
+// persists the (possibly updated) classification.
+//
+// Returns the merged ContractInfo and the detected standard string
+// ("ERC-20"/"ERC-721"/"ERC-1155" or "" for unclassified). Callers should
+// check `standard == ""` to skip non-token logs; the *ContractInfo will still
+// be populated when an existing contract record was preserved.
+//
+// On transient RPC failure DetectContractType returns an error and we return
+// (existing, "") — never demoting a previously-classified contract. The
+// caller's "skip non-token" guard correctly skips this log; the next sighting
+// re-tries and either succeeds (promotion) or stays unclassified (no harm).
+func EnsureContractClassified(contractAddress string, blockNumber string, txHash string) (*models.ContractInfo, string) {
+	detection, detErr := rpc.DetectContractType(contractAddress)
+	if detErr != nil {
+		// Transient probe failure — preserve existing state, don't write
+		// anything that would clobber a previously-good classification.
+		configs.Logger.Debug("Contract type detection failed; preserving existing classification",
 			zap.String("address", contractAddress),
-			zap.Error(err))
+			zap.Error(detErr))
+		existing, _ := GetContract(contractAddress)
+		if existing != nil && existing.TokenStandard != "" {
+			return existing, existing.TokenStandard
+		}
+		return existing, ""
 	}
-
-	return TokenDetectionResult{
-		IsToken:     true,
-		Name:        name,
-		Symbol:      symbol,
-		Decimals:    decimals,
-		TotalSupply: totalSupply,
-	}
-}
-
-// EnsureTokenInDatabase ensures a token contract exists in the database with up-to-date info.
-// If the contract already exists, it preserves existing creation information.
-// Returns the contract info and whether it's a token.
-func EnsureTokenInDatabase(contractAddress string, blockNumber string, txHash string) (*models.ContractInfo, bool) {
-	// First check via RPC if this is actually a token
-	detection := DetectToken(contractAddress)
-	if !detection.IsToken {
-		configs.Logger.Debug("RPC check indicates contract is not a token",
+	if detection.Standard == "" {
+		// Not a recognised standard; not necessarily an error. Don't churn
+		// the DB on every log emission from such a contract.
+		configs.Logger.Debug("Contract is not a recognised token standard",
 			zap.String("address", contractAddress))
-		return nil, false
+		return nil, ""
 	}
 
-	configs.Logger.Debug("RPC check confirms contract is a token",
+	configs.Logger.Debug("Contract classified",
 		zap.String("address", contractAddress),
+		zap.String("standard", detection.Standard),
 		zap.String("name", detection.Name),
 		zap.String("symbol", detection.Symbol))
 
-	// Try to get existing contract from DB to preserve creation information
 	existingContract, err := GetContract(contractAddress)
 	if err != nil {
-		// Log unexpected errors (not just "not found")
-		configs.Logger.Debug("GetContract returned error",
+		configs.Logger.Debug("GetContract returned error (treating as fresh)",
 			zap.String("address", contractAddress),
 			zap.Error(err))
 	}
 
-	// Build the contract info
 	contractInfo := models.ContractInfo{
-		Address:   contractAddress,
-		Status:    "0x1", // Assume successful
-		IsToken:   true,
-		Name:      detection.Name,
-		Symbol:    detection.Symbol,
-		Decimals:  detection.Decimals,
-		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+		Address:       contractAddress,
+		Status:        "0x1",
+		IsToken:       true,
+		Name:          detection.Name,
+		Symbol:        detection.Symbol,
+		Decimals:      detection.Decimals,
+		TotalSupply:   detection.TotalSupply,
+		TokenStandard: detection.Standard,
+		HasERC165:     detection.HasERC165,
+		UpdatedAt:     time.Now().UTC().Format(time.RFC3339),
 	}
 
-	if detection.TotalSupply != "" {
-		contractInfo.TotalSupply = detection.TotalSupply
-	}
-
-	// If this is the first time we're seeing this token, look up the actual
-	// creation transaction from the transfer collection (a fast DB query).
-	// This populates creator info immediately instead of waiting for the
-	// hourly reprocessing job.
 	if existingContract == nil {
+		// First sighting — try to backfill creator info from the transfer
+		// collection now (cheap DB lookup) rather than waiting for the
+		// hourly reprocess job.
 		contractInfo.CreationBlockNumber = blockNumber
 		if creationTx := findCreationTransaction(contractAddress); creationTx != nil {
 			contractInfo.CreationTransaction = creationTx.TxHash
@@ -110,19 +94,17 @@ func EnsureTokenInDatabase(contractAddress string, blockNumber string, txHash st
 			}
 		}
 	} else {
-		// Preserve existing creation information
 		preserveCreationInfo(&contractInfo, existingContract)
 	}
 
-	// Store/merge the contract info
 	if err := StoreContract(contractInfo); err != nil {
-		configs.Logger.Error("Failed to store/update token contract",
+		configs.Logger.Error("Failed to store/update classified contract",
 			zap.String("address", contractAddress),
 			zap.Error(err))
-		return nil, false
+		return nil, ""
 	}
 
-	return &contractInfo, true
+	return &contractInfo, detection.Standard
 }
 
 // GetTokenFromDatabase retrieves token info from database and verifies it's a token.
@@ -137,4 +119,3 @@ func GetTokenFromDatabase(contractAddress string) *models.ContractInfo {
 	}
 	return contract
 }
-

--- a/QRL2MongoDB/db/tokentransfers.go
+++ b/QRL2MongoDB/db/tokentransfers.go
@@ -6,6 +6,8 @@ import (
 	"QRL2MongoDB/rpc"
 	"QRL2MongoDB/validation"
 	"context"
+	"fmt"
+	"math/big"
 	"strings"
 	"time"
 
@@ -123,18 +125,18 @@ func GetTokenTransfersByAddress(address string, skip, limit int64) ([]models.Tok
 }
 
 // TokenTransferExists checks if a specific token transfer is already
-// persisted. The dedupe key is (txHash, contractAddress, logIndex):
+// persisted. The dedupe key is (txHash, contractAddress, logIndex, tokenID):
 //
-//   - txHash + logIndex alone collide across token contracts when a
-//     single tx routes through multiple tokens (a swap that transfers
-//     tokenA at log 0 and tokenB at log 1 → both rows distinct on
-//     logIndex, but the legacy direct-calldata path writes logIndex=""
-//     for every contract it touches in the same tx, so contractAddress
-//     is what keeps them apart).
-//   - The legacy four-arg form (txHash + contractAddress + from + to)
-//     collided on self-transfers (from == to) and on identical
-//     bridge-style transfers within one tx.
-func TokenTransferExists(txHash string, contractAddress string, logIndex string) (bool, error) {
+//   - logIndex was added in #88 so multi-transfer txs (a DEX swap that
+//     emits 3 Transfer events) don't collide on (txHash, contract) alone.
+//   - tokenID was added with NFT support: ERC-1155 TransferBatch logs
+//     produce N rows per log (one per (id, value) tuple) that share the
+//     same (txHash, contract, logIndex) — only tokenID distinguishes them.
+//
+// Legacy rows pre-date the LogIndex and TokenID fields, so a missing-field
+// match is needed for the empty-string sentinel paths (direct-calldata
+// writes LogIndex="" with TokenID=""; pre-NFT rows have no tokenID at all).
+func TokenTransferExists(txHash, contractAddress, logIndex, tokenID string) (bool, error) {
 	collection := configs.GetCollection(configs.DB, "tokenTransfers")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -144,19 +146,28 @@ func TokenTransferExists(txHash string, contractAddress string, logIndex string)
 		"txHash":          txHash,
 		"contractAddress": contractAddress,
 	}
-	// Pre-fix documents (written before LogIndex existed on the model)
-	// have NO `logIndex` field at all. In Mongo a query `{logIndex: ""}`
-	// does NOT match documents where the field is missing, so a direct-
-	// calldata reprocess of any legacy tx would always return false here
-	// and write a duplicate. For the empty-string sentinel (legacy direct
-	// path) match both the explicit "" and missing-field cases.
+
+	andClauses := []bson.M{}
 	if logIndex == "" {
-		filter["$or"] = []bson.M{
+		andClauses = append(andClauses, bson.M{"$or": []bson.M{
 			{"logIndex": ""},
 			{"logIndex": bson.M{"$exists": false}},
-		}
+		}})
 	} else {
 		filter["logIndex"] = logIndex
+	}
+	if tokenID == "" {
+		// `omitempty` on the new TokenID field strips it for ERC-20 writes,
+		// and pre-NFT rows never had the field — both must match this clause.
+		andClauses = append(andClauses, bson.M{"$or": []bson.M{
+			{"tokenID": ""},
+			{"tokenID": bson.M{"$exists": false}},
+		}})
+	} else {
+		filter["tokenID"] = tokenID
+	}
+	if len(andClauses) > 0 {
+		filter["$and"] = andClauses
 	}
 
 	count, err := collection.CountDocuments(ctx, filter)
@@ -165,6 +176,7 @@ func TokenTransferExists(txHash string, contractAddress string, logIndex string)
 			zap.String("txHash", txHash),
 			zap.String("contractAddress", contractAddress),
 			zap.String("logIndex", logIndex),
+			zap.String("tokenID", tokenID),
 			zap.Error(err))
 		return false, err
 	}
@@ -172,16 +184,27 @@ func TokenTransferExists(txHash string, contractAddress string, logIndex string)
 	return count > 0, nil
 }
 
-// ProcessBlockTokenTransfers processes all token transfers in a block
+// ProcessBlockTokenTransfers processes all token-transfer events in a block
+// across the three supported standards (ERC-20, ERC-721, ERC-1155).
+//
+// We pull all three event signatures in a single qrl_getLogs call (OR-matched
+// on topic[0]), classify the emitting contract via supportsInterface, then
+// dispatch to a per-standard decoder. ERC-20/721 share the same topic[0] so
+// the (standard, topicCount) tuple is the disambiguator — relying on the
+// contract's persisted classification rather than per-event guesswork
+// closes the topic-0 ambiguity surface.
 func ProcessBlockTokenTransfers(blockNumber string, blockTimestamp string) error {
-	// Get logs for the Transfer event signature
-	transferEventSignature := "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+	sigs := []string{
+		rpc.TransferEventSignature,       // ERC-20 + ERC-721
+		rpc.TransferSingleEventSignature, // ERC-1155
+		rpc.TransferBatchEventSignature,  // ERC-1155
+	}
 
 	configs.Logger.Info("Searching for token transfers",
 		zap.String("blockNumber", blockNumber),
-		zap.String("eventSignature", transferEventSignature))
+		zap.Strings("eventSignatures", sigs))
 
-	response, err := rpc.ZondGetBlockLogs(blockNumber, []string{transferEventSignature})
+	response, err := rpc.ZondGetBlockLogs(blockNumber, sigs)
 	if err != nil {
 		configs.Logger.Error("Failed to get logs for block",
 			zap.String("blockNumber", blockNumber),
@@ -192,17 +215,15 @@ func ProcessBlockTokenTransfers(blockNumber string, blockTimestamp string) error
 	if response == nil || len(response.Result) == 0 {
 		configs.Logger.Debug("No token transfer logs found in block",
 			zap.String("blockNumber", blockNumber))
-		return nil // No logs found
+		return nil
 	}
 
 	configs.Logger.Info("Found potential token transfer logs",
 		zap.String("blockNumber", blockNumber),
 		zap.Int("logCount", len(response.Result)))
 
-	// Process each log
 	tokenTransfersFound := 0
 	for _, log := range response.Result {
-		// Skip logs with insufficient topics
 		if len(log.Topics) < 3 {
 			configs.Logger.Debug("Skipping log with insufficient topics",
 				zap.String("txHash", log.TransactionHash),
@@ -210,128 +231,236 @@ func ProcessBlockTokenTransfers(blockNumber string, blockTimestamp string) error
 			continue
 		}
 
-		// Extract contract address
 		contractAddress := log.Address
-		configs.Logger.Debug("Processing potential token transfer",
-			zap.String("contractAddress", contractAddress),
-			zap.String("txHash", log.TransactionHash))
-
-		// Use the consolidated contract classification logic.
-		// Phase 1: still ERC-20-only dispatch downstream; ERC-721/1155
-		// classification is persisted but transfer decoding will land in
-		// the next commit. Until then, skip non-ERC-20 logs to avoid
-		// writing garbage rows for events we don't yet decode.
 		contract, standard := EnsureContractClassified(contractAddress, blockNumber, log.TransactionHash)
 		if standard == "" || contract == nil {
 			configs.Logger.Debug("Contract is not a recognised token standard, skipping",
 				zap.String("address", contractAddress))
 			continue
 		}
-		if standard != rpc.StandardERC20 {
-			configs.Logger.Debug("Skipping non-ERC-20 standard until dispatch lands",
-				zap.String("address", contractAddress),
-				zap.String("standard", standard))
-			continue
-		}
 
-		// Extract from and to addresses using canonical Q-prefix form.
-		// topics[1] and topics[2] are 32-byte padded addresses; strip the 12-byte
-		// zero-padding (24 hex chars) to recover the 20-byte address.
-		from := "Q" + strings.ToLower(rpc.TrimLeftZeros(log.Topics[1][26:]))
-		to := "Q" + strings.ToLower(rpc.TrimLeftZeros(log.Topics[2][26:]))
-
-		configs.Logger.Debug("Token transfer details",
-			zap.String("from", from),
-			zap.String("to", to),
-			zap.String("token", contract.Symbol))
-
-		// Extract amount
-		amount := log.Data
-
-		// Check if this specific log already persisted (idempotent on
-		// reprocess). Per-(tx, contract, logIndex) granularity matters:
-		// a single tx may emit Transfer events from multiple token
-		// contracts in any order.
-		exists, err := TokenTransferExists(log.TransactionHash, contractAddress, log.LogIndex)
-		if err != nil {
-			configs.Logger.Error("Failed to check if token transfer exists",
+		rows, decErr := decodeTransferLog(log, contract, standard, blockNumber, blockTimestamp)
+		if decErr != nil {
+			configs.Logger.Warn("Failed to decode transfer log",
 				zap.String("txHash", log.TransactionHash),
-				zap.Error(err))
+				zap.String("contract", contractAddress),
+				zap.String("standard", standard),
+				zap.String("topic0", log.Topics[0]),
+				zap.Int("topicCount", len(log.Topics)),
+				zap.Error(decErr))
 			continue
 		}
 
-		if exists {
-			// Skip duplicate transfers
-			configs.Logger.Debug("Skipping duplicate token transfer",
-				zap.String("txHash", log.TransactionHash))
-			continue
-		}
+		for _, row := range rows {
+			exists, err := TokenTransferExists(row.TxHash, row.ContractAddress, row.LogIndex, row.TokenID)
+			if err != nil {
+				configs.Logger.Error("Failed to check token transfer dedup",
+					zap.String("txHash", row.TxHash),
+					zap.Error(err))
+				continue
+			}
+			if exists {
+				configs.Logger.Debug("Skipping duplicate token transfer",
+					zap.String("txHash", row.TxHash),
+					zap.String("logIndex", row.LogIndex),
+					zap.String("tokenID", row.TokenID))
+				continue
+			}
 
-		// Normalize addresses to ensure consistency.
-		if from == "" || from == "q" || from == "Q" {
-			from = configs.QRLZeroAddress
-		}
+			if err := StoreTokenTransfer(row); err != nil {
+				configs.Logger.Error("Failed to store token transfer",
+					zap.String("txHash", row.TxHash),
+					zap.Error(err))
+				continue
+			}
+			tokenTransfersFound++
 
-		if to == "" || to == "q" || to == "Q" {
-			to = configs.QRLZeroAddress
-		}
-
-		// Debug-level log for per-record operations
-		configs.Logger.Debug("Identified token transfer",
-			zap.String("token", contract.Symbol),
-			zap.String("from", from),
-			zap.String("to", to),
-			zap.String("amount", amount),
-			zap.String("blockNumber", blockNumber))
-
-		// Create token transfer record
-		transfer := models.TokenTransfer{
-			ContractAddress: contractAddress,
-			From:            from,
-			To:              to,
-			Amount:          amount,
-			BlockNumber:     blockNumber,
-			TxHash:          log.TransactionHash,
-			LogIndex:        log.LogIndex,
-			Timestamp:       blockTimestamp,
-			TokenSymbol:     contract.Symbol,
-			TokenDecimals:   contract.Decimals,
-			TokenName:       contract.Name,
-			TransferType:    "event",
-		}
-
-		// Store the transfer
-		err = StoreTokenTransfer(transfer)
-		if err != nil {
-			configs.Logger.Error("Failed to store token transfer",
-				zap.String("txHash", log.TransactionHash),
-				zap.Error(err))
-			continue
-		}
-		tokenTransfersFound++
-
-		// Update token balances
-		if err = StoreTokenBalance(contractAddress, from, amount, blockNumber); err != nil {
-			configs.Logger.Error("Failed to update sender token balance",
-				zap.String("address", from),
-				zap.String("contractAddress", contractAddress),
-				zap.Error(err))
-		}
-
-		if err = StoreTokenBalance(contractAddress, to, amount, blockNumber); err != nil {
-			configs.Logger.Error("Failed to update recipient token balance",
-				zap.String("address", to),
-				zap.String("contractAddress", contractAddress),
-				zap.Error(err))
+			// Phase 1 balance maintenance: ERC-20 only. Per-tokenID NFT
+			// ownership lands in Phase 2 (with the (contract, holder,
+			// tokenID) schema rewrite) — counting NFT "balances" with
+			// the current (contract, holder) schema would either lose
+			// per-id info or over-count, so we deliberately skip.
+			if standard == rpc.StandardERC20 {
+				if err := StoreTokenBalance(contractAddress, row.From, row.Amount, blockNumber); err != nil {
+					configs.Logger.Error("Failed to update sender token balance",
+						zap.String("address", row.From),
+						zap.String("contractAddress", contractAddress),
+						zap.Error(err))
+				}
+				if err := StoreTokenBalance(contractAddress, row.To, row.Amount, blockNumber); err != nil {
+					configs.Logger.Error("Failed to update recipient token balance",
+						zap.String("address", row.To),
+						zap.String("contractAddress", contractAddress),
+						zap.Error(err))
+				}
+			}
 		}
 	}
 
-	// Batch summary at Info level
 	configs.Logger.Info("Finished processing token transfers",
 		zap.String("blockNumber", blockNumber),
 		zap.Int("transfersProcessed", tokenTransfersFound))
 
 	return nil
+}
+
+// decodeTransferLog dispatches a transfer log to the correct per-standard
+// decoder. The (standard, topic0, len(topics)) triple disambiguates the
+// ERC-20/ERC-721 topic-0 collision without ever guessing — the contract's
+// persisted classification (from supportsInterface) is the source of truth.
+//
+// Returns a non-nil error only on truly mismatched shapes (e.g. a 4-topic
+// Transfer on a contract we classified as ERC-20). Decoder helpers
+// surface their own errors for malformed data.
+func decodeTransferLog(
+	log models.Log,
+	contract *models.ContractInfo,
+	standard, blockNumber, blockTimestamp string,
+) ([]models.TokenTransfer, error) {
+	if len(log.Topics) == 0 {
+		return nil, fmt.Errorf("log has no topics")
+	}
+	topic0 := log.Topics[0]
+
+	base := models.TokenTransfer{
+		ContractAddress: log.Address,
+		BlockNumber:     blockNumber,
+		TxHash:          log.TransactionHash,
+		LogIndex:        log.LogIndex,
+		Timestamp:       blockTimestamp,
+		TokenSymbol:     contract.Symbol,
+		TokenDecimals:   contract.Decimals,
+		TokenName:       contract.Name,
+		TransferType:    "event",
+		TokenStandard:   standard,
+	}
+
+	switch {
+	case standard == rpc.StandardERC20 && topic0 == rpc.TransferEventSignature && len(log.Topics) == 3:
+		return decodeERC20TransferRow(log, base)
+	case standard == rpc.StandardERC721 && topic0 == rpc.TransferEventSignature && len(log.Topics) == 4:
+		return decodeERC721TransferRow(log, base)
+	case standard == rpc.StandardERC1155 && topic0 == rpc.TransferSingleEventSignature && len(log.Topics) == 4:
+		return decodeERC1155TransferSingleRow(log, base)
+	case standard == rpc.StandardERC1155 && topic0 == rpc.TransferBatchEventSignature && len(log.Topics) == 4:
+		return decodeERC1155TransferBatchRows(log, base)
+	default:
+		return nil, fmt.Errorf("standard/topic mismatch: standard=%s topic0=%s topicCount=%d",
+			standard, topic0, len(log.Topics))
+	}
+}
+
+// decodeERC20TransferRow produces a single TokenTransfer for an ERC-20
+// Transfer log. Amount is left as the raw hex `log.Data` for backward
+// compatibility with rows written before Phase 1.
+func decodeERC20TransferRow(log models.Log, base models.TokenTransfer) ([]models.TokenTransfer, error) {
+	from, to, _, err := ParseStandardTransferTopics(log)
+	if err != nil {
+		return nil, err
+	}
+	base.From = normalizeAddress(from)
+	base.To = normalizeAddress(to)
+	base.Amount = log.Data
+	return []models.TokenTransfer{base}, nil
+}
+
+// decodeERC721TransferRow produces a single TokenTransfer for an ERC-721
+// Transfer log (4 topics, tokenID in topic[3], data empty).
+// Amount is the canonical "1" — every ERC-721 transfer moves exactly one
+// token, so aggregate "transfers moved" queries stay consistent.
+func decodeERC721TransferRow(log models.Log, base models.TokenTransfer) ([]models.TokenTransfer, error) {
+	from, to, tokenID, err := rpc.ParseERC721Transfer(log)
+	if err != nil {
+		return nil, err
+	}
+	base.From = normalizeAddress(from)
+	base.To = normalizeAddress(to)
+	base.Amount = "1"
+	base.TokenID = tokenID.String()
+	return []models.TokenTransfer{base}, nil
+}
+
+// decodeERC1155TransferSingleRow produces a single TokenTransfer for an
+// ERC-1155 TransferSingle log. Amount is the decimal-string value (not hex)
+// since the data field carries a proper uint256 that we can normalise.
+func decodeERC1155TransferSingleRow(log models.Log, base models.TokenTransfer) ([]models.TokenTransfer, error) {
+	from, to, id, value, err := rpc.ParseERC1155TransferSingle(log)
+	if err != nil {
+		return nil, err
+	}
+	base.From = normalizeAddress(from)
+	base.To = normalizeAddress(to)
+	base.Amount = value.String()
+	base.TokenID = id.String()
+	return []models.TokenTransfer{base}, nil
+}
+
+// decodeERC1155TransferBatchRows fans a single TransferBatch log out to N
+// rows — one per (id, value) tuple. The compound unique index
+// (txHash, contract, logIndex, tokenID) keeps the rows distinct on replay.
+func decodeERC1155TransferBatchRows(log models.Log, base models.TokenTransfer) ([]models.TokenTransfer, error) {
+	from, to, ids, values, err := rpc.ParseERC1155TransferBatch(log)
+	if err != nil {
+		return nil, err
+	}
+	fromQ := normalizeAddress(from)
+	toQ := normalizeAddress(to)
+	out := make([]models.TokenTransfer, len(ids))
+	for i := range ids {
+		row := base
+		row.From = fromQ
+		row.To = toQ
+		row.Amount = values[i].String()
+		row.TokenID = ids[i].String()
+		out[i] = row
+	}
+	return out, nil
+}
+
+// ParseStandardTransferTopics extracts (from, to) from a standard Transfer
+// event's topics[1] / topics[2]. Returns the canonical Q-prefix lowercase
+// form and an empty *big.Int placeholder (kept in the signature so future
+// callers can fold in amount parsing if needed). Errors on malformed topics.
+func ParseStandardTransferTopics(log models.Log) (string, string, *big.Int, error) {
+	if len(log.Topics) < 3 {
+		return "", "", nil, fmt.Errorf("transfer log requires >=3 topics, got %d", len(log.Topics))
+	}
+	from, err := extractAddressTopic(log.Topics[1])
+	if err != nil {
+		return "", "", nil, fmt.Errorf("from: %w", err)
+	}
+	to, err := extractAddressTopic(log.Topics[2])
+	if err != nil {
+		return "", "", nil, fmt.Errorf("to: %w", err)
+	}
+	return from, to, new(big.Int), nil
+}
+
+// extractAddressTopic returns the Q-prefix lowercase address from a
+// 32-byte indexed topic. Tolerates topics of length <66 (some legacy
+// implementations strip leading zeros).
+func extractAddressTopic(topic string) (string, error) {
+	stripped := topic
+	if len(stripped) >= 2 && stripped[:2] == "0x" {
+		stripped = stripped[2:]
+	}
+	if len(stripped) < 40 {
+		return "", fmt.Errorf("topic too short: %s", topic)
+	}
+	addr := "Q" + strings.ToLower(stripped[len(stripped)-40:])
+	if !validation.IsValidAddress(addr) {
+		return "", fmt.Errorf("invalid address derived from topic: %s", addr)
+	}
+	return addr, nil
+}
+
+// normalizeAddress maps degenerate empty / bare-Q forms to the canonical
+// zero address; passes valid Q-addresses through unchanged.
+func normalizeAddress(addr string) string {
+	if addr == "" || addr == "q" || addr == "Q" {
+		return configs.QRLZeroAddress
+	}
+	return addr
 }
 
 // InitializeTokenTransfersCollection ensures the token transfers collection is set up with proper indexes.
@@ -344,24 +473,28 @@ func InitializeTokenTransfersCollection() error {
 
 	configs.Logger.Info("Initializing tokenTransfers collection and indexes")
 
-	// Migration: the previous schema enforced a UNIQUE index on `txHash`
-	// alone, which silently dropped every Transfer event after the first
-	// within any tx that emitted more than one (DEX swaps, batch mints,
-	// fee-skim contracts). Drop it if it's still around — DropOne returns
-	// IndexNotFound on fresh deployments and that's fine.
+	// Drop the long-gone txHash-only unique (pre-#88). DropOne returns
+	// IndexNotFound on fresh deployments — acceptable.
 	if _, err := collection.Indexes().DropOne(ctx, "txHash_idx"); err != nil {
 		msg := err.Error()
-		// Acceptable: index never existed, or collection doesn't yet.
 		if !strings.Contains(msg, "IndexNotFound") &&
 			!strings.Contains(msg, "ns does not exist") &&
 			!strings.Contains(msg, "NamespaceNotFound") {
-			configs.Logger.Warn("Could not drop legacy unique txHash_idx — continuing; new index creation may also fail",
+			configs.Logger.Warn("Could not drop legacy txHash_idx",
 				zap.Error(err))
 		}
 	}
 
-	// Create indexes for token transfers collection.
-	// CreateMany does not drop existing indexes and is idempotent.
+	// Create the new 4-tuple unique index BEFORE dropping the old 3-tuple
+	// version. Order matters: if creation fails (duplicate-key on legacy
+	// data, etc.) we want to leave the old unique in place; only after
+	// the new one is online do we drop the old.
+	//
+	// Legacy rows (pre-tokenID) lack the field — Mongo treats missing
+	// fields as `null` for index uniqueness. Since the prior 3-tuple
+	// unique guaranteed at most one (txHash, contract, logIndex) row,
+	// the 4-tuple `(txHash, contract, logIndex, null)` is also unique
+	// by extension — no migration collision on existing data.
 	indexes := []mongo.IndexModel{
 		{
 			Keys: bson.D{
@@ -385,36 +518,51 @@ func InitializeTokenTransfersCollection() error {
 			Options: options.Index().SetName("to_block_idx"),
 		},
 		{
-			// Unique. The tuple (txHash, contractAddress, logIndex) is
-			// mathematically unique on chain: log indices are unique
-			// within a tx, and the direct-calldata path emits at most
-			// one row per (tx, contract) with logIndex="". This index
-			// is the hard floor against race-condition double-inserts
-			// (two workers concurrently processing the same tx, or the
-			// application-level TokenTransferExists check missing a
-			// row due to read-after-write timing). The previous bug
-			// (C1 from today's review) was the wrong key shape
-			// (`txHash` alone), not "uniqueness was the problem".
-			// On legacy data: existing rows have no `logIndex` field;
-			// Mongo treats that as `null` for uniqueness purposes, and
-			// because the old broken `txHash_idx` UNIQUE constraint
-			// had already prevented multi-row scenarios within a tx,
-			// there are at most one such row per (txHash, contract,
-			// null) tuple — no migration collision.
+			// Phase 1 unique compound: (txHash, contract, logIndex, tokenID).
+			// Replaces the 3-tuple unique with the same race-condition floor
+			// while keeping ERC-1155 TransferBatch rows distinct on tokenID.
 			Keys: bson.D{
 				{Key: "txHash", Value: 1},
 				{Key: "contractAddress", Value: 1},
 				{Key: "logIndex", Value: 1},
+				{Key: "tokenID", Value: 1},
 			},
-			Options: options.Index().SetName("txHash_contract_logIndex_idx").SetUnique(true),
+			Options: options.Index().
+				SetName("txHash_contract_logIndex_tokenID_idx").
+				SetUnique(true).
+				SetBackground(true),
+		},
+		{
+			// Per-NFT history queries: list all transfers of a specific
+			// tokenID in chronological order. Non-unique; serves the
+			// per-NFT page (Phase 3) and the holder timeline UI.
+			Keys: bson.D{
+				{Key: "contractAddress", Value: 1},
+				{Key: "tokenID", Value: 1},
+				{Key: "blockNumber", Value: 1},
+			},
+			Options: options.Index().
+				SetName("contract_tokenID_block_idx").
+				SetBackground(true),
 		},
 	}
 
-	_, err := collection.Indexes().CreateMany(ctx, indexes)
-	if err != nil {
-		configs.Logger.Error("Failed to create indexes for token transfers",
+	if _, err := collection.Indexes().CreateMany(ctx, indexes); err != nil {
+		configs.Logger.Error("Failed to create token transfer indexes",
 			zap.Error(err))
 		return err
+	}
+
+	// Now that the new unique is online, retire the prior 3-tuple unique
+	// from #88. Missing on fresh deployments — IndexNotFound is fine.
+	if _, err := collection.Indexes().DropOne(ctx, "txHash_contract_logIndex_idx"); err != nil {
+		msg := err.Error()
+		if !strings.Contains(msg, "IndexNotFound") &&
+			!strings.Contains(msg, "ns does not exist") &&
+			!strings.Contains(msg, "NamespaceNotFound") {
+			configs.Logger.Warn("Could not drop legacy txHash_contract_logIndex_idx; new 4-tuple unique still active",
+				zap.Error(err))
+		}
 	}
 
 	configs.Logger.Info("Successfully initialized tokenTransfers collection and indexes")

--- a/QRL2MongoDB/db/tokentransfers.go
+++ b/QRL2MongoDB/db/tokentransfers.go
@@ -216,11 +216,21 @@ func ProcessBlockTokenTransfers(blockNumber string, blockTimestamp string) error
 			zap.String("contractAddress", contractAddress),
 			zap.String("txHash", log.TransactionHash))
 
-		// Use the consolidated token detection logic
-		contract, isToken := EnsureTokenInDatabase(contractAddress, blockNumber, log.TransactionHash)
-		if !isToken || contract == nil {
-			configs.Logger.Debug("Contract is not a token, skipping",
+		// Use the consolidated contract classification logic.
+		// Phase 1: still ERC-20-only dispatch downstream; ERC-721/1155
+		// classification is persisted but transfer decoding will land in
+		// the next commit. Until then, skip non-ERC-20 logs to avoid
+		// writing garbage rows for events we don't yet decode.
+		contract, standard := EnsureContractClassified(contractAddress, blockNumber, log.TransactionHash)
+		if standard == "" || contract == nil {
+			configs.Logger.Debug("Contract is not a recognised token standard, skipping",
 				zap.String("address", contractAddress))
+			continue
+		}
+		if standard != rpc.StandardERC20 {
+			configs.Logger.Debug("Skipping non-ERC-20 standard until dispatch lands",
+				zap.String("address", contractAddress),
+				zap.String("standard", standard))
 			continue
 		}
 

--- a/QRL2MongoDB/db/transactions.go
+++ b/QRL2MongoDB/db/transactions.go
@@ -195,10 +195,9 @@ func processTokenContract(targetAddress string, txHash string, blockNumber strin
 			zap.String("amount", amount))
 
 		// Idempotent: the direct-calldata path uses logIndex="" (there's
-		// no originating log). The unique tuple for replay-detection is
-		// (txHash, contractAddress, ""). On a re-process of the same
-		// tx → skip the write so we don't grow duplicate rows.
-		exists, err := TokenTransferExists(txHash, targetAddress, "")
+		// no originating log) and tokenID="" (ERC-20 only). The unique
+		// tuple for replay-detection is (txHash, contractAddress, "", "").
+		exists, err := TokenTransferExists(txHash, targetAddress, "", "")
 		if err == nil && exists {
 			configs.Logger.Debug("Skipping duplicate direct token transfer",
 				zap.String("txHash", txHash),
@@ -251,12 +250,10 @@ func processTokenContract(targetAddress string, txHash string, blockNumber strin
 
 	transfers := rpc.ProcessTransferLogs(receipt)
 	for _, transferEvent := range transfers {
-		// Idempotent dedupe: a re-process of the same tx must not
-		// duplicate the log-derived row. Key is
-		// (txHash, contractAddress, logIndex). The same check inside
-		// ProcessBlockTokenTransfers exists for the initial-sync path;
-		// this is the steady-state mirror.
-		exists, err := TokenTransferExists(txHash, targetAddress, transferEvent.LogIndex)
+		// Idempotent dedupe of the log-derived row. processTokenContract
+		// runs only on ERC-20 contracts (the legacy ProcessTransferLogs
+		// path), so tokenID is always "" here.
+		exists, err := TokenTransferExists(txHash, targetAddress, transferEvent.LogIndex, "")
 		if err != nil {
 			configs.Logger.Error("Failed to check duplicate token transfer",
 				zap.String("txHash", txHash),

--- a/QRL2MongoDB/models/contract.go
+++ b/QRL2MongoDB/models/contract.go
@@ -64,6 +64,16 @@ type ContractInfo struct {
 	MaxWalletAmount string `bson:"maxWalletAmount,omitempty" json:"maxWalletAmount,omitempty"`
 	MaxTxLimit      string `bson:"maxTxLimit,omitempty" json:"maxTxLimit,omitempty"`
 
+	// NFT / multi-token classification — written exclusively by the syncer
+	// (see db/contracts.go:syncerOwnedSet). `tokenStandard` is one of
+	// "ERC-20" / "ERC-721" / "ERC-1155" or empty for unclassified contracts.
+	// `hasERC165` records whether supportsInterface returned a well-formed
+	// answer — once true we skip re-probing the ERC-165 path. `baseURI` is
+	// Phase 3 territory (tokenURI rendering) and stays empty until populated.
+	TokenStandard string `bson:"tokenStandard,omitempty" json:"tokenStandard,omitempty"`
+	HasERC165     bool   `bson:"hasERC165,omitempty" json:"hasERC165,omitempty"`
+	BaseURI       string `bson:"baseURI,omitempty" json:"baseURI,omitempty"`
+
 	// Source-verification fields — mirror backendAPI/models/contract.go.
 	// Written exclusively by the backend verify endpoint; the syncer
 	// holds them only for round-trip preservation.

--- a/QRL2MongoDB/models/tokentransfer.go
+++ b/QRL2MongoDB/models/tokentransfer.go
@@ -29,4 +29,14 @@ type TokenTransfer struct {
 	TokenDecimals   uint8  `bson:"tokenDecimals"`
 	TokenName       string `bson:"tokenName"`
 	TransferType    string `bson:"transferType"` // "direct" for direct transfers, "event" for Transfer events
+	// TokenStandard denormalises ContractInfo.TokenStandard for query
+	// convenience (so /token-transfer endpoints can filter by standard
+	// without joining contractCode). Empty for legacy ERC-20 rows.
+	TokenStandard string `bson:"tokenStandard,omitempty" json:"tokenStandard,omitempty"`
+	// TokenID is the per-event uint256 token identifier (decimal string).
+	// Empty for ERC-20; populated for ERC-721 (topic[3]) and ERC-1155
+	// (data field). One row per (id, value) tuple in TransferBatch logs,
+	// so the compound unique index (txHash, contract, logIndex, tokenID)
+	// keeps batch elements distinct.
+	TokenID string `bson:"tokenID,omitempty" json:"tokenID,omitempty"`
 }

--- a/QRL2MongoDB/rpc/calls.go
+++ b/QRL2MongoDB/rpc/calls.go
@@ -595,8 +595,12 @@ func GetCode(address string, blockNrOrHash string) (string, error) {
 	return GetCode.Result, nil
 }
 
-// ZondGetBlockLogs retrieves logs for a specific block with optional topic filtering
-func ZondGetBlockLogs(blockNumber string, topics []string) (*models.ZondLogsResponse, error) {
+// ZondGetBlockLogs retrieves logs for a specific block with an optional
+// topic[0] filter. When `topic0Filters` has >1 entry the values are
+// OR-matched against topic[0] — the standard JSON-RPC encoding is a
+// nested array `[[t0a, t0b, ...]]` (the outer position is the topic index,
+// the inner array is the candidate set for that position).
+func ZondGetBlockLogs(blockNumber string, topic0Filters []string) (*models.ZondLogsResponse, error) {
 	// Validate block number format - Zond uses 0x prefix for block numbers
 	if len(blockNumber) == 0 || (!strings.HasPrefix(blockNumber, "0x") && blockNumber != "latest") {
 		return nil, fmt.Errorf("invalid block number format: %s", blockNumber)
@@ -607,9 +611,8 @@ func ZondGetBlockLogs(blockNumber string, topics []string) (*models.ZondLogsResp
 		"toBlock":   blockNumber,
 	}
 
-	// Add topics if provided
-	if len(topics) > 0 {
-		filter["topics"] = topics
+	if len(topic0Filters) > 0 {
+		filter["topics"] = [][]string{topic0Filters}
 	}
 
 	group := models.JsonRPC{

--- a/QRL2MongoDB/rpc/tokenscalls.go
+++ b/QRL2MongoDB/rpc/tokenscalls.go
@@ -131,6 +131,99 @@ func CallContractMethod(contractAddress string, methodSig string) (string, error
 	return result.Result, nil
 }
 
+// Canonical TokenStandard values persisted on ContractInfo.TokenStandard.
+const (
+	StandardERC20   = "ERC-20"
+	StandardERC721  = "ERC-721"
+	StandardERC1155 = "ERC-1155"
+)
+
+// ContractDetectionResult is returned by DetectContractType. Fields outside
+// of Standard/Name/Symbol/HasERC165 are only populated for ERC-20 (Decimals,
+// TotalSupply); NFT collections often omit `decimals()` entirely.
+type ContractDetectionResult struct {
+	Standard    string // StandardERC20 | StandardERC721 | StandardERC1155 | ""
+	Name        string
+	Symbol      string
+	Decimals    uint8
+	TotalSupply string
+	HasERC165   bool
+}
+
+// DetectContractType classifies a contract by trying ERC-165 supportsInterface
+// first (the cheap, definitive signal for ERC-721/1155) and falling back to
+// the ERC-20 name+symbol+decimals triad otherwise.
+//
+// Error contract: a non-nil error means the *probe itself* failed (transport
+// blip, etc.) — the caller MUST bail without writing classification fields,
+// to preserve the C5 promote-only invariant established in #88. A nil error
+// with Standard=="" simply means "we can't tell what this is" (and that IS
+// safe to write; the merge in StoreContract treats "" as no-op).
+//
+// Detection order picks the broader standard first so ERC-1155 implementations
+// that ALSO satisfy ERC-721 are categorised as ERC-1155 (matches the plan's
+// dual-impl tie-breaker).
+func DetectContractType(addr string) (ContractDetectionResult, error) {
+	// Try ERC-1155 first (broader spec).
+	supports, hasERC165, err := SupportsInterface(addr, InterfaceIDERC1155)
+	if err != nil {
+		return ContractDetectionResult{}, fmt.Errorf("supportsInterface(ERC-1155): %w", err)
+	}
+	if supports {
+		name, _ := GetTokenName(addr)     // best-effort; many ERC-1155s omit name()
+		symbol, _ := GetTokenSymbol(addr) // best-effort; many ERC-1155s omit symbol()
+		return ContractDetectionResult{
+			Standard:  StandardERC1155,
+			Name:      name,
+			Symbol:    symbol,
+			HasERC165: true,
+		}, nil
+	}
+
+	// Try ERC-721.
+	supports721, hasERC165From721, err := SupportsInterface(addr, InterfaceIDERC721)
+	if err != nil {
+		return ContractDetectionResult{}, fmt.Errorf("supportsInterface(ERC-721): %w", err)
+	}
+	if supports721 {
+		name, _ := GetTokenName(addr)
+		symbol, _ := GetTokenSymbol(addr)
+		return ContractDetectionResult{
+			Standard:  StandardERC721,
+			Name:      name,
+			Symbol:    symbol,
+			HasERC165: true,
+		}, nil
+	}
+
+	// Either probe confirmed the contract responds to ERC-165 (it just
+	// doesn't support either NFT interface). Record that, then fall through
+	// to ERC-20 detection — some hybrid contracts (rare) declare ERC-165
+	// without being ERC-721/1155 and ARE ERC-20.
+	erc165Known := hasERC165 || hasERC165From721
+
+	// Fall back to the original ERC-20 name+symbol+decimals triad.
+	name, symbol, decimals, isERC20 := GetTokenInfo(addr)
+	if !isERC20 {
+		return ContractDetectionResult{HasERC165: erc165Known}, nil
+	}
+	totalSupply, err := GetTokenTotalSupply(addr)
+	if err != nil {
+		// totalSupply RPC failure is non-fatal — the triad already
+		// classified this as ERC-20. Leave TotalSupply empty; the merge
+		// in StoreContract won't demote an existing value.
+		totalSupply = ""
+	}
+	return ContractDetectionResult{
+		Standard:    StandardERC20,
+		Name:        name,
+		Symbol:      symbol,
+		Decimals:    decimals,
+		TotalSupply: totalSupply,
+		HasERC165:   erc165Known,
+	}, nil
+}
+
 // GetTokenInfo attempts to determine if a contract is an ERC20 token and returns its details
 func GetTokenInfo(contractAddress string) (string, string, uint8, bool) {
 	zap.L().Info("Checking if contract is a token", zap.String("address", contractAddress))

--- a/QRL2MongoDB/rpc/tokenscalls.go
+++ b/QRL2MongoDB/rpc/tokenscalls.go
@@ -15,18 +15,38 @@ import (
 	"go.uber.org/zap"
 )
 
-// Method signatures for ERC20 token functions
+// Method signatures for ERC-20/721/1155 contract functions.
 const (
-	SIG_NAME     = "0x06fdde03" // name()
-	SIG_SYMBOL   = "0x95d89b41" // symbol()
-	SIG_DECIMALS = "0x313ce567" // decimals()
-	SIG_BALANCE  = "0x70a08231" // balanceOf(address)
-	SIG_SUPPLY   = "0x18160ddd" // totalSupply()
+	SIG_NAME               = "0x06fdde03" // name()
+	SIG_SYMBOL             = "0x95d89b41" // symbol()
+	SIG_DECIMALS           = "0x313ce567" // decimals()
+	SIG_BALANCE            = "0x70a08231" // balanceOf(address)
+	SIG_SUPPLY             = "0x18160ddd" // totalSupply()
+	SIG_SUPPORTS_INTERFACE = "0x01ffc9a7" // supportsInterface(bytes4)
+	SIG_OWNER_OF           = "0x6352211e" // ownerOf(uint256) — ERC-721
+	SIG_BALANCE_OF_1155    = "0x00fdd58e" // balanceOf(address,uint256) — ERC-1155
+	SIG_TOKEN_URI          = "0xc87b56dd" // tokenURI(uint256) — ERC-721Metadata
+	SIG_URI                = "0x0e89341c" // uri(uint256) — ERC-1155MetadataURI
 )
 
-// Event signatures
-// Transfer event signature: keccak256("Transfer(address,address,uint256)")
-const TransferEventSignature = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+// ERC-165 interface IDs, as the 4-byte XOR of the interface's method selectors.
+var (
+	InterfaceIDERC721          = [4]byte{0x80, 0xac, 0x58, 0xcd}
+	InterfaceIDERC1155         = [4]byte{0xd9, 0xb6, 0x7a, 0x26}
+	InterfaceIDERC721Metadata  = [4]byte{0x5b, 0x5e, 0x13, 0x9f}
+	InterfaceIDERC1155Metadata = [4]byte{0x0e, 0x89, 0x34, 0x1c}
+)
+
+// Token-transfer event signatures.
+//
+// ERC-20 and ERC-721 share the same Transfer(address,address,uint256) hash;
+// disambiguation is by topic count (3 vs 4) and confirmed against the
+// contract's ERC-165 declaration in DetectContractType.
+const (
+	TransferEventSignature       = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+	TransferSingleEventSignature = "0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62"
+	TransferBatchEventSignature  = "0x4a39dc06d4c0dbc64b50af327f5f6b67b0c4b21be9d6c92d40b00b3e7ec1c3ef"
+)
 
 // CallContractMethod makes a qrl_call to a contract method and returns the result
 func CallContractMethod(contractAddress string, methodSig string) (string, error) {
@@ -517,4 +537,225 @@ func ParseTransferEvent(log models.Log) (string, string, *big.Int, error) {
 	}
 
 	return from, to, amount, nil
+}
+
+// SupportsInterface probes a contract via ERC-165 supportsInterface(bytes4).
+//
+// Returns:
+//   - supports    : contract declared support for the queried interface
+//   - hasERC165   : contract returned a well-formed bool32 (i.e. it implements
+//     ERC-165 at all). A `false, true` result means "ERC-165 contract, doesn't
+//     implement this interface" — useful to skip later probes.
+//   - err         : transport-level failure (timeout, network down, etc).
+//     The caller MUST check err and bail without classifying — a transient
+//     blip never demotes existing state (mirrors the C5 promote-only
+//     invariant in db/contracts.go:StoreContract).
+//
+// A contract-level revert ("execution reverted") is mapped to
+// `false, false, nil` because legacy ERC-20s without ERC-165 revert on
+// any unknown selector, and that's the discriminator we rely on.
+//
+// Calldata layout per ABI spec is selector + interfaceID (right-padded to
+// 32 bytes), NOT left-padded — `bytes4` is a fixed-length type and the
+// ABI pads fixed types on the right with zero bytes.
+func SupportsInterface(addr string, interfaceID [4]byte) (supports, hasERC165 bool, err error) {
+	calldata := SIG_SUPPORTS_INTERFACE + hex.EncodeToString(interfaceID[:]) + strings.Repeat("0", 56)
+
+	result, callErr := CallContractMethod(addr, calldata)
+	if callErr != nil {
+		// "RPC error: <message>" is set by CallContractMethod ONLY when the
+		// node returned a JSON-RPC error object (revert / invalid opcode /
+		// out-of-gas / unknown method). That's the not-ERC-165 signal.
+		// Anything else (request build, transport, unmarshal) is transient.
+		if strings.HasPrefix(callErr.Error(), "RPC error:") {
+			return false, false, nil
+		}
+		return false, false, callErr
+	}
+
+	stripped := strings.TrimPrefix(result, "0x")
+	// Empty / "0x" / malformed-too-short: treat as not-ERC-165 (a real
+	// ERC-165 contract returns a full 32-byte bool32).
+	if len(stripped) < 64 {
+		return false, false, nil
+	}
+
+	// Last byte of the 32-byte bool32 tells us true (0x01) vs false (0x00).
+	lastByte := stripped[len(stripped)-2:]
+	switch lastByte {
+	case "01":
+		return true, true, nil
+	case "00":
+		return false, true, nil
+	default:
+		// Non-bool return (e.g. legacy contract returning data of different
+		// shape). Conservatively not-ERC-165.
+		return false, false, nil
+	}
+}
+
+// addressFromTopic extracts a 20-byte address from a 32-byte indexed topic.
+// The topic is the standard "0x" + 64 hex chars; the address is the last
+// 40 hex chars. Returns canonical Q-prefix lowercase form.
+func addressFromTopic(topic string) (string, error) {
+	stripped := strings.TrimPrefix(topic, "0x")
+	if len(stripped) < 40 {
+		return "", fmt.Errorf("topic too short: %s", topic)
+	}
+	addr := "Q" + strings.ToLower(stripped[len(stripped)-40:])
+	if !validation.IsValidAddress(addr) {
+		return "", fmt.Errorf("invalid address derived from topic: %s", addr)
+	}
+	return addr, nil
+}
+
+// ParseERC721Transfer decodes an ERC-721 Transfer(from, to, tokenId) log.
+//
+// Layout: 4 topics [sig, from, to, tokenID], empty data.
+// `tokenID` is the indexed parameter in topic[3]; the data field is empty.
+func ParseERC721Transfer(log models.Log) (from, to string, tokenID *big.Int, err error) {
+	if len(log.Topics) != 4 {
+		return "", "", nil, fmt.Errorf("ERC-721 Transfer requires 4 topics, got %d", len(log.Topics))
+	}
+	from, err = addressFromTopic(log.Topics[1])
+	if err != nil {
+		return "", "", nil, fmt.Errorf("from: %w", err)
+	}
+	to, err = addressFromTopic(log.Topics[2])
+	if err != nil {
+		return "", "", nil, fmt.Errorf("to: %w", err)
+	}
+	id := new(big.Int)
+	if _, ok := id.SetString(strings.TrimPrefix(log.Topics[3], "0x"), 16); !ok {
+		return "", "", nil, fmt.Errorf("failed to parse tokenID from topic[3]: %s", log.Topics[3])
+	}
+	return from, to, id, nil
+}
+
+// ParseERC1155TransferSingle decodes an ERC-1155 TransferSingle(operator, from, to, id, value) log.
+//
+// Layout: 4 topics [sig, operator, from, to], data = abi.encode(uint256 id, uint256 value).
+// The operator is dropped — callers care about the (from, to) pair, not who
+// orchestrated the transfer.
+func ParseERC1155TransferSingle(log models.Log) (from, to string, id, value *big.Int, err error) {
+	if len(log.Topics) != 4 {
+		return "", "", nil, nil, fmt.Errorf("ERC-1155 TransferSingle requires 4 topics, got %d", len(log.Topics))
+	}
+	from, err = addressFromTopic(log.Topics[2])
+	if err != nil {
+		return "", "", nil, nil, fmt.Errorf("from: %w", err)
+	}
+	to, err = addressFromTopic(log.Topics[3])
+	if err != nil {
+		return "", "", nil, nil, fmt.Errorf("to: %w", err)
+	}
+	data := strings.TrimPrefix(log.Data, "0x")
+	if len(data) < 128 {
+		return "", "", nil, nil, fmt.Errorf("TransferSingle data too short: %d hex chars", len(data))
+	}
+	id = new(big.Int)
+	if _, ok := id.SetString(data[:64], 16); !ok {
+		return "", "", nil, nil, fmt.Errorf("failed to parse id from data")
+	}
+	value = new(big.Int)
+	if _, ok := value.SetString(data[64:128], 16); !ok {
+		return "", "", nil, nil, fmt.Errorf("failed to parse value from data")
+	}
+	return from, to, id, value, nil
+}
+
+// maxBatchArrayLen caps the per-array element count we'll decode from a
+// TransferBatch log. Real-world batches are <100; this guards against an
+// adversarial payload claiming a huge array to OOM the decoder.
+const maxBatchArrayLen = 10000
+
+// ParseERC1155TransferBatch decodes an ERC-1155 TransferBatch(operator, from, to, ids[], values[]) log.
+//
+// Layout: 4 topics [sig, operator, from, to], data = abi.encode(uint256[], uint256[]).
+// The dynamic-array encoding starts with two 32-byte offsets pointing to
+// each array's `length || elements...` section. Both arrays must have the
+// same length per the ERC-1155 spec.
+func ParseERC1155TransferBatch(log models.Log) (from, to string, ids, values []*big.Int, err error) {
+	if len(log.Topics) != 4 {
+		return "", "", nil, nil, fmt.Errorf("ERC-1155 TransferBatch requires 4 topics, got %d", len(log.Topics))
+	}
+	from, err = addressFromTopic(log.Topics[2])
+	if err != nil {
+		return "", "", nil, nil, fmt.Errorf("from: %w", err)
+	}
+	to, err = addressFromTopic(log.Topics[3])
+	if err != nil {
+		return "", "", nil, nil, fmt.Errorf("to: %w", err)
+	}
+
+	data := strings.TrimPrefix(log.Data, "0x")
+	if len(data) < 128 {
+		return "", "", nil, nil, fmt.Errorf("TransferBatch data too short: %d hex chars", len(data))
+	}
+
+	idsOffsetBytes, err := readUint64FromWord(data, 0)
+	if err != nil {
+		return "", "", nil, nil, fmt.Errorf("ids offset: %w", err)
+	}
+	valuesOffsetBytes, err := readUint64FromWord(data, 64)
+	if err != nil {
+		return "", "", nil, nil, fmt.Errorf("values offset: %w", err)
+	}
+
+	ids, err = decodeUint256Array(data, idsOffsetBytes*2)
+	if err != nil {
+		return "", "", nil, nil, fmt.Errorf("ids array: %w", err)
+	}
+	values, err = decodeUint256Array(data, valuesOffsetBytes*2)
+	if err != nil {
+		return "", "", nil, nil, fmt.Errorf("values array: %w", err)
+	}
+	if len(ids) != len(values) {
+		return "", "", nil, nil, fmt.Errorf("ids/values length mismatch: %d vs %d", len(ids), len(values))
+	}
+	return from, to, ids, values, nil
+}
+
+// readUint64FromWord parses one 32-byte ABI word at hex position `posHex`
+// and returns its value as uint64. Returns an error if the value exceeds
+// uint64 range (offsets in real logs are tens to hundreds of bytes).
+func readUint64FromWord(data string, posHex uint64) (uint64, error) {
+	if posHex+64 > uint64(len(data)) {
+		return 0, fmt.Errorf("data too short at hex offset %d", posHex)
+	}
+	word := new(big.Int)
+	if _, ok := word.SetString(data[posHex:posHex+64], 16); !ok {
+		return 0, fmt.Errorf("failed to parse word at hex offset %d", posHex)
+	}
+	if !word.IsUint64() {
+		return 0, fmt.Errorf("word value exceeds uint64 at hex offset %d", posHex)
+	}
+	return word.Uint64(), nil
+}
+
+// decodeUint256Array reads an ABI-encoded uint256[] starting at hex position
+// `startHex` of `data`. The encoding is `[length(32B) || elements(32B each)]`.
+func decodeUint256Array(data string, startHex uint64) ([]*big.Int, error) {
+	length, err := readUint64FromWord(data, startHex)
+	if err != nil {
+		return nil, err
+	}
+	if length > maxBatchArrayLen {
+		return nil, fmt.Errorf("array length %d exceeds cap %d", length, maxBatchArrayLen)
+	}
+	elemStart := startHex + 64
+	end := elemStart + length*64
+	if end > uint64(len(data)) {
+		return nil, fmt.Errorf("data too short for %d elements", length)
+	}
+	out := make([]*big.Int, length)
+	for i := uint64(0); i < length; i++ {
+		pos := elemStart + i*64
+		item := new(big.Int)
+		if _, ok := item.SetString(data[pos:pos+64], 16); !ok {
+			return nil, fmt.Errorf("failed to parse element %d", i)
+		}
+		out[i] = item
+	}
+	return out, nil
 }

--- a/QRL2MongoDB/rpc/tokenscalls_test.go
+++ b/QRL2MongoDB/rpc/tokenscalls_test.go
@@ -1,0 +1,364 @@
+package rpc
+
+import (
+	"QRL2MongoDB/models"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// Test fixtures: realistic Q-addresses that pass validation.IsValidAddress.
+// `topic(addr)` left-pads the 20-byte address into a 32-byte indexed topic.
+const (
+	aliceAddr = "Q6153d37fa4da7193e6219dcbd2bbe62fa12905b1"
+	bobAddr   = "Q539f73306bdd4288f93a5e50b4d5bf1a9b07f147"
+	opAddr    = "Qa1b2c3d4e5f60708090a0b0c0d0e0f1011121314"
+)
+
+// topic builds an indexed-topic representation of a Q-prefix address:
+// "0x" + 24 zero hex chars + 40-char lowercase hex.
+func topic(addr string) string {
+	stripped := strings.TrimPrefix(strings.ToLower(addr), "q")
+	return "0x" + strings.Repeat("0", 24) + stripped
+}
+
+// word builds a 32-byte ABI-encoded uint256 word from a hex string (no 0x).
+func word(hexStr string) string {
+	if len(hexStr) > 64 {
+		panic("word > 32 bytes")
+	}
+	return strings.Repeat("0", 64-len(hexStr)) + hexStr
+}
+
+func TestParseERC721Transfer(t *testing.T) {
+	tests := []struct {
+		name        string
+		log         models.Log
+		wantFrom    string
+		wantTo      string
+		wantTokenID string
+		wantErr     bool
+	}{
+		{
+			name: "valid Transfer with tokenID=42",
+			log: models.Log{
+				Topics: []string{
+					TransferEventSignature,
+					topic(aliceAddr),
+					topic(bobAddr),
+					"0x" + word("2a"),
+				},
+				Data: "0x",
+			},
+			wantFrom:    aliceAddr,
+			wantTo:      bobAddr,
+			wantTokenID: "42",
+		},
+		{
+			name: "valid Transfer with tokenID=0 (genesis mint)",
+			log: models.Log{
+				Topics: []string{
+					TransferEventSignature,
+					"0x" + strings.Repeat("0", 64),
+					topic(bobAddr),
+					"0x" + word("0"),
+				},
+				Data: "0x",
+			},
+			// Zero-address from is canonicalized to Q + 40 zeros.
+			wantFrom:    "Q" + strings.Repeat("0", 40),
+			wantTo:      bobAddr,
+			wantTokenID: "0",
+		},
+		{
+			name: "valid Transfer with large tokenID (uint256 max bits)",
+			log: models.Log{
+				Topics: []string{
+					TransferEventSignature,
+					topic(aliceAddr),
+					topic(bobAddr),
+					"0x" + strings.Repeat("f", 64),
+				},
+				Data: "0x",
+			},
+			wantFrom:    aliceAddr,
+			wantTo:      bobAddr,
+			wantTokenID: new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)).String(),
+		},
+		{
+			name: "wrong topic count (3 — looks like ERC-20)",
+			log: models.Log{
+				Topics: []string{
+					TransferEventSignature,
+					topic(aliceAddr),
+					topic(bobAddr),
+				},
+				Data: "0x" + word("64"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "wrong topic count (5)",
+			log: models.Log{
+				Topics: []string{
+					TransferEventSignature,
+					topic(aliceAddr),
+					topic(bobAddr),
+					"0x" + word("1"),
+					"0x" + word("2"),
+				},
+				Data: "0x",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			from, to, id, err := ParseERC721Transfer(tt.log)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got from=%s to=%s id=%v", from, to, id)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.EqualFold(from, tt.wantFrom) {
+				t.Errorf("from = %s, want %s", from, tt.wantFrom)
+			}
+			if !strings.EqualFold(to, tt.wantTo) {
+				t.Errorf("to = %s, want %s", to, tt.wantTo)
+			}
+			if id.String() != tt.wantTokenID {
+				t.Errorf("tokenID = %s, want %s", id.String(), tt.wantTokenID)
+			}
+		})
+	}
+}
+
+func TestParseERC1155TransferSingle(t *testing.T) {
+	tests := []struct {
+		name      string
+		log       models.Log
+		wantFrom  string
+		wantTo    string
+		wantID    string
+		wantValue string
+		wantErr   bool
+	}{
+		{
+			name: "valid TransferSingle id=42 value=100",
+			log: models.Log{
+				Topics: []string{
+					TransferSingleEventSignature,
+					topic(opAddr),
+					topic(aliceAddr),
+					topic(bobAddr),
+				},
+				Data: "0x" + word("2a") + word("64"),
+			},
+			wantFrom:  aliceAddr,
+			wantTo:    bobAddr,
+			wantID:    "42",
+			wantValue: "100",
+		},
+		{
+			name: "valid TransferSingle mint (from=0)",
+			log: models.Log{
+				Topics: []string{
+					TransferSingleEventSignature,
+					topic(opAddr),
+					"0x" + strings.Repeat("0", 64),
+					topic(bobAddr),
+				},
+				Data: "0x" + word("1") + word("3e8"),
+			},
+			wantFrom:  "Q" + strings.Repeat("0", 40),
+			wantTo:    bobAddr,
+			wantID:    "1",
+			wantValue: "1000",
+		},
+		{
+			name: "wrong topic count",
+			log: models.Log{
+				Topics: []string{TransferSingleEventSignature, topic(opAddr), topic(aliceAddr)},
+				Data:   "0x" + word("2a") + word("64"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "data too short",
+			log: models.Log{
+				Topics: []string{
+					TransferSingleEventSignature,
+					topic(opAddr),
+					topic(aliceAddr),
+					topic(bobAddr),
+				},
+				Data: "0x" + word("2a"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			from, to, id, value, err := ParseERC1155TransferSingle(tt.log)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.EqualFold(from, tt.wantFrom) {
+				t.Errorf("from = %s, want %s", from, tt.wantFrom)
+			}
+			if !strings.EqualFold(to, tt.wantTo) {
+				t.Errorf("to = %s, want %s", to, tt.wantTo)
+			}
+			if id.String() != tt.wantID {
+				t.Errorf("id = %s, want %s", id.String(), tt.wantID)
+			}
+			if value.String() != tt.wantValue {
+				t.Errorf("value = %s, want %s", value.String(), tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestParseERC1155TransferBatch(t *testing.T) {
+	// Construct data: offsets at words 0-1, ids array at offset 0x40,
+	// values array at offset (0x40 + 32 + len_ids*32).
+	makeBatchData := func(ids, values []string) string {
+		idsOffset := word("40")
+		valuesOffset := word(big.NewInt(64 + 32 + int64(len(ids))*32).Text(16))
+		idsLen := word(big.NewInt(int64(len(ids))).Text(16))
+		valuesLen := word(big.NewInt(int64(len(values))).Text(16))
+		buf := idsOffset + valuesOffset + idsLen
+		for _, id := range ids {
+			buf += word(id)
+		}
+		buf += valuesLen
+		for _, v := range values {
+			buf += word(v)
+		}
+		return "0x" + buf
+	}
+
+	tests := []struct {
+		name       string
+		log        models.Log
+		wantFrom   string
+		wantTo     string
+		wantIDs    []string
+		wantValues []string
+		wantErr    bool
+	}{
+		{
+			name: "valid batch [1,2,3] / [10,20,30]",
+			log: models.Log{
+				Topics: []string{
+					TransferBatchEventSignature,
+					topic(opAddr),
+					topic(aliceAddr),
+					topic(bobAddr),
+				},
+				Data: makeBatchData([]string{"1", "2", "3"}, []string{"a", "14", "1e"}),
+			},
+			wantFrom:   aliceAddr,
+			wantTo:     bobAddr,
+			wantIDs:    []string{"1", "2", "3"},
+			wantValues: []string{"10", "20", "30"},
+		},
+		{
+			name: "valid empty batch",
+			log: models.Log{
+				Topics: []string{
+					TransferBatchEventSignature,
+					topic(opAddr),
+					topic(aliceAddr),
+					topic(bobAddr),
+				},
+				Data: makeBatchData([]string{}, []string{}),
+			},
+			wantFrom:   aliceAddr,
+			wantTo:     bobAddr,
+			wantIDs:    []string{},
+			wantValues: []string{},
+		},
+		{
+			name: "ids/values length mismatch (malformed log)",
+			log: models.Log{
+				Topics: []string{
+					TransferBatchEventSignature,
+					topic(opAddr),
+					topic(aliceAddr),
+					topic(bobAddr),
+				},
+				Data: makeBatchData([]string{"1", "2"}, []string{"a"}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "wrong topic count",
+			log: models.Log{
+				Topics: []string{TransferBatchEventSignature, topic(opAddr), topic(aliceAddr)},
+				Data:   makeBatchData([]string{"1"}, []string{"a"}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "array length exceeds cap (adversarial)",
+			log: models.Log{
+				Topics: []string{
+					TransferBatchEventSignature,
+					topic(opAddr),
+					topic(aliceAddr),
+					topic(bobAddr),
+				},
+				// offset_ids = 0x40, offset_values = 0x60, length_ids = (cap+1) — but no data
+				Data: "0x" + word("40") + word("60") + word(big.NewInt(maxBatchArrayLen+1).Text(16)),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			from, to, ids, values, err := ParseERC1155TransferBatch(tt.log)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got from=%s to=%s ids=%v values=%v", from, to, ids, values)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.EqualFold(from, tt.wantFrom) {
+				t.Errorf("from = %s, want %s", from, tt.wantFrom)
+			}
+			if !strings.EqualFold(to, tt.wantTo) {
+				t.Errorf("to = %s, want %s", to, tt.wantTo)
+			}
+			if len(ids) != len(tt.wantIDs) {
+				t.Fatalf("ids length = %d, want %d", len(ids), len(tt.wantIDs))
+			}
+			for i, id := range ids {
+				if id.String() != tt.wantIDs[i] {
+					t.Errorf("ids[%d] = %s, want %s", i, id.String(), tt.wantIDs[i])
+				}
+			}
+			for i, v := range values {
+				if v.String() != tt.wantValues[i] {
+					t.Errorf("values[%d] = %s, want %s", i, v.String(), tt.wantValues[i])
+				}
+			}
+		})
+	}
+}

--- a/backendAPI/db/contract.go
+++ b/backendAPI/db/contract.go
@@ -14,7 +14,12 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-func ReturnContracts(page int64, limit int64, search string, isTokenFilter *bool) ([]models.ContractInfo, int64, error) {
+// ReturnContracts paginates contracts with optional `isToken` and
+// `tokenStandard` filters. `standardFilter` overlays on top of
+// `isTokenFilter` so e.g. `isToken=true,standard=ERC-721` returns the
+// intersection (NFT collections only). Pass nil/empty for either filter to
+// skip that predicate.
+func ReturnContracts(page int64, limit int64, search string, isTokenFilter *bool, standardFilter *string) ([]models.ContractInfo, int64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -27,6 +32,12 @@ func ReturnContracts(page int64, limit int64, search string, isTokenFilter *bool
 	// Add isToken filter if specified
 	if isTokenFilter != nil {
 		filter = append(filter, bson.E{Key: "isToken", Value: *isTokenFilter})
+	}
+
+	// Add tokenStandard filter if specified. Both filters AND together —
+	// `?isToken=true&standard=ERC-721` returns NFT collections only.
+	if standardFilter != nil && *standardFilter != "" {
+		filter = append(filter, bson.E{Key: "tokenStandard", Value: *standardFilter})
 	}
 
 	// Add search if provided, using correct field names

--- a/backendAPI/db/contract.go
+++ b/backendAPI/db/contract.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -42,15 +43,26 @@ func ReturnContracts(page int64, limit int64, search string, isTokenFilter *bool
 
 	// Add search if provided, using correct field names
 	if search != "" {
-		// Normalize the search address to canonical Q-prefix form
+		// Normalize the search address to canonical Q-prefix form (for the
+		// address + creatorAddress exact-match branches).
 		normalizedSearch := normalizeAddress(search)
 
-		// Zond addresses start with 'Q'. Search by normalized address or token name.
+		// Escape regex metacharacters in the user input so a `.` or `*`
+		// in the search term doesn't behave as a wildcard or DoS vector.
+		escaped := regexp.QuoteMeta(search)
+		nameRegex := bson.D{{Key: "$regex", Value: escaped}, {Key: "$options", Value: "i"}}
+
+		// Search by exact address, exact creator address, OR partial
+		// case-insensitive match against name + symbol. Symbol was
+		// previously absent — searching "MQW" missed tokens whose `name`
+		// field held the full project label instead of the ticker (and
+		// vice versa).
 		searchFilter := bson.D{
 			{Key: "$or", Value: bson.A{
-				bson.D{{Key: "address", Value: normalizedSearch}},        // Match contract address
-				bson.D{{Key: "creatorAddress", Value: normalizedSearch}}, // Match creator address
-				bson.D{{Key: "name", Value: bson.D{{Key: "$regex", Value: search}, {Key: "$options", Value: "i"}}}}, // Match token name
+				bson.D{{Key: "address", Value: normalizedSearch}},
+				bson.D{{Key: "creatorAddress", Value: normalizedSearch}},
+				bson.D{{Key: "name", Value: nameRegex}},
+				bson.D{{Key: "symbol", Value: nameRegex}},
 			}},
 		}
 		// Combine with existing filter

--- a/backendAPI/models/contract.go
+++ b/backendAPI/models/contract.go
@@ -26,6 +26,14 @@ type ContractInfo struct {
 	TotalSupply            string `json:"totalSupply" bson:"totalSupply"`
 	UpdatedAt              string `json:"updatedAt" bson:"updatedAt"`
 
+	// NFT / multi-token fields — mirror QRL2MongoDB/models/contract.go.
+	// Written exclusively by the syncer; held here only for round-trip
+	// preservation and to allow the /contracts endpoint to filter on
+	// `?standard=ERC-721`.
+	TokenStandard string `json:"tokenStandard,omitempty" bson:"tokenStandard,omitempty"`
+	HasERC165     bool   `json:"hasERC165,omitempty" bson:"hasERC165,omitempty"`
+	BaseURI       string `json:"baseURI,omitempty" bson:"baseURI,omitempty"`
+
 	// Source-verification fields. `verified` defaults to false (omitted from
 	// omitempty so it is always present in the JSON shape clients consume).
 	// Everything else uses omitempty so unverified contracts stay clean.

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -669,7 +669,23 @@ func UserRoute(router *gin.Engine) {
 			isTokenFilter = &isToken
 		}
 
-		query, total, err := db.ReturnContracts(page, limit, search, isTokenFilter)
+		// Parse standard filter (optional). Validates against the known
+		// set to keep the BSON query well-typed and prevent arbitrary
+		// strings from being passed as a filter predicate.
+		var standardFilter *string
+		if standardParam := c.Query("standard"); standardParam != "" {
+			switch standardParam {
+			case "ERC-20", "ERC-721", "ERC-1155":
+				standardFilter = &standardParam
+			default:
+				c.JSON(http.StatusBadRequest, gin.H{
+					"error": "invalid standard; expected one of ERC-20, ERC-721, ERC-1155",
+				})
+				return
+			}
+		}
+
+		query, total, err := db.ReturnContracts(page, limit, search, isTokenFilter, standardFilter)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": fmt.Sprintf("Failed to fetch contracts: %v", err),


### PR DESCRIPTION
## Summary

Phase 1 of the [3-phase NFT roadmap](../../../.claude/plans/yes-i-remember-now-unified-truffle.md): contracts classified, ERC-721 / ERC-1155 transfers indexed, explorer UI surfaces the three standards.

Builds on top of [#88](https://github.com/DigitalGuards/zondscan/pull/88) (C1 multi-Transfer + C5 promote-only invariant).

## Why now

The foundation NFT test fixtures —

- ERC-721 `Q539f73306bdd4288f93a5e50b4d5bf1a9b07f147` (MQTC)
- ERC-1155 `Qb70193d03d693c2c3d0eba4b7d08f31c2b5fe871`

— were invisible to the explorer. Three root causes layered:

1. **Detection floor wrong for NFTs.** The old `rpc.GetTokenInfo` triad required `name + symbol + decimals`. ERC-721 typically omits `decimals()`; ERC-1155 frequently omits all three.
2. **Topic-0 ambiguity.** ERC-20 and ERC-721 share `Transfer(address,address,uint256)` hash. The current decoder skipped 4-topic ERC-721 events as malformed ERC-20.
3. **ERC-1155 entirely unhandled.** `TransferSingle` / `TransferBatch` were never decoded.

## What landed

5 commits inside this PR:

1. **`feat(rpc): ERC-165 SupportsInterface + ERC-721/1155 event constants + parsers`** — `SupportsInterface(addr, [4]byte)` with three-way error semantics (revert / not-ERC-165 / transport), event sig + interface ID constants, three new ABI parsers. 14 table-driven tests.
2. **`feat(syncer): DetectContractType + tokenStandard schema + C5 extension`** — single classifier; `ContractInfo` gains `tokenStandard` / `hasERC165` / `baseURI`; `TokenTransfer` gains `tokenStandard` / `tokenID`; `StoreContract` merge extends the promote-only ladder to TokenStandard; `EnsureTokenInDatabase` → `EnsureContractClassified`.
3. **`feat(syncer): dispatch ERC-721/1155 transfer events + index migration`** — per-standard dispatch keyed by (standard, topic[0], topic count); `TokenTransferExists` gains a 4th tokenID arg; compound unique index migration `(txHash, contract, logIndex)` → `(txHash, contract, logIndex, tokenID)` with create-before-drop ordering.
4. **`feat(zondscan): backend ?standard filter + frontend standard-aware UI`** — `/contracts?standard=ERC-20|ERC-721|ERC-1155` filter (validated; invalid → 400); four-tab `/contracts` page with standard-aware tables; address + tx pages branch on `tokenStandard`.
5. **`fix(zondscan): unified contract table + QRC-X labels + symbol search`** — all four `/contracts` tabs now share one `ContractRowsTable` for visual consistency; QRC-X branding on user-facing strings (DB value stays ERC-X); backend search regex covers `name` + `symbol` (was `name` only); `regexp.QuoteMeta` to neutralise `.` / `*` in user input.

## Phase 2 / 3 deferred

- Per-tokenID ownership (Phase 2)
- `tokenURI` + IPFS metadata rendering (Phase 3)
- `Approval` / `ApprovalForAll` events (Phase 3)
- Backend IPFS proxy (Phase 3)

## End-to-end verified on local syncer

Full wipe + resync against testnet v2:

| Standard  | Classified contracts | Transfers indexed |
|-----------|---------------------|-------------------|
| ERC-20    | 19                  | 40                |
| ERC-721   | 5 (incl. MQTC + 4 new) | 10              |
| ERC-1155  | 5 (incl. foundation fixture + 4 new) | 4 |

Sample ERC-721 row inspected — `tokenStandard: "ERC-721"`, `tokenID: "2"`, `amount: "1"`, `from: Q000…0000` (mint), `to: Q6153d37…05b1` (operator).
Sample ERC-1155 row inspected — `tokenStandard: "ERC-1155"`, `tokenID: "42"`, `amount: "1"`.
Zero `Failed to decode` warnings.

API verified:
```
GET /contracts?standard=ERC-721  → 5 rows
GET /contracts?standard=ERC-1155 → 5 rows
GET /contracts?standard=invalid  → 400
GET /contracts?search=PQL        → 2 rows (symbol match)
GET /contracts?search=governance → 2 rows (name match)
```

## Test plan
- [x] Parser unit tests pass (14 cases across 3 parsers)
- [x] `go build ./...` clean for syncer + backend
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean (28 pre-existing lint warnings, 0 new errors)
- [x] Local syncer wipe + resync to chain tip — no dispatch warnings
- [x] Mongo `tokenStandard` populated correctly for ERC-20/721/1155
- [x] Compound unique index migration (3-tuple → 4-tuple) lands without duplicate-key error on legacy rows
- [x] Backend `?standard=` filter returns correct subsets
- [x] Backend `?search=` matches both name + symbol
- [ ] Reviewer to confirm UI consistency across all four `/contracts` tabs
- [ ] Reviewer to confirm Address page renders correctly for an ERC-721 (e.g. `/address/Q539f73306bdd4288f93a5e50b4d5bf1a9b07f147`) and ERC-1155 (e.g. `/address/Qb70193d03d693c2c3d0eba4b7d08f31c2b5fe871`)
- [ ] Reviewer to confirm Transaction page renders `tokenID` row for an NFT transfer