### PR TITLE
feat(syncer): per-tokenID ownership for ERC-721/1155 (Phase 2)

### DIFF
--- a/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
@@ -29,6 +29,17 @@ interface TokenHolder {
     balance: string;
     blockNumber: string;
     updatedAt: string;
+    // Phase 2: per-id storage for NFT collections. Always absent for ERC-20.
+    tokenID?: string;
+    tokenStandard?: 'ERC-20' | 'ERC-721' | 'ERC-1155' | string;
+}
+
+interface TokenIDSummary {
+    tokenID: string;
+    holderCount: number;
+    tokenStandard?: string;
+    blockNumber?: string;
+    updatedAt?: string;
 }
 
 interface TokenTransfer {
@@ -128,7 +139,7 @@ const formatTimestamp = (timestamp: string): string => {
 };
 
 export default function TokenContractView({ address, contractData, handlerUrl }: TokenContractViewProps) {
-    const [activeTab, setActiveTab] = useState<'overview' | 'holders' | 'transfers'>('overview');
+    const [activeTab, setActiveTab] = useState<'overview' | 'holders' | 'transfers' | 'tokens'>('overview');
     const [tokenInfo, setTokenInfo] = useState<TokenInfo | null>(null);
     const [holders, setHolders] = useState<TokenHolder[]>([]);
     const [transfers, setTransfers] = useState<TokenTransfer[]>([]);
@@ -138,6 +149,13 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
     const [transfersPage, setTransfersPage] = useState(0);
     const [loading, setLoading] = useState(true);
     const [creationTx, setCreationTx] = useState<CreationTxData | null>(null);
+    // Phase 2: NFT-specific state. holderTokenIDFilter narrows /holders to
+    // a single tokenID; tokensList drives the new "Tokens" tab listing.
+    const [holderTokenIDFilter, setHolderTokenIDFilter] = useState<string>('');
+    const [holderTokenIDInput, setHolderTokenIDInput] = useState<string>('');
+    const [tokensList, setTokensList] = useState<TokenIDSummary[]>([]);
+    const [tokensTotal, setTokensTotal] = useState(0);
+    const [tokensPage, setTokensPage] = useState(0);
     const limit = 25;
 
     // Fetch token info
@@ -177,14 +195,20 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
         fetchCreationTx();
     }, [tokenInfo?.creationTxHash, contractData.creationTransaction, handlerUrl]);
 
