### PR TITLE
fix(syncer): initialize token collections on every Sync() startup

### DIFF
--- a/QRL2MongoDB/synchroniser/sync.go
+++ b/QRL2MongoDB/synchroniser/sync.go
@@ -98,6 +98,21 @@ func Sync() {
 	var nextBlock string
 	var maxHex string
 
+	// Ensure the token collections + their indexes exist before we start
+	// processing blocks. Pre-Phase-2 this only ran via processInitialBlock,
+	// which is gated on IsCollectionsExist() == false, but the configs init
+	// path creates non-token collections (dailyTransactionsVolume etc), so
+	// IsCollectionsExist returns true on every restart and the gate never
+	// opens. Calling InitializeTokenCollections here is idempotent
+	// (CreateMany no-ops on existing indexes) and guarantees the Phase 2
+	// (contract, holder, tokenID) unique index actually gets created.
+	if err := InitializeTokenCollections(); err != nil {
+		configs.Logger.Error("Failed to initialize token collections at sync start",
+			zap.Error(err))
+		// Continue anyway: the indexes are about correctness, not liveness;
+		// the syncer can still index blocks and we'll log the issue loudly.
+	}
+
 	// DB queries, no retry needed, these are local and don't fail transiently.
 	nextBlock = db.GetLastKnownBlockNumber()
 	if nextBlock == "0x0" {


### PR DESCRIPTION
## Summary

Hotfix surfaced during Phase 2 prod deploy: \`InitializeTokenCollections()\` only ran via \`processInitialBlock\`, which is gated on \`IsCollectionsExist() == false\`. \`configs.ConnectDB\` pre-creates other collections so that gate is always closed on restart, and the Phase 2 (contract, holder, tokenID) unique index was never created. Phase 1 unintentionally hid the bug because \`configs/setup.go\` was double-creating the legacy 2-tuple unique; Phase 2 moved that responsibility to \`InitializeTokenBalancesCollection\` and the latent miss became visible.

Call \`InitializeTokenCollections()\` at the top of \`Sync()\` unconditionally. The function is idempotent (\`CreateMany\` no-ops on existing indexes); cost is one extra \`listIndexes\` round-trip per restart.

## Reproduction

\`\`\`bash
mongosh --quiet --eval 'db.getSiblingDB("qrldata-z").dropDatabase()'
pm2 restart synchroniser
# wait for sync
mongosh --quiet --eval 'db.getSiblingDB("qrldata-z").tokenBalances.getIndexes()'
# pre-fix: [{_id_}]
# post-fix: includes contract_holder_tokenID_idx (unique), contract_tokenID_holder_idx, holder_idx, contract_idx
\`\`\`

## Test plan
- [x] \`cd QRL2MongoDB && go build .\` green
- [ ] Manual: restart syncer on prod, confirm \`tokenBalances.getIndexes()\` returns the four Phase 2 indexes
- [ ] Manual: confirm \`/token/Q539f73306.../holders\` returns NFT holder rows after resync