-    // Fetch holders when tab is active
+    // Fetch holders when tab is active. Phase 2: append ?tokenID= when the
+    // filter is set so the backend returns rows for that specific id only.
     useEffect(() => {
         if (activeTab !== 'holders') return;
 
         const fetchHolders = async () => {
             setLoading(true);
             try {
-                const res = await fetch(`${handlerUrl}/token/${address}/holders?page=${holdersPage}&limit=${limit}`);
+                const qs = new URLSearchParams({
+                    page: String(holdersPage),
+                    limit: String(limit),
+                });
+                if (holderTokenIDFilter) qs.set('tokenID', holderTokenIDFilter);
+                const res = await fetch(`${handlerUrl}/token/${address}/holders?${qs.toString()}`);
                 if (res.ok) {
                     const data = await res.json();
                     setHolders(data.holders || []);
@@ -196,7 +220,28 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
             setLoading(false);
         };
         fetchHolders();
-    }, [address, handlerUrl, activeTab, holdersPage]);
+    }, [address, handlerUrl, activeTab, holdersPage, holderTokenIDFilter]);
+
+    // Fetch tokens (distinct tokenID list) when the tokens tab is active.
+    useEffect(() => {
+        if (activeTab !== 'tokens') return;
+
+        const fetchTokens = async () => {
+            setLoading(true);
+            try {
+                const res = await fetch(`${handlerUrl}/token/${address}/tokens?page=${tokensPage}&limit=${limit}`);
+                if (res.ok) {
+                    const data = await res.json();
+                    setTokensList(data.tokens || []);
+                    setTokensTotal(data.totalTokenIDs || 0);
+                }
+            } catch (error) {
+                console.error('Failed to fetch tokens:', error);
+            }
+            setLoading(false);
+        };
+        fetchTokens();
+    }, [address, handlerUrl, activeTab, tokensPage]);
 
     // Fetch transfers when tab is active
     useEffect(() => {
@@ -242,11 +287,15 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
         ? 'bg-purple-500/20 text-purple-300'
         : 'bg-green-500/20 text-green-400';
 
-    const tabs = [
+    const tabs: { id: typeof activeTab; label: string }[] = [
         { id: 'overview', label: 'Overview' },
         { id: 'holders', label: `Holders${tokenInfo ? ` (${tokenInfo.holderCount})` : ''}` },
         { id: 'transfers', label: `Transfers${tokenInfo ? ` (${tokenInfo.transferCount})` : ''}` },
     ];
+    // Phase 2: only NFT collections have a meaningful per-id list.
+    if (isNFT) {
+        tabs.push({ id: 'tokens', label: 'Tokens' });
+    }
 
     // Three-step breadcrumb: Home > Contracts > <standard tab> > <this contract>.
     // The middle step deep-links back to the /contracts page with the
@@ -520,6 +569,58 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                 {/* Holders Tab */}
                 {activeTab === 'holders' && (
                     <div>
+                        {/* Phase 2: per-tokenID filter for NFT collections. The input
+                            debounces locally and only sets the actual filter on submit,
+                            so each keystroke doesn't trigger a network request. */}
+                        {isNFT && (
+                            <div className="flex flex-wrap items-center gap-2 px-4 py-3 border-b border-gray-700 bg-black/20">
+                                <label htmlFor="tokenIDFilter" className="text-xs text-gray-400">
+                                    Filter by tokenID:
+                                </label>
+                                <input
+                                    id="tokenIDFilter"
+                                    type="text"
+                                    inputMode="numeric"
+                                    placeholder="e.g. 1"
+                                    value={holderTokenIDInput}
+                                    onChange={(e) => setHolderTokenIDInput(e.target.value)}
+                                    onKeyDown={(e) => {
+                                        if (e.key === 'Enter') {
+                                            setHoldersPage(0);
+                                            setHolderTokenIDFilter(holderTokenIDInput.trim());
+                                        }
+                                    }}
+                                    className="px-2 py-1 rounded bg-black/40 border border-gray-700 text-sm text-white font-mono w-32"
+                                />
+                                <button
+                                    onClick={() => {
+                                        setHoldersPage(0);
+                                        setHolderTokenIDFilter(holderTokenIDInput.trim());
+                                    }}
+                                    className="px-3 py-1 rounded bg-[#ffa729]/20 text-[#ffa729] text-sm hover:bg-[#ffa729]/30"
+                                >
+                                    Apply
+                                </button>
+                                {holderTokenIDFilter && (
+                                    <button
+                                        onClick={() => {
+                                            setHolderTokenIDInput('');
+                                            setHolderTokenIDFilter('');
+                                            setHoldersPage(0);
+                                        }}
+                                        className="px-3 py-1 rounded bg-gray-700 text-sm hover:bg-gray-600"
+                                    >
+                                        Clear
+                                    </button>
+                                )}
+                                {holderTokenIDFilter && (
+                                    <span className="text-xs text-gray-400">
+                                        Showing holders of tokenID <span className="font-mono text-white">{holderTokenIDFilter}</span>
+                                    </span>
+                                )}
+                            </div>
+                        )}
+
                         {loading ? (
                             <div className="p-8 text-center text-gray-400">Loading holders...</div>
                         ) : holders.length === 0 ? (
@@ -532,32 +633,70 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                             <tr>
                                                 <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">#</th>
                                                 <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">Address</th>
+                                                {isNFT && holderTokenIDFilter === '' && (
+                                                    <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase hidden md:table-cell">
+                                                        {tokenStandard === 'ERC-721' ? 'NFTs owned' : 'Total quantity'}
+                                                    </th>
+                                                )}
+                                                {isNFT && holderTokenIDFilter !== '' && (
+                                                    <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">Token ID</th>
+                                                )}
                                                 <th scope="col" className="px-4 py-3 text-right text-xs font-medium text-gray-400 uppercase">Balance</th>
-                                                <th scope="col" className="px-4 py-3 text-right text-xs font-medium text-gray-400 uppercase hidden md:table-cell">Share</th>
+                                                {!isNFT && (
+                                                    <th scope="col" className="px-4 py-3 text-right text-xs font-medium text-gray-400 uppercase hidden md:table-cell">Share</th>
+                                                )}
                                             </tr>
                                         </thead>
                                         <tbody className="divide-y divide-gray-700/50">
                                             {holders.map((holder, idx) => {
                                                 const totalSupplyBigInt = totalSupply ? BigInt(totalSupply) : BigInt(0);
-                                                const share = totalSupplyBigInt > BigInt(0) && holder.balance
-                                                    ? ((BigInt(holder.balance) * BigInt(10000)) / totalSupplyBigInt)
-                                                    : BigInt(0);
-                                                const sharePercent = Number(share) / 100;
+                                                let sharePercent = 0;
+                                                try {
+                                                    const share = totalSupplyBigInt > BigInt(0) && holder.balance
+                                                        ? ((BigInt(holder.balance) * BigInt(10000)) / totalSupplyBigInt)
+                                                        : BigInt(0);
+                                                    sharePercent = Number(share) / 100;
+                                                } catch {
+                                                    sharePercent = 0;
+                                                }
+
+                                                const rowKey = holder.tokenID
+                                                    ? `${holder.holderAddress}-${holder.tokenID}`
+                                                    : holder.holderAddress;
+
+                                                // ERC-721 balance column is the per-id "1"; show
+                                                // a count instead in the aggregated view (which is
+                                                // the sum coming from the backend).
+                                                const balanceCell = isNFT
+                                                    ? holder.balance
+                                                    : `${formatTokenAmount(holder.balance, decimals)}${rawSymbol ? ' ' + rawSymbol : ''}`;
 
                                                 return (
-                                                    <tr key={holder.holderAddress} className="hover:bg-white/5">
+                                                    <tr key={rowKey} className="hover:bg-white/5">
                                                         <td className="px-4 py-3 text-sm text-gray-400">
                                                             {holdersPage * limit + idx + 1}
                                                         </td>
                                                         <td className="px-4 py-3">
                                                             <AddressDisplay address={holder.holderAddress} truncate />
                                                         </td>
+                                                        {isNFT && holderTokenIDFilter === '' && (
+                                                            <td className="px-4 py-3 text-left text-sm text-gray-300 font-mono hidden md:table-cell">
+                                                                {holder.balance}
+                                                            </td>
+                                                        )}
+                                                        {isNFT && holderTokenIDFilter !== '' && (
+                                                            <td className="px-4 py-3 text-left text-sm text-white font-mono">
+                                                                #{holder.tokenID ?? holderTokenIDFilter}
+                                                            </td>
+                                                        )}
                                                         <td className="px-4 py-3 text-right text-sm text-white font-mono">
-                                                            {formatTokenAmount(holder.balance, decimals)}{rawSymbol ? ' ' + rawSymbol : ''}
+                                                            {balanceCell}
                                                         </td>
-                                                        <td className="px-4 py-3 text-right text-sm text-gray-400 hidden md:table-cell">
-                                                            {sharePercent.toFixed(2)}%
-                                                        </td>
+                                                        {!isNFT && (
+                                                            <td className="px-4 py-3 text-right text-sm text-gray-400 hidden md:table-cell">
+                                                                {sharePercent.toFixed(2)}%
+                                                            </td>
+                                                        )}
                                                     </tr>
                                                 );
                                             })}
@@ -584,6 +723,80 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                                 aria-label="Go to next page"
                                                 onClick={() => setHoldersPage(p => p + 1)}
                                                 disabled={(holdersPage + 1) * limit >= holdersTotal}
+                                                className="px-3 py-1 rounded bg-gray-700 text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-600"
+                                            >
+                                                Next
+                                            </button>
+                                        </div>
+                                    </div>
+                                )}
+                            </>
+                        )}
+                    </div>
+                )}
+
+                {/* Tokens Tab. Phase 2: lists every distinct tokenID minted
+                    on this NFT contract, with the holder count for each id.
+                    Clicking a row jumps to the holders tab filtered to that id. */}
+                {activeTab === 'tokens' && (
+                    <div>
+                        {loading ? (
+                            <div className="p-8 text-center text-gray-400">Loading tokens...</div>
+                        ) : tokensList.length === 0 ? (
+                            <div className="p-8 text-center text-gray-400">No tokens have been minted yet</div>
+                        ) : (
+                            <>
+                                <div className="overflow-x-auto">
+                                    <table aria-label="Token IDs" className="w-full">
+                                        <thead className="bg-black/30">
+                                            <tr>
+                                                <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">Token ID</th>
+                                                <th scope="col" className="px-4 py-3 text-right text-xs font-medium text-gray-400 uppercase">Holders</th>
+                                                <th scope="col" className="px-4 py-3 text-right text-xs font-medium text-gray-400 uppercase hidden md:table-cell">Standard</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody className="divide-y divide-gray-700/50">
+                                            {tokensList.map((t) => (
+                                                <tr
+                                                    key={t.tokenID}
+                                                    className="hover:bg-white/5 cursor-pointer"
+                                                    onClick={() => {
+                                                        setHolderTokenIDInput(t.tokenID);
+                                                        setHolderTokenIDFilter(t.tokenID);
+                                                        setHoldersPage(0);
+                                                        setActiveTab('holders');
+                                                    }}
+                                                >
+                                                    <td className="px-4 py-3 text-sm font-mono text-accent">#{t.tokenID}</td>
+                                                    <td className="px-4 py-3 text-right text-sm text-white">{t.holderCount}</td>
+                                                    <td className="px-4 py-3 text-right text-xs text-gray-400 hidden md:table-cell">
+                                                        {t.tokenStandard ? t.tokenStandard.replace(/^ERC-/, 'QRC-') : '-'}
+                                                    </td>
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                </div>
+
+                                {/* Pagination */}
+                                {tokensTotal > limit && (
+                                    <div className="flex items-center justify-between px-4 py-3 border-t border-gray-700">
+                                        <div className="text-sm text-gray-400">
+                                            Showing {tokensPage * limit + 1} - {Math.min((tokensPage + 1) * limit, tokensTotal)} of {tokensTotal}
+                                        </div>
+                                        <div className="flex gap-2">
+                                            <button
+                                                aria-label="Go to previous page"
+                                                onClick={() => setTokensPage(p => Math.max(0, p - 1))}
+                                                disabled={tokensPage === 0}
+                                                className="px-3 py-1 rounded bg-gray-700 text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-600"
+                                            >
+                                                Previous
+                                            </button>
+                                            <button
+                                                aria-label="Go to next page"
+                                                onClick={() => setTokensPage(p => p + 1)}
+                                                disabled={(tokensPage + 1) * limit >= tokensTotal}
                                                 className="px-3 py-1 rounded bg-gray-700 text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-600"
                                             >
                                                 Next

--- a/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
@@ -583,7 +583,7 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                     inputMode="numeric"
                                     placeholder="e.g. 1"
                                     value={holderTokenIDInput}
-                                    onChange={(e) => setHolderTokenIDInput(e.target.value)}
+                                    onChange={(e) => setHolderTokenIDInput(e.target.value.replace(/[^0-9]/g, ''))}
                                     onKeyDown={(e) => {
                                         if (e.key === 'Enter') {
                                             setHoldersPage(0);

--- a/ExplorerFrontend/app/api-explorer/api-explorer-client.tsx
+++ b/ExplorerFrontend/app/api-explorer/api-explorer-client.tsx
@@ -122,7 +122,7 @@ const endpointGroups: EndpointGroup[] = [
       {
         method: 'GET',
         path: '/address/:address/tokens',
-        description: 'Returns all token balances held by an address. Useful for wallet integration and token auto-discovery.',
+        description: 'Returns all token balances held by an address. Useful for wallet integration and token auto-discovery. Phase 2: NFT holdings expand to one row per (collection, tokenID), each row carries `tokenStandard` and (for NFTs) `tokenID`. ERC-20 rows continue to return one row per collection with the existing balance string.',
         example: '/address/Q6153d37fa4da7193e6219dcbd2bbe62fa12905b1/tokens',
       },
       {
@@ -214,9 +214,16 @@ const endpointGroups: EndpointGroup[] = [
       {
         method: 'GET',
         path: '/token/:address/holders',
-        description: 'Returns a paginated list of token holders for a given contract.',
+        description: 'Returns a paginated list of token holders for a given contract. ERC-20 returns one row per (contract, holder). For ERC-721/1155, holders are aggregated across all ids by default (one row per distinct holder, balance is the cross-id total). Pass `tokenID=<decimal>` to filter to a single id (one row per holder of that id, balance is per-id quantity).',
+        params: 'page (query, default: 0), limit (query, default: 25, max: 100), tokenID (query, optional, decimal uint256 NFT id filter)',
+        example: '/token/Q539f73306bdd4288f93a5e50b4d5bf1a9b07f147/holders?page=0&limit=25&tokenID=1',
+      },
+      {
+        method: 'GET',
+        path: '/token/:address/tokens',
+        description: 'Phase 2: returns the distinct tokenID list minted on an NFT contract with holder count per id. Empty list for ERC-20 contracts. Useful for browsing the catalog of an ERC-721/1155 collection or for downstream Phase 3 metadata lookups.',
         params: 'page (query, default: 0), limit (query, default: 25, max: 100)',
-        example: '/token/Q539f73306bdd4288f93a5e50b4d5bf1a9b07f147/holders?page=0&limit=25',
+        example: '/token/Q539f73306bdd4288f93a5e50b4d5bf1a9b07f147/tokens?page=0&limit=25',
       },
       {
         method: 'GET',

--- a/QRL2MongoDB/configs/setup.go
+++ b/QRL2MongoDB/configs/setup.go
@@ -144,6 +144,11 @@ func ConnectDB() *mongo.Client {
 	ensureCollection(db, "totalCirculatingSupply", circulatingValidator)
 
 	// Token Balances
+	//
+	// Phase 2 adds optional `tokenID` (decimal uint256) and `tokenStandard`
+	// (ERC-20/721/1155) so the same collection stores per-tokenID NFT
+	// ownership rows alongside the legacy ERC-20 ones. Both are omitted on
+	// ERC-20 rows so the validator keeps them optional.
 	tokenBalanceValidator := bson.M{
 		"$jsonSchema": bson.M{
 			"bsonType": "object",
@@ -168,6 +173,14 @@ func ConnectDB() *mongo.Client {
 				"updatedAt": bson.M{
 					"bsonType":    "string",
 					"description": "must be a string and is required",
+				},
+				"tokenID": bson.M{
+					"bsonType":    "string",
+					"description": "decimal uint256 token id, optional (NFTs only)",
+				},
+				"tokenStandard": bson.M{
+					"bsonType":    "string",
+					"description": "ERC-20 | ERC-721 | ERC-1155, optional",
 				},
 			},
 		},
@@ -232,25 +245,15 @@ func initializeCollections(db *mongo.Database) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// Initialize token balances collection with compound index
-	tokenBalancesCollection := db.Collection("tokenBalances")
-	_, err := tokenBalancesCollection.Indexes().CreateOne(
-		ctx,
-		mongo.IndexModel{
-			Keys: bson.D{
-				{Key: "contractAddress", Value: 1},
-				{Key: "holderAddress", Value: 1},
-			},
-			Options: options.Index().SetUnique(true),
-		},
-	)
-	if err != nil {
-		Logger.Error("Failed to create index for token balances collection", zap.Error(err))
-	}
+	// tokenBalances indexes are owned by db.InitializeTokenBalancesCollection
+	// (called from synchroniser/token_sync.go at syncer startup). Keeping the
+	// owner in one place lets the Phase 2 migration drop the legacy 2-tuple
+	// unique and replace it with the 3-tuple `(contract, holder, tokenID)`
+	// without a second creator racing it on each restart.
 
 	// Initialize pending token contracts collection with compound index
 	pendingTokenContractsCollection := db.Collection("pending_token_contracts")
-	_, err = pendingTokenContractsCollection.Indexes().CreateOne(
+	_, err := pendingTokenContractsCollection.Indexes().CreateOne(
 		ctx,
 		mongo.IndexModel{
 			Keys: bson.D{

--- a/QRL2MongoDB/db/tokenbalances.go
+++ b/QRL2MongoDB/db/tokenbalances.go
@@ -7,9 +7,11 @@ import (
 	"QRL2MongoDB/validation"
 	"context"
 	"fmt"
+	"math/big"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.uber.org/zap"
 )
@@ -64,7 +66,11 @@ func StoreTokenBalance(contractAddress string, holderAddress string, amount stri
 			zap.String("balance", balance))
 	}
 
-	// Create update document
+	// Create update document. Phase 2 tags every ERC-20 row with
+	// tokenStandard="ERC-20" so backend / frontend queries can filter by
+	// standard without having to JOIN against contractCode. Legacy rows
+	// without the field are still uniquely keyed by (contract, holder)
+	// because Mongo treats their missing tokenID as null.
 	update := bson.M{
 		"$set": bson.M{
 			"contractAddress": contractAddress,
@@ -72,6 +78,7 @@ func StoreTokenBalance(contractAddress string, holderAddress string, amount stri
 			"balance":         balance,
 			"blockNumber":     blockNumber,
 			"updatedAt":       time.Now().UTC().Format(time.RFC3339),
+			"tokenStandard":   rpc.StandardERC20,
 		},
 	}
 
@@ -150,4 +157,205 @@ func GetTokenHolders(contractAddress string) ([]models.TokenBalance, error) {
 	}
 
 	return balances, nil
+}
+
+// StoreERC721Ownership refreshes the single-owner row for one ERC-721
+// (contract, tokenID) pair via `ownerOf(uint256)` and reconciles the
+// (contract, holder, tokenID) rows accordingly.
+//
+// Behaviour:
+//   - Transport error from the RPC layer leaves existing rows untouched
+//     (C5 promote-only invariant: a transient blip must not delete state).
+//   - Contract revert / empty return => no current owner; delete any stale
+//     row that claimed this id. Sparse storage; burned NFTs leave no row.
+//   - Owner returned => upsert (contract, owner, tokenID) with balance="1"
+//     and tokenStandard="ERC-721". Single-owner invariant: any other row
+//     with the same (contract, tokenID) but a different holder is deleted.
+//
+// TODO(scale): One RPC call per ERC-721 transfer event. Testnet OK; mainnet
+// at high NFT volume would prefer an event-delta accumulator with periodic
+// reconciliation. See GetERC721Owner for the same note.
+func StoreERC721Ownership(contractAddress string, tokenID *big.Int, blockNumber string) error {
+	if tokenID == nil {
+		return fmt.Errorf("tokenID required")
+	}
+	contractAddress = validation.ConvertToQAddress(contractAddress)
+
+	configs.Logger.Debug("Refreshing ERC-721 ownership",
+		zap.String("contract", contractAddress),
+		zap.String("tokenID", tokenID.String()),
+		zap.String("blockNumber", blockNumber))
+
+	owner, err := rpc.GetERC721Owner(contractAddress, tokenID)
+	if err != nil {
+		// Transport / unmarshal failure. Preserve existing state.
+		configs.Logger.Warn("GetERC721Owner transport error; preserving existing balance state",
+			zap.String("contract", contractAddress),
+			zap.String("tokenID", tokenID.String()),
+			zap.Error(err))
+		return err
+	}
+
+	collection := configs.GetTokenBalancesCollection()
+	if collection == nil {
+		return fmt.Errorf("token balances collection is nil")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	idStr := tokenID.String()
+
+	// No current owner (burned / never minted): drop any stale row.
+	if owner == "" {
+		_, dErr := collection.DeleteMany(ctx, bson.M{
+			"contractAddress": contractAddress,
+			"tokenID":         idStr,
+			"tokenStandard":   rpc.StandardERC721,
+		})
+		if dErr != nil {
+			configs.Logger.Warn("Failed to delete stale ERC-721 ownership row",
+				zap.String("contract", contractAddress),
+				zap.String("tokenID", idStr),
+				zap.Error(dErr))
+		}
+		return nil
+	}
+
+	owner = validation.ConvertToQAddress(owner)
+
+	// Delete any stale row for this (contract, tokenID) held by anyone other
+	// than the current owner. Enforces the single-owner invariant.
+	_, dErr := collection.DeleteMany(ctx, bson.M{
+		"contractAddress": contractAddress,
+		"tokenID":         idStr,
+		"tokenStandard":   rpc.StandardERC721,
+		"holderAddress":   bson.M{"$ne": owner},
+	})
+	if dErr != nil {
+		configs.Logger.Warn("Failed to delete stale ERC-721 ownership row(s) for prior holder",
+			zap.String("contract", contractAddress),
+			zap.String("tokenID", idStr),
+			zap.Error(dErr))
+	}
+
+	// Upsert the current owner's row.
+	filter := bson.M{
+		"contractAddress": contractAddress,
+		"holderAddress":   owner,
+		"tokenID":         idStr,
+	}
+	update := bson.M{
+		"$set": bson.M{
+			"contractAddress": contractAddress,
+			"holderAddress":   owner,
+			"tokenID":         idStr,
+			"tokenStandard":   rpc.StandardERC721,
+			"balance":         "1",
+			"blockNumber":     blockNumber,
+			"updatedAt":       time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+	if _, err := collection.UpdateOne(ctx, filter, update, options.Update().SetUpsert(true)); err != nil {
+		configs.Logger.Error("Failed to upsert ERC-721 ownership row",
+			zap.String("contract", contractAddress),
+			zap.String("holder", owner),
+			zap.String("tokenID", idStr),
+			zap.Error(err))
+		return err
+	}
+
+	return nil
+}
+
+// StoreERC1155Balance refreshes a holder's per-id balance for one ERC-1155
+// (contract, holder, tokenID) tuple via `balanceOf(address,uint256)`.
+//
+// Behaviour:
+//   - Transport error: preserve existing state (C5 invariant), propagate err.
+//   - Balance == 0 (incl. contract revert): delete the row (sparse storage).
+//   - Balance > 0: upsert (contract, holder, tokenID) with the decimal-string
+//     quantity and tokenStandard="ERC-1155".
+//
+// TODO(scale): One RPC call per (from, to) side per ERC-1155 transfer. See
+// GetERC1155Balance for the accumulator/reconciliation note.
+func StoreERC1155Balance(contractAddress, holderAddress string, tokenID *big.Int, blockNumber string) error {
+	if tokenID == nil {
+		return fmt.Errorf("tokenID required")
+	}
+	contractAddress = validation.ConvertToQAddress(contractAddress)
+	holderAddress = validation.ConvertToQAddress(holderAddress)
+
+	// Skip zero-address; mint/burn endpoints don't hold balances.
+	if holderAddress == "Q0" ||
+		holderAddress == configs.QRLZeroAddress ||
+		holderAddress == "0x0" ||
+		holderAddress == "0x0000000000000000000000000000000000000000" {
+		return nil
+	}
+
+	configs.Logger.Debug("Refreshing ERC-1155 balance",
+		zap.String("contract", contractAddress),
+		zap.String("holder", holderAddress),
+		zap.String("tokenID", tokenID.String()),
+		zap.String("blockNumber", blockNumber))
+
+	balance, err := rpc.GetERC1155Balance(contractAddress, holderAddress, tokenID)
+	if err != nil {
+		configs.Logger.Warn("GetERC1155Balance transport error; preserving existing balance state",
+			zap.String("contract", contractAddress),
+			zap.String("holder", holderAddress),
+			zap.String("tokenID", tokenID.String()),
+			zap.Error(err))
+		return err
+	}
+
+	collection := configs.GetTokenBalancesCollection()
+	if collection == nil {
+		return fmt.Errorf("token balances collection is nil")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	idStr := tokenID.String()
+	filter := bson.M{
+		"contractAddress": contractAddress,
+		"holderAddress":   holderAddress,
+		"tokenID":         idStr,
+	}
+
+	// Sparse storage: delete the row when balance is zero.
+	if balance == nil || balance.Sign() == 0 {
+		if _, dErr := collection.DeleteOne(ctx, filter); dErr != nil && dErr != mongo.ErrNoDocuments {
+			configs.Logger.Warn("Failed to delete zero ERC-1155 balance row",
+				zap.String("contract", contractAddress),
+				zap.String("holder", holderAddress),
+				zap.String("tokenID", idStr),
+				zap.Error(dErr))
+		}
+		return nil
+	}
+
+	update := bson.M{
+		"$set": bson.M{
+			"contractAddress": contractAddress,
+			"holderAddress":   holderAddress,
+			"tokenID":         idStr,
+			"tokenStandard":   rpc.StandardERC1155,
+			"balance":         balance.String(),
+			"blockNumber":     blockNumber,
+			"updatedAt":       time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+	if _, err := collection.UpdateOne(ctx, filter, update, options.Update().SetUpsert(true)); err != nil {
+		configs.Logger.Error("Failed to upsert ERC-1155 balance row",
+			zap.String("contract", contractAddress),
+			zap.String("holder", holderAddress),
+			zap.String("tokenID", idStr),
+			zap.Error(err))
+		return err
+	}
+
+	return nil
 }

--- a/QRL2MongoDB/db/tokentransfers.go
+++ b/QRL2MongoDB/db/tokentransfers.go
@@ -275,12 +275,24 @@ func ProcessBlockTokenTransfers(blockNumber string, blockTimestamp string) error
 			}
 			tokenTransfersFound++
 
-			// Phase 1 balance maintenance: ERC-20 only. Per-tokenID NFT
-			// ownership lands in Phase 2 (with the (contract, holder,
-			// tokenID) schema rewrite), counting NFT "balances" with
-			// the current (contract, holder) schema would either lose
-			// per-id info or over-count, so we deliberately skip.
-			if standard == rpc.StandardERC20 {
+			// Per-standard balance maintenance.
+			//
+			// ERC-20: refresh sender + recipient via the existing helper
+			// (RPC-confirmed balanceOf, full-precision string storage).
+			//
+			// ERC-721: the row's transfer ALREADY happened on chain by the
+			// time we got the log. ownerOf is global truth, so a single
+			// StoreERC721Ownership call refreshes the (contract, tokenID)
+			// row to point at the new holder AND clears the prior holder's
+			// row through the single-owner-invariant branch.
+			//
+			// ERC-1155: refresh both sides of the transfer with balanceOf
+			// (per id). Zero balance deletes the row (sparse storage).
+			// Errors are logged but non-fatal, the underlying tokenTransfer
+			// row is already persisted, balance refresh is reconcilable
+			// next time the holder transacts.
+			switch standard {
+			case rpc.StandardERC20:
 				if err := StoreTokenBalance(contractAddress, row.From, row.Amount, blockNumber); err != nil {
 					configs.Logger.Error("Failed to update sender token balance",
 						zap.String("address", row.From),
@@ -292,6 +304,40 @@ func ProcessBlockTokenTransfers(blockNumber string, blockTimestamp string) error
 						zap.String("address", row.To),
 						zap.String("contractAddress", contractAddress),
 						zap.Error(err))
+				}
+			case rpc.StandardERC721:
+				if id, ok := new(big.Int).SetString(row.TokenID, 10); ok {
+					if err := StoreERC721Ownership(contractAddress, id, blockNumber); err != nil {
+						configs.Logger.Warn("ERC-721 ownership refresh failed; will retry on next transfer",
+							zap.String("contractAddress", contractAddress),
+							zap.String("tokenID", row.TokenID),
+							zap.Error(err))
+					}
+				} else {
+					configs.Logger.Warn("ERC-721 transfer row has unparseable tokenID; skipping ownership refresh",
+						zap.String("contractAddress", contractAddress),
+						zap.String("tokenID", row.TokenID))
+				}
+			case rpc.StandardERC1155:
+				if id, ok := new(big.Int).SetString(row.TokenID, 10); ok {
+					if err := StoreERC1155Balance(contractAddress, row.From, id, blockNumber); err != nil {
+						configs.Logger.Warn("ERC-1155 sender balance refresh failed",
+							zap.String("contractAddress", contractAddress),
+							zap.String("holder", row.From),
+							zap.String("tokenID", row.TokenID),
+							zap.Error(err))
+					}
+					if err := StoreERC1155Balance(contractAddress, row.To, id, blockNumber); err != nil {
+						configs.Logger.Warn("ERC-1155 recipient balance refresh failed",
+							zap.String("contractAddress", contractAddress),
+							zap.String("holder", row.To),
+							zap.String("tokenID", row.TokenID),
+							zap.Error(err))
+					}
+				} else {
+					configs.Logger.Warn("ERC-1155 transfer row has unparseable tokenID; skipping balance refresh",
+						zap.String("contractAddress", contractAddress),
+						zap.String("tokenID", row.TokenID))
 				}
 			}
 		}
@@ -569,8 +615,33 @@ func InitializeTokenTransfersCollection() error {
 	return nil
 }
 
-// InitializeTokenBalancesCollection ensures the token balances collection is set up with proper indexes.
-// Uses CreateMany which is a no-op for indexes that already exist, safe to call on every restart.
+// InitializeTokenBalancesCollection sets up tokenBalances indexes, including
+// the Phase 2 per-tokenID migration.
+//
+// Index plan:
+//
+//   - UNIQUE (contractAddress, holderAddress, tokenID): primary key. Legacy
+//     ERC-20 rows lack `tokenID`, Mongo treats missing fields as `null` for
+//     index purposes, so the legacy (contract, holder, null) rows remain
+//     unique by extension of the prior (contract, holder) unique. No
+//     migration collision.
+//   - secondary (contractAddress, tokenID, holderAddress): drives per-id
+//     holder lookups (`/token/<addr>/holders?tokenID=`).
+//   - secondary (holderAddress) and (contractAddress): unchanged, support
+//     address-page and token-page sweeps.
+//
+// Phase 2 migration:
+//
+//   - Create the new 3-tuple unique BEFORE dropping the legacy 2-tuple unique.
+//     A partial failure (e.g. transient duplicate-key on legacy data) leaves
+//     the old unique in place, never an unguarded collection.
+//   - Drop the legacy index by name only after the new one is online. Errors
+//     other than IndexNotFound are warnings; the new unique is the source of
+//     truth either way.
+//
+// Note on the old `address_idx` / `contract_address_idx` indexes from #88:
+// those targeted a non-existent `address` field (storage writes
+// `holderAddress`). They were vestigial, the Phase 2 reset drops them.
 func InitializeTokenBalancesCollection() error {
 	collection := configs.GetTokenBalancesCollection()
 
@@ -579,23 +650,42 @@ func InitializeTokenBalancesCollection() error {
 
 	configs.Logger.Info("Initializing tokenBalances collection and indexes")
 
-	// Create indexes for token balances collection.
-	// CreateMany does not drop existing indexes and is idempotent.
 	indexes := []mongo.IndexModel{
 		{
+			// Phase 2 primary key: per-(contract, holder, tokenID) ownership.
+			// Legacy ERC-20 rows (no tokenID field) collapse to a null third
+			// key, which the prior (contract, holder) unique already kept
+			// distinct, so this is non-disruptive on existing data.
 			Keys: bson.D{
 				{Key: "contractAddress", Value: 1},
-				{Key: "address", Value: 1},
+				{Key: "holderAddress", Value: 1},
+				{Key: "tokenID", Value: 1},
 			},
-			Options: options.Index().SetName("contract_address_idx").SetUnique(true),
+			Options: options.Index().
+				SetName("contract_holder_tokenID_idx").
+				SetUnique(true).
+				SetBackground(true),
 		},
 		{
+			// Per-id holder lookups: powers /token/<addr>/holders?tokenID=.
 			Keys: bson.D{
-				{Key: "address", Value: 1},
+				{Key: "contractAddress", Value: 1},
+				{Key: "tokenID", Value: 1},
+				{Key: "holderAddress", Value: 1},
 			},
-			Options: options.Index().SetName("address_idx"),
+			Options: options.Index().
+				SetName("contract_tokenID_holder_idx").
+				SetBackground(true),
 		},
 		{
+			// Address-page sweep: list every token row a holder owns.
+			Keys: bson.D{
+				{Key: "holderAddress", Value: 1},
+			},
+			Options: options.Index().SetName("holder_idx"),
+		},
+		{
+			// Token-page sweep: list every holder/row for a contract.
 			Keys: bson.D{
 				{Key: "contractAddress", Value: 1},
 			},
@@ -603,11 +693,43 @@ func InitializeTokenBalancesCollection() error {
 		},
 	}
 
-	_, err := collection.Indexes().CreateMany(ctx, indexes)
-	if err != nil {
+	if _, err := collection.Indexes().CreateMany(ctx, indexes); err != nil {
 		configs.Logger.Error("Failed to create indexes for token balances",
 			zap.Error(err))
 		return err
+	}
+
+	// Drop the prior 2-tuple unique once the new 3-tuple unique is online.
+	// The legacy index was auto-named by Mongo when configs.ConnectDB created
+	// it (no explicit SetName), so we drop by its conventional auto-generated
+	// name `contractAddress_1_holderAddress_1`. IndexNotFound is fine on
+	// fresh deployments.
+	legacyName := "contractAddress_1_holderAddress_1"
+	if _, err := collection.Indexes().DropOne(ctx, legacyName); err != nil {
+		msg := err.Error()
+		if !strings.Contains(msg, "IndexNotFound") &&
+			!strings.Contains(msg, "ns does not exist") &&
+			!strings.Contains(msg, "NamespaceNotFound") {
+			configs.Logger.Warn("Could not drop legacy 2-tuple unique; new 3-tuple unique still active",
+				zap.String("indexName", legacyName),
+				zap.Error(err))
+		}
+	}
+
+	// Also retire the vestigial pre-Phase-2 indexes that targeted a non-
+	// existent `address` field. Safe to drop, the new indexes cover the
+	// same access patterns through `holderAddress`.
+	for _, name := range []string{"contract_address_idx", "address_idx"} {
+		if _, err := collection.Indexes().DropOne(ctx, name); err != nil {
+			msg := err.Error()
+			if !strings.Contains(msg, "IndexNotFound") &&
+				!strings.Contains(msg, "ns does not exist") &&
+				!strings.Contains(msg, "NamespaceNotFound") {
+				configs.Logger.Warn("Could not drop vestigial tokenBalances index",
+					zap.String("indexName", name),
+					zap.Error(err))
+			}
+		}
 	}
 
 	configs.Logger.Info("Successfully initialized tokenBalances collection and indexes")

--- a/QRL2MongoDB/db/tokentransfers.go
+++ b/QRL2MongoDB/db/tokentransfers.go
@@ -700,20 +700,62 @@ func InitializeTokenBalancesCollection() error {
 	}
 
 	// Drop the prior 2-tuple unique once the new 3-tuple unique is online.
-	// The legacy index was auto-named by Mongo when configs.ConnectDB created
-	// it (no explicit SetName), so we drop by its conventional auto-generated
-	// name `contractAddress_1_holderAddress_1`. IndexNotFound is fine on
-	// fresh deployments.
-	legacyName := "contractAddress_1_holderAddress_1"
-	if _, err := collection.Indexes().DropOne(ctx, legacyName); err != nil {
-		msg := err.Error()
-		if !strings.Contains(msg, "IndexNotFound") &&
-			!strings.Contains(msg, "ns does not exist") &&
-			!strings.Contains(msg, "NamespaceNotFound") {
-			configs.Logger.Warn("Could not drop legacy 2-tuple unique; new 3-tuple unique still active",
-				zap.String("indexName", legacyName),
-				zap.Error(err))
+	// We can't rely on the legacy index name because different MongoDB
+	// versions / manual creators may have named it differently (the
+	// `configs.ConnectDB` path historically created it without an explicit
+	// SetName, so Mongo auto-generated something like
+	// `contractAddress_1_holderAddress_1`, but that's not a guarantee).
+	// Iterate every index on the collection, match on the key spec instead,
+	// and drop any (contractAddress, holderAddress) unique. The new 3-tuple
+	// unique is keyed on three fields so it can't be confused.
+	if cursor, err := collection.Indexes().List(ctx); err == nil {
+		defer cursor.Close(ctx)
+		for cursor.Next(ctx) {
+			var idx struct {
+				Name   string `bson:"name"`
+				Key    bson.D `bson:"key"`
+				Unique bool   `bson:"unique"`
+			}
+			if decErr := cursor.Decode(&idx); decErr != nil {
+				continue
+			}
+			if len(idx.Key) != 2 {
+				continue
+			}
+			// Match on the (contractAddress, holderAddress) key pair, in
+			// either order, regardless of direction. The legacy unique
+			// always pinned both to ascending (1), but matching by name
+			// only would miss any variant.
+			haveContract := false
+			haveHolder := false
+			for _, e := range idx.Key {
+				switch e.Key {
+				case "contractAddress":
+					haveContract = true
+				case "holderAddress":
+					haveHolder = true
+				}
+			}
+			if !haveContract || !haveHolder {
+				continue
+			}
+			if _, dErr := collection.Indexes().DropOne(ctx, idx.Name); dErr != nil {
+				msg := dErr.Error()
+				if !strings.Contains(msg, "IndexNotFound") &&
+					!strings.Contains(msg, "ns does not exist") &&
+					!strings.Contains(msg, "NamespaceNotFound") {
+					configs.Logger.Warn("Could not drop legacy 2-tuple unique; new 3-tuple unique still active",
+						zap.String("indexName", idx.Name),
+						zap.Error(dErr))
+				}
+			} else {
+				configs.Logger.Info("Dropped legacy 2-tuple tokenBalances index",
+					zap.String("indexName", idx.Name))
+			}
 		}
+	} else {
+		configs.Logger.Warn("Could not list tokenBalances indexes for migration; new 3-tuple unique still active",
+			zap.Error(err))
 	}
 
 	// Also retire the vestigial pre-Phase-2 indexes that targeted a non-

--- a/QRL2MongoDB/models/tokenbalance.go
+++ b/QRL2MongoDB/models/tokenbalance.go
@@ -4,12 +4,24 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-// TokenBalance represents a holder's balance for a specific token
+// TokenBalance represents a holder's balance for a specific token.
+//
+// Phase 2 extends the original (contractAddress, holderAddress) shape with
+// TokenID + TokenStandard so the same collection can store ERC-721
+// single-owner rows and ERC-1155 per-id quantities alongside the existing
+// ERC-20 rows. TokenID is the decimal-string form of the on-chain uint256.
+//
+// For ERC-20 rows, TokenID and TokenStandard are emitted as `omitempty`,
+// legacy rows (pre-migration) lack the field entirely, which Mongo treats as
+// null and which still upholds the new (contract, holder, tokenID) unique by
+// extension of the prior (contract, holder) unique.
 type TokenBalance struct {
 	ID              primitive.ObjectID `bson:"_id"`
-	ContractAddress string            `bson:"contractAddress" json:"contractAddress"`
-	HolderAddress   string            `bson:"holderAddress" json:"holderAddress"`
-	Balance         string            `bson:"balance" json:"balance"`         // hex string
-	BlockNumber     string            `bson:"blockNumber" json:"blockNumber"` // hex string
-	UpdatedAt       string            `bson:"updatedAt" json:"updatedAt"`
+	ContractAddress string             `bson:"contractAddress" json:"contractAddress"`
+	HolderAddress   string             `bson:"holderAddress" json:"holderAddress"`
+	Balance         string             `bson:"balance" json:"balance"`                                 // decimal string for NFT counts, hex/decimal for ERC-20
+	BlockNumber     string             `bson:"blockNumber" json:"blockNumber"`                         // hex string
+	UpdatedAt       string             `bson:"updatedAt" json:"updatedAt"`
+	TokenID         string             `bson:"tokenID,omitempty" json:"tokenID,omitempty"`             // decimal uint256, empty for ERC-20
+	TokenStandard   string             `bson:"tokenStandard,omitempty" json:"tokenStandard,omitempty"` // ERC-20 | ERC-721 | ERC-1155
 }

--- a/QRL2MongoDB/rpc/tokenscalls.go
+++ b/QRL2MongoDB/rpc/tokenscalls.go
@@ -852,3 +852,136 @@ func decodeUint256Array(data string, startHex uint64) ([]*big.Int, error) {
 	}
 	return out, nil
 }
+
+// encodeAddressForABI strips the Q/0x prefix from `addr` and left-pads it to a
+// 32-byte word for ABI encoding. Caller is responsible for passing a validated
+// address; the upstream `validation.IsValidAddress` check is enforced where
+// callers source addresses from log topics or user input.
+func encodeAddressForABI(addr string) string {
+	raw := strings.ToLower(validation.StripAddressPrefix(addr))
+	if len(raw) > 64 {
+		raw = raw[len(raw)-64:]
+	}
+	return strings.Repeat("0", 64-len(raw)) + raw
+}
+
+// encodeUint256ForABI left-pads `v` to a 32-byte uint256 word.
+// Negative values are rejected (uint256 has no sign).
+func encodeUint256ForABI(v *big.Int) (string, error) {
+	if v == nil {
+		return "", fmt.Errorf("uint256 cannot be nil")
+	}
+	if v.Sign() < 0 {
+		return "", fmt.Errorf("uint256 cannot be negative: %s", v.String())
+	}
+	h := v.Text(16)
+	if len(h) > 64 {
+		return "", fmt.Errorf("uint256 exceeds 32 bytes: %s", v.String())
+	}
+	return strings.Repeat("0", 64-len(h)) + h, nil
+}
+
+// parseAddressFromWord decodes the rightmost 32-byte word of `result` into a
+// canonical Q-prefix lowercase address. Returns ("", nil) if the word is the
+// zero address, callers interpret that as "no owner" (sparse storage).
+func parseAddressFromWord(result string) (string, error) {
+	stripped := strings.TrimPrefix(result, "0x")
+	if len(stripped) < 64 {
+		return "", fmt.Errorf("address word too short: %d hex chars", len(stripped))
+	}
+	word := stripped[len(stripped)-64:]
+	// All-zero word is the zero address: treat as "no owner".
+	if strings.TrimLeft(word, "0") == "" {
+		return "", nil
+	}
+	addrHex := word[len(word)-40:]
+	// The high 12 bytes (24 hex chars) must be zero for a valid 20-byte address.
+	if strings.TrimLeft(word[:24], "0") != "" {
+		return "", fmt.Errorf("address word has nonzero high bytes: %s", word)
+	}
+	addr := "Q" + strings.ToLower(addrHex)
+	if !validation.IsValidAddress(addr) {
+		return "", fmt.Errorf("invalid address derived from word: %s", addr)
+	}
+	return addr, nil
+}
+
+// parseUint256FromWord decodes the rightmost 32-byte word of `result` into a
+// *big.Int. Returns nil + error when the word is shorter than 32 bytes or
+// fails hex parsing.
+func parseUint256FromWord(result string) (*big.Int, error) {
+	stripped := strings.TrimPrefix(result, "0x")
+	if len(stripped) < 64 {
+		return nil, fmt.Errorf("uint256 word too short: %d hex chars", len(stripped))
+	}
+	word := stripped[len(stripped)-64:]
+	v := new(big.Int)
+	if _, ok := v.SetString(word, 16); !ok {
+		return nil, fmt.Errorf("failed to parse uint256 from word: %s", word)
+	}
+	return v, nil
+}
+
+// GetERC721Owner queries `ownerOf(uint256)` on an ERC-721 contract and returns
+// the current owner's Q-prefix address.
+//
+// Three-way error contract (mirrors SupportsInterface):
+//   - Contract revert (burned or never-minted id): returns ("", nil), callers
+//     treat as "no current owner" and delete any stale balance row.
+//   - Transport error: returns ("", err), callers preserve existing state to
+//     uphold the C5 promote-only invariant.
+//   - Zero address / empty word: returns ("", nil), same "no owner" semantics.
+//
+// TODO(scale): one RPC call per ERC-721 transfer. Testnet handles it; mainnet
+// at high NFT volume would want an event-delta accumulator with periodic
+// reconciliation instead.
+func GetERC721Owner(contractAddress string, tokenID *big.Int) (string, error) {
+	idWord, err := encodeUint256ForABI(tokenID)
+	if err != nil {
+		return "", fmt.Errorf("encode tokenID: %w", err)
+	}
+	calldata := SIG_OWNER_OF + idWord
+
+	result, callErr := CallContractMethod(contractAddress, calldata)
+	if callErr != nil {
+		// JSON-RPC error => contract reverted (typical for burned/unminted ids).
+		// Anything else (transport, marshalling) is transient; propagate so the
+		// caller can preserve existing state.
+		if strings.HasPrefix(callErr.Error(), "RPC error:") {
+			return "", nil
+		}
+		return "", callErr
+	}
+	return parseAddressFromWord(result)
+}
+
+// GetERC1155Balance queries `balanceOf(address,uint256)` on an ERC-1155
+// contract and returns the holder's current per-id balance.
+//
+// Three-way error contract:
+//   - Contract revert: returns (big.NewInt(0), nil), treated as "no balance"
+//     (sparse storage; caller deletes the row).
+//   - Transport error: returns (nil, err), caller preserves existing state.
+//   - Empty / zero return: returns (big.NewInt(0), nil), same as revert.
+//
+// TODO(scale): one RPC call per (from, to) side of an ERC-1155 transfer.
+// Same accumulator/reconciliation concern as GetERC721Owner above.
+func GetERC1155Balance(contractAddress, holderAddress string, tokenID *big.Int) (*big.Int, error) {
+	if !validation.IsValidAddress(holderAddress) {
+		return nil, fmt.Errorf("invalid holder address: %s", holderAddress)
+	}
+	idWord, err := encodeUint256ForABI(tokenID)
+	if err != nil {
+		return nil, fmt.Errorf("encode tokenID: %w", err)
+	}
+	calldata := SIG_BALANCE_OF_1155 + encodeAddressForABI(holderAddress) + idWord
+
+	result, callErr := CallContractMethod(contractAddress, calldata)
+	if callErr != nil {
+		if strings.HasPrefix(callErr.Error(), "RPC error:") {
+			return big.NewInt(0), nil
+		}
+		return nil, callErr
+	}
+	return parseUint256FromWord(result)
+}

--- a/QRL2MongoDB/rpc/tokenscalls_test.go
+++ b/QRL2MongoDB/rpc/tokenscalls_test.go
@@ -231,6 +231,251 @@ func TestParseERC1155TransferSingle(t *testing.T) {
 	}
 }
 
+func TestEncodeAddressForABI(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want string
+	}{
+		{
+			name: "Q-prefix lowercase",
+			addr: aliceAddr,
+			want: strings.Repeat("0", 24) + "6153d37fa4da7193e6219dcbd2bbe62fa12905b1",
+		},
+		{
+			name: "0x-prefix uppercase canonicalised to lowercase",
+			addr: "0x6153D37FA4DA7193E6219DCBD2BBE62FA12905B1",
+			want: strings.Repeat("0", 24) + "6153d37fa4da7193e6219dcbd2bbe62fa12905b1",
+		},
+		{
+			name: "no prefix",
+			addr: "6153d37fa4da7193e6219dcbd2bbe62fa12905b1",
+			want: strings.Repeat("0", 24) + "6153d37fa4da7193e6219dcbd2bbe62fa12905b1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := encodeAddressForABI(tt.addr)
+			if got != tt.want {
+				t.Errorf("encodeAddressForABI(%s)\n got %s\nwant %s", tt.addr, got, tt.want)
+			}
+			if len(got) != 64 {
+				t.Errorf("encoded length = %d, want 64", len(got))
+			}
+		})
+	}
+}
+
+func TestEncodeUint256ForABI(t *testing.T) {
+	maxUint256 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
+
+	tests := []struct {
+		name    string
+		v       *big.Int
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "zero",
+			v:    big.NewInt(0),
+			want: strings.Repeat("0", 64),
+		},
+		{
+			name: "42",
+			v:    big.NewInt(42),
+			want: strings.Repeat("0", 62) + "2a",
+		},
+		{
+			name: "uint256 max",
+			v:    maxUint256,
+			want: strings.Repeat("f", 64),
+		},
+		{
+			name:    "nil",
+			v:       nil,
+			wantErr: true,
+		},
+		{
+			name:    "negative",
+			v:       big.NewInt(-1),
+			wantErr: true,
+		},
+		{
+			name:    "exceeds 32 bytes",
+			v:       new(big.Int).Lsh(big.NewInt(1), 256),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := encodeUint256ForABI(tt.v)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseAddressFromWord(t *testing.T) {
+	aliceRaw := strings.TrimPrefix(strings.ToLower(aliceAddr), "q")
+
+	tests := []struct {
+		name     string
+		result   string
+		wantAddr string
+		wantErr  bool
+	}{
+		{
+			name:     "happy path: alice's address padded",
+			result:   "0x" + strings.Repeat("0", 24) + aliceRaw,
+			wantAddr: aliceAddr,
+		},
+		{
+			name:     "zero address returns empty (no owner)",
+			result:   "0x" + strings.Repeat("0", 64),
+			wantAddr: "",
+		},
+		{
+			name:     "no 0x prefix accepted",
+			result:   strings.Repeat("0", 24) + aliceRaw,
+			wantAddr: aliceAddr,
+		},
+		{
+			name:    "too-short response",
+			result:  "0x" + aliceRaw,
+			wantErr: true,
+		},
+		{
+			name:    "nonzero high bytes (malformed)",
+			result:  "0x" + "ff" + strings.Repeat("0", 22) + aliceRaw,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAddressFromWord(tt.result)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.EqualFold(got, tt.wantAddr) {
+				t.Errorf("got %s, want %s", got, tt.wantAddr)
+			}
+		})
+	}
+}
+
+func TestParseUint256FromWord(t *testing.T) {
+	maxHex := strings.Repeat("f", 64)
+	maxUint256 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
+
+	tests := []struct {
+		name    string
+		result  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "happy path: 100",
+			result: "0x" + word("64"),
+			want:   "100",
+		},
+		{
+			name:   "zero",
+			result: "0x" + strings.Repeat("0", 64),
+			want:   "0",
+		},
+		{
+			name:   "uint256 max",
+			result: "0x" + maxHex,
+			want:   maxUint256.String(),
+		},
+		{
+			name:    "too short",
+			result:  "0x" + word("64")[:32],
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseUint256FromWord(tt.result)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.String() != tt.want {
+				t.Errorf("got %s, want %s", got.String(), tt.want)
+			}
+		})
+	}
+}
+
+// Ensure encodeAddressForABI + parseAddressFromWord round-trip cleanly.
+func TestAddressWordRoundTrip(t *testing.T) {
+	for _, addr := range []string{aliceAddr, bobAddr, opAddr} {
+		encoded := encodeAddressForABI(addr)
+		decoded, err := parseAddressFromWord("0x" + encoded)
+		if err != nil {
+			t.Fatalf("decode %s: %v", addr, err)
+		}
+		if !strings.EqualFold(decoded, addr) {
+			t.Errorf("round-trip: got %s, want %s", decoded, addr)
+		}
+	}
+}
+
+// Helper to construct calldata that GetERC721Owner / GetERC1155Balance would
+// emit. Used below by tests that verify the request payload (selector +
+// padding) the helpers send to CallContractMethod.
+func expectedOwnerOfCalldata(id *big.Int) string {
+	w, _ := encodeUint256ForABI(id)
+	return SIG_OWNER_OF + w
+}
+
+func expectedBalanceOf1155Calldata(holder string, id *big.Int) string {
+	w, _ := encodeUint256ForABI(id)
+	return SIG_BALANCE_OF_1155 + encodeAddressForABI(holder) + w
+}
+
+func TestExpectedCalldataSelectors(t *testing.T) {
+	// Sanity: selector + padded uint256 = "0x" + 8 + 64 = 74 chars.
+	got := expectedOwnerOfCalldata(big.NewInt(1))
+	if len(got) != 74 {
+		t.Errorf("ownerOf calldata length = %d, want 74 (%q)", len(got), got)
+	}
+	if !strings.HasPrefix(got, SIG_OWNER_OF) {
+		t.Errorf("ownerOf calldata missing selector prefix: %q", got)
+	}
+
+	// Sanity: selector + padded address + padded uint256 = "0x" + 8 + 64 + 64 = 138.
+	got1155 := expectedBalanceOf1155Calldata(aliceAddr, big.NewInt(1))
+	if len(got1155) != 138 {
+		t.Errorf("balanceOf(addr,id) calldata length = %d, want 138 (%q)", len(got1155), got1155)
+	}
+	if !strings.HasPrefix(got1155, SIG_BALANCE_OF_1155) {
+		t.Errorf("balanceOf(addr,id) calldata missing selector prefix: %q", got1155)
+	}
+}
+
 func TestParseERC1155TransferBatch(t *testing.T) {
 	// Construct data: offsets at words 0-1, ids array at offset 0x40,
 	// values array at offset (0x40 + 32 + len_ids*32).

--- a/backendAPI/db/token.go
+++ b/backendAPI/db/token.go
@@ -157,6 +157,23 @@ func GetTokenHolders(contractAddress, tokenID string, page, limit int) ([]models
 	skip := int64(page * limit)
 	lim := int64(limit)
 
+	// uint256 balances can be up to 78 digits, well past Decimal128's
+	// 34-digit limit. A raw $toDecimal would throw on extreme values; both
+	// paths below avoid that. The tokenID-scoped path sorts by string
+	// (length, lex) which gives correct numeric order for any uint256
+	// without Decimal128 at all. The aggregated path needs $sum so it
+	// keeps Decimal128 but wraps the $toDecimal in $convert with onError=0,
+	// any single oversized balance falls back to 0 for sort purposes only
+	// (the original string is still in the row).
+	safeDecimalBalance := bson.M{
+		"$convert": bson.M{
+			"input":   "$balance",
+			"to":      "decimal",
+			"onError": 0,
+			"onNull":  0,
+		},
+	}
+
 	// tokenID-scoped path: rows already represent (holder, id) tuples, no
 	// grouping needed.
 	if tokenID != "" {
@@ -166,10 +183,15 @@ func GetTokenHolders(contractAddress, tokenID string, page, limit int) ([]models
 		}
 		pipeline := []bson.M{
 			{"$match": matchStage},
-			{"$addFields": bson.M{"balanceDecimal": bson.M{"$toDecimal": "$balance"}}},
-			{"$sort": bson.M{"balanceDecimal": -1}},
+			{
+				"$addFields": bson.M{
+					"balanceLen": bson.M{"$strLenCP": bson.M{"$ifNull": []interface{}{"$balance", ""}}},
+				},
+			},
+			{"$sort": bson.D{{Key: "balanceLen", Value: -1}, {Key: "balance", Value: -1}}},
 			{"$skip": skip},
 			{"$limit": lim},
+			{"$project": bson.M{"balanceLen": 0}},
 		}
 		cursor, err := collection.Aggregate(ctx, pipeline)
 		if err != nil {
@@ -195,7 +217,7 @@ func GetTokenHolders(contractAddress, tokenID string, page, limit int) ([]models
 		"$group": bson.M{
 			"_id":             "$holderAddress",
 			"contractAddress": bson.M{"$first": "$contractAddress"},
-			"balanceDecimal":  bson.M{"$sum": bson.M{"$toDecimal": "$balance"}},
+			"balanceDecimal":  bson.M{"$sum": safeDecimalBalance},
 			"blockNumber":     bson.M{"$max": "$blockNumber"},
 			"updatedAt":       bson.M{"$max": "$updatedAt"},
 			"tokenStandard":   bson.M{"$first": "$tokenStandard"},
@@ -282,10 +304,25 @@ func GetTokenIDs(contractAddress string, page, limit int) ([]TokenIDSummary, int
 
 	collection := configs.GetCollection(configs.DB, "tokenBalances")
 
-	groupStage := bson.M{
+	// Two-stage group to count distinct (tokenID, holder) pairs per id
+	// without holding the holder list in memory. First stage collapses
+	// duplicate (id, holder) rows; second stage counts them per id. Avoids
+	// the $addToSet array-build that would OOM on hot ERC-1155 collections.
+	firstGroup := bson.M{
 		"$group": bson.M{
-			"_id":           "$tokenID",
-			"holders":       bson.M{"$addToSet": "$holderAddress"},
+			"_id": bson.M{
+				"tokenID":       "$tokenID",
+				"holderAddress": "$holderAddress",
+			},
+			"tokenStandard": bson.M{"$first": "$tokenStandard"},
+			"blockNumber":   bson.M{"$max": "$blockNumber"},
+			"updatedAt":     bson.M{"$max": "$updatedAt"},
+		},
+	}
+	secondGroup := bson.M{
+		"$group": bson.M{
+			"_id":           "$_id.tokenID",
+			"holderCount":   bson.M{"$sum": 1},
 			"tokenStandard": bson.M{"$first": "$tokenStandard"},
 			"blockNumber":   bson.M{"$max": "$blockNumber"},
 			"updatedAt":     bson.M{"$max": "$updatedAt"},
@@ -295,7 +332,8 @@ func GetTokenIDs(contractAddress string, page, limit int) ([]TokenIDSummary, int
 	// Total count of distinct ids.
 	countPipeline := []bson.M{
 		{"$match": matchStage},
-		groupStage,
+		firstGroup,
+		secondGroup,
 		{"$count": "total"},
 	}
 	countCursor, err := collection.Aggregate(ctx, countPipeline)
@@ -314,36 +352,32 @@ func GetTokenIDs(contractAddress string, page, limit int) ([]TokenIDSummary, int
 		totalCount = countResult[0].Total
 	}
 
+	// Sort key: full uint256 IDs can be up to 78 digits, well past
+	// Decimal128's 34-digit limit, so $convert-to-decimal will throw on
+	// extreme values. Sort by (string length DESC of "1" -> "01" no, we
+	// want ASC numeric order so shorter-len first, then lex). Lexicographic
+	// sort on equal-length numeric strings matches numeric sort, so the
+	// (len, lex) tuple gives correct numeric ascending order for the full
+	// uint256 range without involving Decimal128.
 	pipeline := []bson.M{
 		{"$match": matchStage},
-		groupStage,
+		firstGroup,
+		secondGroup,
 		{
 			"$project": bson.M{
 				"_id":           0,
 				"tokenID":       "$_id",
-				"holderCount":   bson.M{"$size": "$holders"},
+				"holderCount":   1,
 				"tokenStandard": 1,
 				"blockNumber":   1,
 				"updatedAt":     1,
-				// Sort key: cast tokenID to decimal so "10" > "2" (string
-				// sort would have put "10" before "2"). big-ints up to
-				// uint256 fit in Mongo's Decimal128 (up to 34 sig digits)
-				// for sorting purposes; the response keeps the original
-				// string for full precision.
-				"sortKey": bson.M{
-					"$convert": bson.M{
-						"input":   "$_id",
-						"to":      "decimal",
-						"onError": "0",
-						"onNull":  "0",
-					},
-				},
+				"tokenIDLen":    bson.M{"$strLenCP": bson.M{"$ifNull": []interface{}{"$_id", ""}}},
 			},
 		},
-		{"$sort": bson.M{"sortKey": 1}},
+		{"$sort": bson.D{{Key: "tokenIDLen", Value: 1}, {Key: "tokenID", Value: 1}}},
 		{"$skip": int64(page * limit)},
 		{"$limit": int64(limit)},
-		{"$project": bson.M{"sortKey": 0}},
+		{"$project": bson.M{"tokenIDLen": 0}},
 	}
 
 	cursor, err := collection.Aggregate(ctx, pipeline)

--- a/backendAPI/db/token.go
+++ b/backendAPI/db/token.go
@@ -64,7 +64,9 @@ func GetTokenBalancesByAddress(address string) ([]models.TokenBalance, error) {
 				"preserveNullAndEmptyArrays": true,
 			},
 		},
-		// Project final structure with token metadata
+		// Project final structure with token metadata. Phase 2: include
+		// tokenID + tokenStandard so the address page can render NFT
+		// holdings per (collection, tokenID) row.
 		{
 			"$project": bson.M{
 				"contractAddress": 1,
@@ -72,6 +74,8 @@ func GetTokenBalancesByAddress(address string) ([]models.TokenBalance, error) {
 				"balance":         1,
 				"blockNumber":     1,
 				"updatedAt":       1,
+				"tokenID":         1,
+				"tokenStandard":   1,
 				"name":            "$tokenInfo.name",
 				"symbol":          "$tokenInfo.symbol",
 				"decimals":        "$tokenInfo.decimals",
@@ -126,43 +130,121 @@ func normalizeAddressBoth(address string) []string {
 	return []string{normalizeAddress(address)}
 }
 
-// GetTokenHolders returns all holders of a specific token contract with pagination
-func GetTokenHolders(contractAddress string, page, limit int) ([]models.TokenBalance, int, error) {
+// GetTokenHolders returns all holders of a specific token contract with pagination.
+//
+// Phase 2: when `tokenID` is empty, holders are aggregated across all ids
+// (one row per distinct holder; balance is the sum of per-id quantities,
+// useful for ERC-1155 "how many copies in total" or ERC-721 "how many NFTs
+// owned"). When `tokenID` is set, only rows for that specific id are
+// returned (one per holder of that id).
+//
+// ERC-20 behaviour is unchanged: rows already have a null tokenID, so the
+// aggregate-by-holder path produces the same shape as before, one row per
+// (contract, holder) with the existing balance string.
+func GetTokenHolders(contractAddress, tokenID string, page, limit int) ([]models.TokenBalance, int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	contractVariants := normalizeAddressBoth(contractAddress)
-	contractFilter := bson.M{"contractAddress": bson.M{"$in": contractVariants}}
+	matchStage := bson.M{"contractAddress": bson.M{"$in": contractVariants}}
+	if tokenID != "" {
+		matchStage["tokenID"] = tokenID
+	}
+
 	collection := configs.GetCollection(configs.DB, "tokenBalances")
 
-	// Count total holders
-	totalCount, err := collection.CountDocuments(ctx, contractFilter)
+	// Pagination skip+limit (decimal-sorted by balance, descending).
+	skip := int64(page * limit)
+	lim := int64(limit)
+
+	// tokenID-scoped path: rows already represent (holder, id) tuples, no
+	// grouping needed.
+	if tokenID != "" {
+		totalCount, err := collection.CountDocuments(ctx, matchStage)
+		if err != nil {
+			return nil, 0, err
+		}
+		pipeline := []bson.M{
+			{"$match": matchStage},
+			{"$addFields": bson.M{"balanceDecimal": bson.M{"$toDecimal": "$balance"}}},
+			{"$sort": bson.M{"balanceDecimal": -1}},
+			{"$skip": skip},
+			{"$limit": lim},
+		}
+		cursor, err := collection.Aggregate(ctx, pipeline)
+		if err != nil {
+			return nil, 0, err
+		}
+		defer cursor.Close(ctx)
+
+		var holders []models.TokenBalance
+		if err := cursor.All(ctx, &holders); err != nil {
+			return nil, 0, err
+		}
+		if holders == nil {
+			holders = make([]models.TokenBalance, 0)
+		}
+		return holders, int(totalCount), nil
+	}
+
+	// Aggregated-by-holder path (no tokenID filter).
+	// $group collapses the per-id rows; balanceSum is the cross-id total.
+	// For ERC-20 (no tokenID rows) each holder already has one row, so the
+	// sum equals the row's balance.
+	groupStage := bson.M{
+		"$group": bson.M{
+			"_id":             "$holderAddress",
+			"contractAddress": bson.M{"$first": "$contractAddress"},
+			"balanceDecimal":  bson.M{"$sum": bson.M{"$toDecimal": "$balance"}},
+			"blockNumber":     bson.M{"$max": "$blockNumber"},
+			"updatedAt":       bson.M{"$max": "$updatedAt"},
+			"tokenStandard":   bson.M{"$first": "$tokenStandard"},
+		},
+	}
+
+	// Distinct-holder count. Mongo doesn't have a clean "$count after $group"
+	// alongside the paginated cursor, so issue a separate aggregation that
+	// stops at $count.
+	countPipeline := []bson.M{
+		{"$match": matchStage},
+		groupStage,
+		{"$count": "total"},
+	}
+	countCursor, err := collection.Aggregate(ctx, countPipeline)
 	if err != nil {
 		return nil, 0, err
 	}
+	defer countCursor.Close(ctx)
+	var countResult []struct {
+		Total int `bson:"total"`
+	}
+	if err := countCursor.All(ctx, &countResult); err != nil {
+		return nil, 0, err
+	}
+	totalCount := 0
+	if len(countResult) > 0 {
+		totalCount = countResult[0].Total
+	}
 
-	// Aggregation pipeline to get holders sorted by balance
 	pipeline := []bson.M{
+		{"$match": matchStage},
+		groupStage,
+		// Reshape grouped doc back into TokenBalance.
 		{
-			"$match": contractFilter,
-		},
-		// Convert balance to decimal for proper sorting
-		{
-			"$addFields": bson.M{
-				"balanceDecimal": bson.M{"$toDecimal": "$balance"},
+			"$project": bson.M{
+				"_id":             0,
+				"contractAddress": 1,
+				"holderAddress":   "$_id",
+				"balance":         bson.M{"$toString": "$balanceDecimal"},
+				"blockNumber":     1,
+				"updatedAt":       1,
+				"tokenStandard":   1,
+				"balanceDecimal":  1,
 			},
 		},
-		// Sort by balance descending
-		{
-			"$sort": bson.M{"balanceDecimal": -1},
-		},
-		// Pagination
-		{
-			"$skip": int64(page * limit),
-		},
-		{
-			"$limit": int64(limit),
-		},
+		{"$sort": bson.M{"balanceDecimal": -1}},
+		{"$skip": skip},
+		{"$limit": lim},
 	}
 
 	cursor, err := collection.Aggregate(ctx, pipeline)
@@ -175,12 +257,118 @@ func GetTokenHolders(contractAddress string, page, limit int) ([]models.TokenBal
 	if err := cursor.All(ctx, &holders); err != nil {
 		return nil, 0, err
 	}
-
 	if holders == nil {
 		holders = make([]models.TokenBalance, 0)
 	}
 
-	return holders, int(totalCount), nil
+	return holders, totalCount, nil
+}
+
+// GetTokenIDs returns the distinct list of tokenIDs minted on a given NFT
+// contract, with the holder count for each id. Paginated. ERC-20 contracts
+// have no tokenID column and will return an empty list.
+//
+// Holder count is the number of distinct (holder, id) rows for that id,
+// i.e. how many addresses currently hold at least one copy of the id.
+func GetTokenIDs(contractAddress string, page, limit int) ([]TokenIDSummary, int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	contractVariants := normalizeAddressBoth(contractAddress)
+	matchStage := bson.M{
+		"contractAddress": bson.M{"$in": contractVariants},
+		"tokenID":         bson.M{"$exists": true, "$ne": ""},
+	}
+
+	collection := configs.GetCollection(configs.DB, "tokenBalances")
+
+	groupStage := bson.M{
+		"$group": bson.M{
+			"_id":           "$tokenID",
+			"holders":       bson.M{"$addToSet": "$holderAddress"},
+			"tokenStandard": bson.M{"$first": "$tokenStandard"},
+			"blockNumber":   bson.M{"$max": "$blockNumber"},
+			"updatedAt":     bson.M{"$max": "$updatedAt"},
+		},
+	}
+
+	// Total count of distinct ids.
+	countPipeline := []bson.M{
+		{"$match": matchStage},
+		groupStage,
+		{"$count": "total"},
+	}
+	countCursor, err := collection.Aggregate(ctx, countPipeline)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer countCursor.Close(ctx)
+	var countResult []struct {
+		Total int `bson:"total"`
+	}
+	if err := countCursor.All(ctx, &countResult); err != nil {
+		return nil, 0, err
+	}
+	totalCount := 0
+	if len(countResult) > 0 {
+		totalCount = countResult[0].Total
+	}
+
+	pipeline := []bson.M{
+		{"$match": matchStage},
+		groupStage,
+		{
+			"$project": bson.M{
+				"_id":           0,
+				"tokenID":       "$_id",
+				"holderCount":   bson.M{"$size": "$holders"},
+				"tokenStandard": 1,
+				"blockNumber":   1,
+				"updatedAt":     1,
+				// Sort key: cast tokenID to decimal so "10" > "2" (string
+				// sort would have put "10" before "2"). big-ints up to
+				// uint256 fit in Mongo's Decimal128 (up to 34 sig digits)
+				// for sorting purposes; the response keeps the original
+				// string for full precision.
+				"sortKey": bson.M{
+					"$convert": bson.M{
+						"input":   "$_id",
+						"to":      "decimal",
+						"onError": "0",
+						"onNull":  "0",
+					},
+				},
+			},
+		},
+		{"$sort": bson.M{"sortKey": 1}},
+		{"$skip": int64(page * limit)},
+		{"$limit": int64(limit)},
+		{"$project": bson.M{"sortKey": 0}},
+	}
+
+	cursor, err := collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer cursor.Close(ctx)
+
+	var summaries []TokenIDSummary
+	if err := cursor.All(ctx, &summaries); err != nil {
+		return nil, 0, err
+	}
+	if summaries == nil {
+		summaries = make([]TokenIDSummary, 0)
+	}
+	return summaries, totalCount, nil
+}
+
+// TokenIDSummary is one row in the GET /token/:addr/tokens response.
+type TokenIDSummary struct {
+	TokenID       string `json:"tokenID" bson:"tokenID"`
+	HolderCount   int    `json:"holderCount" bson:"holderCount"`
+	TokenStandard string `json:"tokenStandard,omitempty" bson:"tokenStandard,omitempty"`
+	BlockNumber   string `json:"blockNumber,omitempty" bson:"blockNumber,omitempty"`
+	UpdatedAt     string `json:"updatedAt,omitempty" bson:"updatedAt,omitempty"`
 }
 
 // GetTokenTransfers returns all transfers for a specific token contract with pagination

--- a/backendAPI/models/token_balance.go
+++ b/backendAPI/models/token_balance.go
@@ -1,12 +1,20 @@
 package models
 
-// TokenBalance represents a token holding for a specific address
+// TokenBalance represents a token holding for a specific address.
+//
+// Phase 2: NFT collections store one row per (contract, holder, tokenID) so
+// the same struct serves ERC-20 (TokenID empty), ERC-721 (Balance="1" per id),
+// and ERC-1155 (Balance is per-id quantity as a decimal string). Legacy
+// pre-Phase-2 rows have no TokenID / TokenStandard fields, the omitempty
+// tags keep their JSON shape stable.
 type TokenBalance struct {
 	ContractAddress string `json:"contractAddress" bson:"contractAddress"`
 	HolderAddress   string `json:"holderAddress" bson:"holderAddress"`
 	Balance         string `json:"balance" bson:"balance"`
 	BlockNumber     string `json:"blockNumber" bson:"blockNumber"`
 	UpdatedAt       string `json:"updatedAt" bson:"updatedAt"`
+	TokenID         string `json:"tokenID,omitempty" bson:"tokenID,omitempty"`
+	TokenStandard   string `json:"tokenStandard,omitempty" bson:"tokenStandard,omitempty"`
 	// Token metadata (populated via aggregation)
 	Name     string `json:"name,omitempty" bson:"name,omitempty"`
 	Symbol   string `json:"symbol,omitempty" bson:"symbol,omitempty"`

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -844,14 +844,18 @@ func UserRoute(router *gin.Engine) {
 		c.JSON(http.StatusOK, info)
 	})
 
-	// Get token holders with pagination
+	// Get token holders with pagination. Phase 2: optional `?tokenID=`
+	// query param filters to holders of a specific NFT tokenID. When
+	// absent, holders are aggregated across all ids (one row per distinct
+	// holder, balance is the cross-id total). ERC-20 behaviour unchanged.
 	router.GET("/token/:address/holders", func(c *gin.Context) {
 		address := c.Param("address")
+		tokenID := c.Query("tokenID")
 		page, limit := getPaginationParams(c, 0, 25)
 
-		holders, totalCount, err := db.GetTokenHolders(address, page, limit)
+		holders, totalCount, err := db.GetTokenHolders(address, tokenID, page, limit)
 		if err != nil {
-			log.Printf("Error fetching token holders for %s: %v", address, err)
+			log.Printf("Error fetching token holders for %s (tokenID=%q): %v", address, tokenID, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Failed to fetch token holders",
 			})
@@ -864,6 +868,31 @@ func UserRoute(router *gin.Engine) {
 			TotalHolders:    totalCount,
 			Page:            page,
 			Limit:           limit,
+		})
+	})
+
+	// Phase 2: list distinct tokenIDs minted on an NFT contract, with the
+	// number of holders for each id. Paginated by `?page=&limit=` like the
+	// other token endpoints. Returns an empty list for ERC-20 contracts.
+	router.GET("/token/:address/tokens", func(c *gin.Context) {
+		address := c.Param("address")
+		page, limit := getPaginationParams(c, 0, 25)
+
+		tokens, totalCount, err := db.GetTokenIDs(address, page, limit)
+		if err != nil {
+			log.Printf("Error fetching tokenIDs for %s: %v", address, err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to fetch tokenIDs",
+			})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"contractAddress": address,
+			"tokens":          tokens,
+			"totalTokenIDs":   totalCount,
+			"page":            page,
+			"limit":           limit,
 		})
 	})
 


### PR DESCRIPTION
## Summary

Phase 2 of zondscan NFT support: extend `tokenBalances` to a per-tokenID 3-tuple key and wire per-standard balance helpers into the syncer + backend + explorer UI. Phase 1 (PR #89) gave us per-transfer indexing; Phase 2 gives us per-tokenID ownership.

Three logical commits:

1. **`feat(rpc): GetERC721Owner + GetERC1155Balance helpers`** (356a0e9): ABI encoders + JSON-RPC wrappers for `ownerOf(uint256)` and `balanceOf(address,uint256)`. Three-way error contract (contract revert / transport / empty), matching the C5 promote-only invariant from Phase 1's `SupportsInterface`. Table-driven unit tests on the pure decoders + calldata sanity checks.

2. **`feat(syncer): per-tokenID balance schema + dispatch wiring`** (cb85c75): extends `tokenBalances` to `(contractAddress, holderAddress, tokenID)`. Create-before-drop index migration (legacy 2-tuple unique stays active until the new 3-tuple is online). New `StoreERC721Ownership` enforces the single-owner invariant on `ownerOf` truth; `StoreERC1155Balance` does sparse-storage per-id quantities via `balanceOf(addr,id)`. `ProcessBlockTokenTransfers` dispatch switch wires the per-standard helpers. ERC-20 path unchanged.

3. **`feat(zondscan): per-tokenID holder + tokens API + UI`** (35bd138): backend gains `?tokenID=` on `/token/:addr/holders` (filters to that id) and a new `GET /token/:addr/tokens` (distinct id list with holder counts). Token contract view gets a "Tokens" tab (NFT collections only) and a tokenID filter on the holders tab. ERC-20 view + ERC-20 row shape unchanged. API explorer updated.

## Schema changes

`tokenBalances` collection:
- new optional fields `tokenID` (decimal uint256) and `tokenStandard` (`ERC-20|ERC-721|ERC-1155`)
- new unique compound index `(contractAddress, holderAddress, tokenID)`
- new secondary `(contractAddress, tokenID, holderAddress)` powers `/holders?tokenID=`
- legacy 2-tuple unique dropped after the new one is online; vestigial pre-Phase-2 `address_idx` / `contract_address_idx` indexes (which targeted a non-existent `address` field) also retired

Legacy ERC-20 rows lack `tokenID`, Mongo treats missing fields as `null` for uniqueness so the new 3-tuple unique is non-disruptive on existing data.

## Tradeoffs documented

The dispatch helpers call `ownerOf` / `balanceOf` once per NFT transfer. Testnet handles that fine; mainnet at high NFT volume would want an event-delta accumulator with periodic reconciliation. Tagged `// TODO(scale)` on both helpers and the dispatch comment.

## Out of scope (deferred)

- Phase 3 metadata pipeline (`tokenURI` / `uri` / `contractURI` + IPFS gateway + image rendering)
- Address-page UI holdings list (the data is already on `/address/:addr/tokens`; the explorer just doesn't render a holdings list there yet)
- ERC-20 helper convergence on the C5 invariant (the new helpers honour it; the existing `StoreTokenBalance` still zero-fills on transient RPC errors; tracked in plan as out-of-scope follow-up)

## Test plan

- [x] `MONGOURI=mongodb://localhost:27017 go test ./QRL2MongoDB/rpc ./QRL2MongoDB/db ./backendAPI/...` green
- [x] `cd QRL2MongoDB && go build .` green
- [x] `cd backendAPI && go build .` green
- [x] `cd ExplorerFrontend && npx tsc --noEmit && npm run build` green
- [ ] Post-merge: drop `qrldata-z` on prod, full resync, verify `db.tokenBalances.find({contractAddress: "Q539f73306..."})` returns one row per minted tokenID for the SimpleERC721 fixture; verify `/token/Qb70193d0.../holders?tokenID=42` returns the expected ERC-1155 holders.