### PR TITLE
feat(syncer): collection-level NFT metadata via contractURI (Phase 3a)

### DIFF
--- a/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
 import CopyButton from "../../components/CopyButton";
 import QRCodeButton from "../../components/QRCodeButton";
@@ -267,11 +268,19 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
     const decimals = tokenInfo?.decimals ?? contractData.decimals ?? 18;
     const rawSymbol = tokenInfo?.symbol ?? contractData.symbol ?? '';
     const rawName = tokenInfo?.name ?? contractData.name ?? '';
+    // Phase 3a: prefer the off-chain metadata-name over the on-chain
+    // name() because most NFT collections leave name() empty and put the
+    // human-readable title in the contractURI JSON instead. The on-chain
+    // symbol still wins for the badge (collection JSONs don't carry one).
+    const metaName = contractData.metadataName?.trim() || '';
+    const metaImage = contractData.metadataImage?.trim() || '';
+    const metaDescription = contractData.metadataDescription?.trim() || '';
+    const metaExternalURL = contractData.metadataExternalURL?.trim() || '';
     // ERC-1155 collections often omit name()/symbol(), so fall back to a
     // truncated address rather than rendering "Unknown Token" / "TOKEN".
     const addrShort = `${address.slice(0, 10)}...${address.slice(-6)}`;
     const symbol = rawSymbol || addrShort;
-    const name = rawName || addrShort;
+    const name = metaName || rawName || addrShort;
     const totalSupply = tokenInfo?.totalSupply ?? contractData.totalSupply ?? '0';
     const creatorAddress = creationTx?.From || tokenInfo?.creatorAddress || contractData.creatorAddress || '';
     const creationTxHash = tokenInfo?.creationTxHash || contractData.creationTransaction || '';
@@ -325,19 +334,52 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                     {/* Token Identity */}
                     <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-6 pb-4 border-b border-gray-700">
                         <div className="flex items-center gap-4">
-                            {/* Token Icon */}
-                            <div className="w-12 h-12 md:w-16 md:h-16 rounded-full bg-gradient-to-br from-[#ffa729] to-[#ff6b00] flex items-center justify-center text-xl md:text-2xl font-bold text-white">
-                                {symbol.charAt(0)}
-                            </div>
+                            {/* Token Icon. Phase 3a: render the off-chain
+                                metadata image when present, fall back to the
+                                first-character monogram. Fixed 64px square so
+                                the layout doesn't shift while the next/image
+                                loader resolves. */}
+                            {metaImage ? (
+                                <div className="relative w-12 h-12 md:w-16 md:h-16 rounded-full overflow-hidden border border-gray-700 bg-black/30">
+                                    <Image
+                                        src={metaImage}
+                                        alt={name}
+                                        fill
+                                        sizes="64px"
+                                        className="object-cover"
+                                        unoptimized
+                                    />
+                                </div>
+                            ) : (
+                                <div className="w-12 h-12 md:w-16 md:h-16 rounded-full bg-gradient-to-br from-[#ffa729] to-[#ff6b00] flex items-center justify-center text-xl md:text-2xl font-bold text-white">
+                                    {symbol.charAt(0)}
+                                </div>
+                            )}
                             <div>
-                                <div className="flex items-center gap-2">
+                                <div className="flex items-center gap-2 flex-wrap">
                                     <h1 className="text-xl md:text-2xl font-bold text-white">{name}</h1>
                                     {rawSymbol && (
                                         <span className="px-2 py-0.5 rounded bg-[#ffa729]/20 text-[#ffa729] text-sm font-medium">
                                             {rawSymbol}
                                         </span>
                                     )}
+                                    {metaExternalURL && (
+                                        <a
+                                            href={metaExternalURL}
+                                            target="_blank"
+                                            rel="noreferrer noopener nofollow"
+                                            className="text-xs text-gray-400 hover:text-accent underline"
+                                            title="External URL from contract metadata"
+                                        >
+                                            site ↗
+                                        </a>
+                                    )}
                                 </div>
+                                {metaDescription && (
+                                    <p className="text-xs md:text-sm text-gray-300 mt-1 line-clamp-2 max-w-prose">
+                                        {metaDescription}
+                                    </p>
+                                )}
                                 <div className="flex items-center gap-2 mt-1">
                                     <span className="text-xs md:text-sm text-gray-400 font-mono">{address}</span>
                                     <CopyButton value={address} label="Copy address" />

--- a/ExplorerFrontend/app/api-explorer/api-explorer-client.tsx
+++ b/ExplorerFrontend/app/api-explorer/api-explorer-client.tsx
@@ -201,14 +201,14 @@ const endpointGroups: EndpointGroup[] = [
       {
         method: 'GET',
         path: '/contracts',
-        description: 'Returns a paginated list of smart contracts. Supports search, token/standard filtering, and substring match on name or symbol. The `standard` filter (Phase 1 NFT support) returns only contracts classified as the given EIP standard; `isToken=true` is the looser superset (matches all three token standards).',
-        params: 'page (query, default: 0), limit (query, default: 10, max: 100), search (query, matches address, creator address, name, or symbol, case-insensitive), isToken (query, true/false), standard (query, ERC-20|ERC-721|ERC-1155, invalid value → 400)',
+        description: 'Returns a paginated list of smart contracts. Supports search, token/standard filtering, and substring match on name, symbol, or off-chain metadataName. The `standard` filter (Phase 1 NFT support) returns only contracts classified as the given EIP standard; `isToken=true` is the looser superset (matches all three token standards). Phase 3a: each row includes optional `metadataName` / `metadataImage` / `metadataDescription` / `metadataExternalURL` populated from the contract\'s `contractURI()` getter via the IPFS gateway.',
+        params: 'page (query, default: 0), limit (query, default: 10, max: 100), search (query, matches address, creator address, name, symbol, or metadataName, case-insensitive), isToken (query, true/false), standard (query, ERC-20|ERC-721|ERC-1155, invalid value → 400)',
         example: '/contracts?page=0&limit=10&standard=ERC-721',
       },
       {
         method: 'GET',
         path: '/token/:address/info',
-        description: 'Returns summary information for a token contract (name, symbol, decimals, supply).',
+        description: 'Returns summary information for a token contract (name, symbol, decimals, supply). Phase 3a: the underlying contract document also carries `metadataName` / `metadataImage` / `metadataDescription` / `metadataExternalURL` resolved from `contractURI()`, available on the /contracts list rows and on the address-page contract document.',
         example: '/token/Q539f73306bdd4288f93a5e50b4d5bf1a9b07f147/info',
       },
       {

--- a/ExplorerFrontend/app/contracts/contracts-client.tsx
+++ b/ExplorerFrontend/app/contracts/contracts-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import axios from 'axios';
@@ -26,6 +27,11 @@ interface ContractData {
   creationBlockNumber?: string;
   isToken: boolean;
   tokenStandard?: 'ERC-20' | 'ERC-721' | 'ERC-1155' | string;
+  // Phase 3a: off-chain collection metadata. metadataName preferred over
+  // on-chain name() when both exist, NFT collections typically leave
+  // name() empty and put the display title in the contractURI JSON.
+  metadataName?: string;
+  metadataImage?: string;
 }
 
 interface ContractsClientProps {
@@ -438,16 +444,18 @@ function ContractRow({
   const avatarTextColor = isToken ? 'text-black' : 'text-white';
 
   // Some standards (ERC-1155 in particular) don't expose name()/symbol(),
-  // so the syncer stores empty strings. Fall back to the truncated address
-  // for the primary line and the standard label for the secondary line so
-  // the row remains identifiable instead of a generic "Unknown".
+  // so the syncer stores empty strings. Phase 3a adds an off-chain name
+  // from contractURI(); prefer it over the on-chain name when present.
+  // Fall through to a truncated address + standard-label so the row
+  // remains identifiable instead of a generic "Unknown".
   const standardFallback =
     variant === 'erc20' ? 'Token'
     : variant === 'erc721' ? 'NFT Collection'
     : variant === 'erc1155' ? 'Multi-Token Collection'
     : 'Contract';
+  const displayName = (contract.metadataName?.trim() || contract.name || '').trim();
   const primary = isToken
-    ? (contract.name || truncateAddress(contract.address, 10, 8))
+    ? (displayName || truncateAddress(contract.address, 10, 8))
     : 'Smart Contract';
   const secondary = isToken
     ? (contract.symbol || standardFallback)
@@ -460,15 +468,28 @@ function ContractRow({
     return <Badge variant="info">Contract</Badge>;
   })();
 
+  // Phase 3a: render the off-chain collection image in the avatar slot
+  // when present. Falls back to the monogram gradient when missing/empty.
+  // Fixed 32px square so the row height doesn't shift while next/image
+  // resolves; `unoptimized` because the wallet backend's IPFS proxy
+  // already streams pre-sized originals (no /_next/image rewrite path).
+  const metaImage = (contract.metadataImage || '').trim();
+
   return (
     <tr className="hover:bg-[#2d2d2d]/30">
       <td className={TD_BASE}>
         <div className="flex items-center gap-3">
-          <div
-            className={`w-8 h-8 rounded-full bg-gradient-to-br ${avatarGradient} flex items-center justify-center font-bold text-sm shrink-0 ${avatarTextColor}`}
-          >
-            {avatarChar}
-          </div>
+          {metaImage ? (
+            <div className="relative w-8 h-8 rounded-full overflow-hidden border border-gray-700/50 bg-black/30 shrink-0">
+              <Image src={metaImage} alt={primary} fill sizes="32px" className="object-cover" unoptimized />
+            </div>
+          ) : (
+            <div
+              className={`w-8 h-8 rounded-full bg-gradient-to-br ${avatarGradient} flex items-center justify-center font-bold text-sm shrink-0 ${avatarTextColor}`}
+            >
+              {avatarChar}
+            </div>
+          )}
           <div className="min-w-0">
             <div className="text-white font-medium truncate">{primary}</div>
             <div className="text-gray-500 text-sm truncate">{secondary}</div>

--- a/ExplorerFrontend/app/types/address.ts
+++ b/ExplorerFrontend/app/types/address.ts
@@ -25,6 +25,20 @@ export interface ContractData {
   symbol: string;
   updatedAt: string;
 
+  /** Phase 3a: off-chain collection metadata fetched from contractURI()
+   *  via the IPFS gateway. The image URL is pre-resolved to an HTTPS
+   *  URL renderable directly via next/image; the syncer never persists
+   *  bare `ipfs://...` here so the frontend doesn't have to deal with it.
+   *  All fields are absent ("not fetched yet") on contracts whose
+   *  `contractURI()` reverts or whose fetcher pass hasn't run. */
+  metadataURI?: string;
+  metadataName?: string;
+  metadataDescription?: string;
+  metadataImage?: string;
+  metadataExternalURL?: string;
+  metadataFetchedAt?: string;
+  metadataFetchError?: string;
+
   // Source verification (added by M1, populated by M2+)
   verified: boolean;
   sourceCode?: string;

--- a/ExplorerFrontend/next.config.js
+++ b/ExplorerFrontend/next.config.js
@@ -18,6 +18,21 @@ const nextConfig = {
     HANDLER_URL: process.env.HANDLER_URL,
     DOMAIN_NAME: process.env.DOMAIN_NAME,
   },
+  // Phase 3a: allow next/image to render off-chain NFT metadata images.
+  // The syncer's metadata fetcher resolves every NFT image URL through
+  // its configured IPFS gateway (default https://qrlwallet.com/api/ipfs/),
+  // so the primary allowed origins are the wallet backend's IPFS proxy
+  // (prod + dev) plus a small fallback list of common public gateways
+  // for the rare contract whose metadata image points outside the proxy.
+  images: {
+    remotePatterns: [
+      { protocol: 'https', hostname: 'qrlwallet.com', pathname: '/api/ipfs/**' },
+      { protocol: 'https', hostname: 'dev.qrlwallet.com', pathname: '/api/ipfs/**' },
+      { protocol: 'https', hostname: 'ipfs.io', pathname: '/ipfs/**' },
+      { protocol: 'https', hostname: 'cloudflare-ipfs.com', pathname: '/ipfs/**' },
+      { protocol: 'https', hostname: 'nftstorage.link', pathname: '/ipfs/**' },
+    ],
+  },
   // Optimize bundle size by transforming barrel imports
   modularizeImports: {
     '@heroicons/react/24/outline': {

--- a/QRL2MongoDB/db/contracts.go
+++ b/QRL2MongoDB/db/contracts.go
@@ -129,6 +129,15 @@ func StoreContract(contract models.ContractInfo) error {
 		if merged.BaseURI == "" && contract.BaseURI != "" {
 			merged.BaseURI = contract.BaseURI
 		}
+		// Phase 3a collection metadata: gap-fill only for MetadataURI from
+		// the classifier path. The metadata fetcher service has its own
+		// write path (UpdateContractMetadata) for the *resolved* fields
+		// (Name/Description/Image/ExternalURL/FetchedAt/FetchError); the
+		// classifier never touches those, so a transient classification
+		// blip can't clobber a previously-resolved metadata document.
+		if merged.MetadataURI == "" && contract.MetadataURI != "" {
+			merged.MetadataURI = contract.MetadataURI
+		}
 	} else if !errors.Is(err, mongo.ErrNoDocuments) {
 		configs.Logger.Error("Failed to check for existing contract",
 			zap.String("address", contract.Address),
@@ -224,7 +233,103 @@ func syncerOwnedSet(c models.ContractInfo) bson.M {
 	if c.BaseURI != "" {
 		m["baseURI"] = c.BaseURI
 	}
+	// Phase 3a collection metadata: classifier writes only the URI; the
+	// resolved fields are owned by the fetcher and updated through
+	// UpdateContractMetadata (below). The omitempty pattern protects
+	// existing fetcher state from being clobbered on classifier passes.
+	if c.MetadataURI != "" {
+		m["metadataURI"] = c.MetadataURI
+	}
 	return m
+}
+
+// UpdateContractMetadata writes the resolved off-chain collection metadata
+// for one contract. The fetcher service is the only caller, the classifier
+// path (StoreContract) deliberately doesn't touch these fields. This
+// separation lets a transient classification blip retain the resolved
+// metadata while still allowing the fetcher to record a new fetch attempt's
+// outcome (success or error) without racing the classifier.
+//
+// Empty `name` / `description` / `image` / `externalURL` arguments clear
+// those fields. The expected pattern is:
+//
+//   - Success: pass the parsed values + FetchedAt = now, FetchError = "".
+//   - Failure: pass empty for the four content fields, FetchedAt = "",
+//     FetchError = the reason. Existing content fields are preserved
+//     because the merge sentinel below skips empty content writes.
+//
+// The fetcher records FetchError without blanking previously-resolved
+// content fields, a temporary IPFS gateway 503 should NOT wipe out a
+// successfully-fetched display name from yesterday.
+func UpdateContractMetadata(address, name, description, image, externalURL, fetchedAt, fetchError string) error {
+	address = validation.ConvertToQAddress(address)
+
+	set := bson.M{
+		"metadataFetchedAt":  fetchedAt,
+		"metadataFetchError": fetchError,
+	}
+	// Only overwrite content fields when we have new content. On failure
+	// the four content args are "" and we skip the writes, preserving the
+	// last-good state.
+	if name != "" {
+		set["metadataName"] = name
+	}
+	if description != "" {
+		set["metadataDescription"] = description
+	}
+	if image != "" {
+		set["metadataImage"] = image
+	}
+	if externalURL != "" {
+		set["metadataExternalURL"] = externalURL
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := configs.GetContractsCollection().UpdateOne(
+		ctx,
+		bson.M{"address": address},
+		bson.M{"$set": set},
+	)
+	if err != nil {
+		configs.Logger.Error("Failed to update contract metadata",
+			zap.String("address", address),
+			zap.Error(err))
+		return err
+	}
+	return nil
+}
+
+// GetContractsAwaitingMetadata returns up to `limit` NFT contracts that have
+// a populated MetadataURI but have not yet been fetched successfully
+// (FetchedAt is empty OR FetchError is set). The metadata fetcher service
+// uses this as its work queue.
+func GetContractsAwaitingMetadata(limit int) ([]models.ContractInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	filter := bson.M{
+		"metadataURI":   bson.M{"$ne": ""},
+		"tokenStandard": bson.M{"$in": []string{"ERC-721", "ERC-1155"}},
+		"$or": []bson.M{
+			{"metadataFetchedAt": bson.M{"$in": []interface{}{"", nil}}},
+			{"metadataFetchError": bson.M{"$ne": ""}},
+		},
+	}
+	opts := options.Find().SetLimit(int64(limit))
+
+	cur, err := configs.GetContractsCollection().Find(ctx, filter, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer cur.Close(ctx)
+
+	var out []models.ContractInfo
+	if err := cur.All(ctx, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // standardRank orders TokenStandard values for promote-only merging.

--- a/QRL2MongoDB/db/contracts.go
+++ b/QRL2MongoDB/db/contracts.go
@@ -244,24 +244,27 @@ func syncerOwnedSet(c models.ContractInfo) bson.M {
 }
 
 // UpdateContractMetadata writes the resolved off-chain collection metadata
-// for one contract. The fetcher service is the only caller, the classifier
+// for one contract. The fetcher service is the only caller; the classifier
 // path (StoreContract) deliberately doesn't touch these fields. This
 // separation lets a transient classification blip retain the resolved
 // metadata while still allowing the fetcher to record a new fetch attempt's
 // outcome (success or error) without racing the classifier.
 //
-// Empty `name` / `description` / `image` / `externalURL` arguments clear
-// those fields. The expected pattern is:
+// Empty `name` / `description` / `image` / `externalURL` arguments PRESERVE
+// the existing database values (last-good state). Only `fetchedAt` and
+// `fetchError` are always written, so an operator can see the latest probe
+// result without blowing away previously-fetched content. The expected
+// pattern is:
 //
 //   - Success: pass the parsed values + FetchedAt = now, FetchError = "".
 //   - Failure: pass empty for the four content fields, FetchedAt = "",
 //     FetchError = the reason. Existing content fields are preserved
 //     because the merge sentinel below skips empty content writes.
 //
-// The fetcher records FetchError without blanking previously-resolved
-// content fields, a temporary IPFS gateway 503 should NOT wipe out a
-// successfully-fetched display name from yesterday.
-func UpdateContractMetadata(address, name, description, image, externalURL, fetchedAt, fetchError string) error {
+// The caller-supplied ctx scopes both timeout and cancellation. The fetcher
+// passes the shutdown-aware ctx so a pm2 stop interrupts an in-flight write
+// instead of leaking a 10s context.Background goroutine.
+func UpdateContractMetadata(ctx context.Context, address, name, description, image, externalURL, fetchedAt, fetchError string) error {
 	address = validation.ConvertToQAddress(address)
 
 	set := bson.M{
@@ -284,7 +287,7 @@ func UpdateContractMetadata(address, name, description, image, externalURL, fetc
 		set["metadataExternalURL"] = externalURL
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	_, err := configs.GetContractsCollection().UpdateOne(
@@ -304,9 +307,10 @@ func UpdateContractMetadata(address, name, description, image, externalURL, fetc
 // GetContractsAwaitingMetadata returns up to `limit` NFT contracts that have
 // a populated MetadataURI but have not yet been fetched successfully
 // (FetchedAt is empty OR FetchError is set). The metadata fetcher service
-// uses this as its work queue.
-func GetContractsAwaitingMetadata(limit int) ([]models.ContractInfo, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+// uses this as its work queue and passes its shutdown-aware ctx so a pm2
+// stop cancels an in-flight read promptly.
+func GetContractsAwaitingMetadata(ctx context.Context, limit int) ([]models.ContractInfo, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	filter := bson.M{

--- a/QRL2MongoDB/db/token_detection.go
+++ b/QRL2MongoDB/db/token_detection.go
@@ -78,6 +78,7 @@ func EnsureContractClassified(contractAddress string, blockNumber string, txHash
 		TotalSupply:   detection.TotalSupply,
 		TokenStandard: detection.Standard,
 		HasERC165:     detection.HasERC165,
+		MetadataURI:   detection.MetadataURI,
 		UpdatedAt:     time.Now().UTC().Format(time.RFC3339),
 	}
 

--- a/QRL2MongoDB/main.go
+++ b/QRL2MongoDB/main.go
@@ -129,6 +129,20 @@ func main() {
 	configs.Logger.Info("Starting pending transaction sync service...")
 	synchroniser.StartPendingTransactionSync()
 
+	// Phase 3a: start the off-chain NFT collection metadata fetcher.
+	// Background goroutine that polls contractCode for unfetched
+	// metadataURI rows and resolves them through the configured IPFS
+	// gateway. Self-disables via METADATA_FETCHER_ENABLED=false.
+	metadataCtx, cancelMetadata := context.WithCancel(context.Background())
+	metadataSvc := synchroniser.NewMetadataService()
+	metadataSvc.Start(metadataCtx)
+	// Ensure the goroutine stops cleanly on shutdown.
+	go func() {
+		<-stopCh
+		cancelMetadata()
+		metadataSvc.Stop()
+	}()
+
 	// Run the main sync in a goroutine so the signal handler above can observe doneCh.
 	go func() {
 		defer close(doneCh)

--- a/QRL2MongoDB/models/contract.go
+++ b/QRL2MongoDB/models/contract.go
@@ -69,10 +69,32 @@ type ContractInfo struct {
 	// "ERC-20" / "ERC-721" / "ERC-1155" or empty for unclassified contracts.
 	// `hasERC165` records whether supportsInterface returned a well-formed
 	// answer, once true we skip re-probing the ERC-165 path. `baseURI` is
-	// Phase 3 territory (tokenURI rendering) and stays empty until populated.
+	// reserved for tokenURI rendering (Phase 3b) and stays empty until then.
 	TokenStandard string `bson:"tokenStandard,omitempty" json:"tokenStandard,omitempty"`
 	HasERC165     bool   `bson:"hasERC165,omitempty" json:"hasERC165,omitempty"`
 	BaseURI       string `bson:"baseURI,omitempty" json:"baseURI,omitempty"`
+
+	// Collection-level off-chain metadata (Phase 3a).
+	//
+	// `MetadataURI` is written by the syncer at classification time from the
+	// OpenSea-convention contractURI() getter; everything else is populated
+	// by the background metadata fetcher service after it resolves the URI
+	// and parses the JSON. Empty strings on all fields are the "not fetched"
+	// signal, the merge in db/contracts.go preserves any previously
+	// populated value if a later probe fails (C5 promote-only invariant).
+	//
+	// `MetadataImage` is stored as the gateway-resolved URL so the frontend
+	// can pass it directly to next/image, no per-render IPFS resolution.
+	// `MetadataFetchError` surfaces non-fatal fetch failures for diagnostics
+	// (gateway down, JSON malformed) without blocking the rest of the
+	// indexer; cleared on the next successful fetch.
+	MetadataURI         string `bson:"metadataURI,omitempty" json:"metadataURI,omitempty"`
+	MetadataName        string `bson:"metadataName,omitempty" json:"metadataName,omitempty"`
+	MetadataDescription string `bson:"metadataDescription,omitempty" json:"metadataDescription,omitempty"`
+	MetadataImage       string `bson:"metadataImage,omitempty" json:"metadataImage,omitempty"`
+	MetadataExternalURL string `bson:"metadataExternalURL,omitempty" json:"metadataExternalURL,omitempty"`
+	MetadataFetchedAt   string `bson:"metadataFetchedAt,omitempty" json:"metadataFetchedAt,omitempty"`
+	MetadataFetchError  string `bson:"metadataFetchError,omitempty" json:"metadataFetchError,omitempty"`
 
 	// Source-verification fields, mirror backendAPI/models/contract.go.
 	// Written exclusively by the backend verify endpoint; the syncer

--- a/QRL2MongoDB/rpc/tokenscalls.go
+++ b/QRL2MongoDB/rpc/tokenscalls.go
@@ -997,19 +997,32 @@ func parseDynamicString(result string) (string, error) {
 		return "", fmt.Errorf("dynamic string payload too short: %d hex chars", len(stripped))
 	}
 
-	offset, err := strconv.ParseInt(stripped[:64], 16, 64)
-	if err != nil || offset < 0 {
-		return "", fmt.Errorf("invalid offset word: %w", err)
+	// ABI words are 256 bits; strconv.ParseInt caps at 64. Real offsets are
+	// tiny (start at 0x20 = 32 bytes for one dynamic return), but an
+	// attacker-crafted return value could fill the full 32-byte word to try
+	// to crash the decoder. Parse as big.Int and reject anything that
+	// doesn't fit a signed int64 before downcasting.
+	offsetInt := new(big.Int)
+	if _, ok := offsetInt.SetString(stripped[:64], 16); !ok {
+		return "", fmt.Errorf("invalid offset word")
 	}
+	if !offsetInt.IsInt64() || offsetInt.Sign() < 0 {
+		return "", fmt.Errorf("offset out of int64 range")
+	}
+	offset := offsetInt.Int64()
 	startPos := offset * 2
 	if startPos+64 > int64(len(stripped)) {
 		return "", fmt.Errorf("string length word out of bounds: offset=%d payload=%d", offset, len(stripped)/2)
 	}
 
-	length, err := strconv.ParseInt(stripped[startPos:startPos+64], 16, 64)
-	if err != nil || length < 0 {
-		return "", fmt.Errorf("invalid length word: %w", err)
+	lengthInt := new(big.Int)
+	if _, ok := lengthInt.SetString(stripped[startPos:startPos+64], 16); !ok {
+		return "", fmt.Errorf("invalid length word")
 	}
+	if !lengthInt.IsInt64() || lengthInt.Sign() < 0 {
+		return "", fmt.Errorf("length out of int64 range")
+	}
+	length := lengthInt.Int64()
 	// Cap at a sane upper bound; nothing legitimate is going to return a
 	// multi-MB string from a view call, and an attacker could otherwise
 	// force a huge allocation.

--- a/QRL2MongoDB/rpc/tokenscalls.go
+++ b/QRL2MongoDB/rpc/tokenscalls.go
@@ -1000,8 +1000,11 @@ func parseDynamicString(result string) (string, error) {
 	// ABI words are 256 bits; strconv.ParseInt caps at 64. Real offsets are
 	// tiny (start at 0x20 = 32 bytes for one dynamic return), but an
 	// attacker-crafted return value could fill the full 32-byte word to try
-	// to crash the decoder. Parse as big.Int and reject anything that
-	// doesn't fit a signed int64 before downcasting.
+	// to crash the decoder. Parse as big.Int, reject negatives + anything
+	// outside int64, then bound against the payload size BEFORE the *2
+	// multiplication so an offset near math.MaxInt64 can't overflow
+	// startPos into a negative number that would silently bypass the
+	// subsequent slice-bounds check and panic on `stripped[startPos:...]`.
 	offsetInt := new(big.Int)
 	if _, ok := offsetInt.SetString(stripped[:64], 16); !ok {
 		return "", fmt.Errorf("invalid offset word")
@@ -1010,6 +1013,14 @@ func parseDynamicString(result string) (string, error) {
 		return "", fmt.Errorf("offset out of int64 range")
 	}
 	offset := offsetInt.Int64()
+	// `offset` is a byte index into the payload; `len(stripped)` is hex
+	// chars (2x byte count). The check `offset > len(stripped)` is a
+	// generous upper bound that's still tight enough to prevent the
+	// multiplication overflow, the next bounds check below handles the
+	// precise condition.
+	if offset > int64(len(stripped)) {
+		return "", fmt.Errorf("offset out of bounds: offset=%d payload=%d", offset, len(stripped)/2)
+	}
 	startPos := offset * 2
 	if startPos+64 > int64(len(stripped)) {
 		return "", fmt.Errorf("string length word out of bounds: offset=%d payload=%d", offset, len(stripped)/2)

--- a/QRL2MongoDB/rpc/tokenscalls.go
+++ b/QRL2MongoDB/rpc/tokenscalls.go
@@ -27,6 +27,7 @@ const (
 	SIG_BALANCE_OF_1155    = "0x00fdd58e" // balanceOf(address,uint256), ERC-1155
 	SIG_TOKEN_URI          = "0xc87b56dd" // tokenURI(uint256), ERC-721Metadata
 	SIG_URI                = "0x0e89341c" // uri(uint256), ERC-1155MetadataURI
+	SIG_CONTRACT_URI       = "0xe8a3d485" // contractURI(), OpenSea convention
 )
 
 // ERC-165 interface IDs, as the 4-byte XOR of the interface's method selectors.
@@ -953,6 +954,98 @@ func GetERC721Owner(contractAddress string, tokenID *big.Int) (string, error) {
 		return "", callErr
 	}
 	return parseAddressFromWord(result)
+}
+
+// parseDynamicString decodes the ABI-encoded `bytes`/`string` return value of
+// a no-argument view function (e.g. name(), symbol(), contractURI()).
+//
+// The ABI layout for a single dynamic return value is:
+//
+//	[ offset (32B) || length (32B) || data (length bytes, right-padded to 32B) ]
+//
+// `result` is the raw `qrl_call` result with or without the "0x" prefix.
+// Empty or all-zero results return ("", nil), the caller treats that as
+// "method returned empty" which is distinct from a transport / decode error.
+//
+// Defensive against malformed payloads: every offset / length read is
+// bounds-checked against the available hex chars, so a truncated response
+// returns a clean error instead of panicking.
+func parseDynamicString(result string) (string, error) {
+	stripped := strings.TrimPrefix(result, "0x")
+
+	// Empty or all-zero is treated as "method exists but returned empty
+	// string"; not an error so callers can record `metadataURI=""` as a
+	// successful probe (no URI set on chain).
+	if len(stripped) == 0 || strings.TrimLeft(stripped, "0") == "" {
+		return "", nil
+	}
+
+	// Minimum payload: 32 bytes offset + 32 bytes length = 128 hex chars.
+	if len(stripped) < 128 {
+		return "", fmt.Errorf("dynamic string payload too short: %d hex chars", len(stripped))
+	}
+
+	offset, err := strconv.ParseInt(stripped[:64], 16, 64)
+	if err != nil || offset < 0 {
+		return "", fmt.Errorf("invalid offset word: %w", err)
+	}
+	startPos := offset * 2
+	if startPos+64 > int64(len(stripped)) {
+		return "", fmt.Errorf("string length word out of bounds: offset=%d payload=%d", offset, len(stripped)/2)
+	}
+
+	length, err := strconv.ParseInt(stripped[startPos:startPos+64], 16, 64)
+	if err != nil || length < 0 {
+		return "", fmt.Errorf("invalid length word: %w", err)
+	}
+	// Cap at a sane upper bound; nothing legitimate is going to return a
+	// multi-MB string from a view call, and an attacker could otherwise
+	// force a huge allocation.
+	const maxDynamicStringBytes = 1 << 20 // 1 MiB
+	if length > maxDynamicStringBytes {
+		return "", fmt.Errorf("dynamic string length %d exceeds cap %d", length, maxDynamicStringBytes)
+	}
+	if startPos+64+length*2 > int64(len(stripped)) {
+		return "", fmt.Errorf("string data out of bounds: declared length=%d available=%d", length, (int64(len(stripped))-startPos-64)/2)
+	}
+
+	dataHex := stripped[startPos+64 : startPos+64+length*2]
+	bytes, err := hex.DecodeString(dataHex)
+	if err != nil {
+		return "", fmt.Errorf("hex decode failed: %w", err)
+	}
+	return string(bytes), nil
+}
+
+// GetContractURI queries `contractURI()` on a contract (OpenSea convention
+// for collection-level NFT metadata) and returns the raw URI string.
+//
+// Three-way error contract, mirrors SupportsInterface / GetERC721Owner:
+//   - Contract revert (the contract doesn't implement contractURI, which is
+//     true of most collections): returns ("", nil) so the caller can record
+//     "no collection metadata" without treating it as a fetch failure.
+//   - Transport error: returns ("", err); callers preserve existing state
+//     (C5 promote-only invariant).
+//   - Empty / malformed return: returns ("", nil), same "no URI" semantic.
+//
+// The returned URI is whatever the contract emitted, no IPFS gateway
+// resolution happens here, the metadata service does that.
+func GetContractURI(contractAddress string) (string, error) {
+	result, callErr := CallContractMethod(contractAddress, SIG_CONTRACT_URI)
+	if callErr != nil {
+		if strings.HasPrefix(callErr.Error(), "RPC error:") {
+			return "", nil
+		}
+		return "", callErr
+	}
+	uri, decErr := parseDynamicString(result)
+	if decErr != nil {
+		// Malformed return word, treat as "no URI" rather than failing the
+		// caller; we never want a single misbehaving contract to throw off
+		// classification of every contract that comes after.
+		return "", nil
+	}
+	return uri, nil
 }
 
 // GetERC1155Balance queries `balanceOf(address,uint256)` on an ERC-1155

--- a/QRL2MongoDB/rpc/tokenscalls.go
+++ b/QRL2MongoDB/rpc/tokenscalls.go
@@ -142,6 +142,13 @@ const (
 // ContractDetectionResult is returned by DetectContractType. Fields outside
 // of Standard/Name/Symbol/HasERC165 are only populated for ERC-20 (Decimals,
 // TotalSupply); NFT collections often omit `decimals()` entirely.
+//
+// MetadataURI is best-effort populated for NFT (ERC-721/1155) contracts via
+// the OpenSea-convention contractURI() probe. Empty means either "the contract
+// doesn't implement contractURI" or "the probe failed transiently" - the
+// background metadata fetcher service handles the URI -> JSON resolution
+// separately, so a missing URI at classification time can be filled in on a
+// later reclassification pass without breaking anything.
 type ContractDetectionResult struct {
 	Standard    string // StandardERC20 | StandardERC721 | StandardERC1155 | ""
 	Name        string
@@ -149,6 +156,7 @@ type ContractDetectionResult struct {
 	Decimals    uint8
 	TotalSupply string
 	HasERC165   bool
+	MetadataURI string
 }
 
 // DetectContractType classifies a contract by trying ERC-165 supportsInterface
@@ -173,11 +181,13 @@ func DetectContractType(addr string) (ContractDetectionResult, error) {
 	if supports {
 		name, _ := GetTokenName(addr)     // best-effort; many ERC-1155s omit name()
 		symbol, _ := GetTokenSymbol(addr) // best-effort; many ERC-1155s omit symbol()
+		metaURI, _ := GetContractURI(addr) // best-effort; many collections omit contractURI()
 		return ContractDetectionResult{
-			Standard:  StandardERC1155,
-			Name:      name,
-			Symbol:    symbol,
-			HasERC165: true,
+			Standard:    StandardERC1155,
+			Name:        name,
+			Symbol:      symbol,
+			HasERC165:   true,
+			MetadataURI: metaURI,
 		}, nil
 	}
 
@@ -189,11 +199,13 @@ func DetectContractType(addr string) (ContractDetectionResult, error) {
 	if supports721 {
 		name, _ := GetTokenName(addr)
 		symbol, _ := GetTokenSymbol(addr)
+		metaURI, _ := GetContractURI(addr)
 		return ContractDetectionResult{
-			Standard:  StandardERC721,
-			Name:      name,
-			Symbol:    symbol,
-			HasERC165: true,
+			Standard:    StandardERC721,
+			Name:        name,
+			Symbol:      symbol,
+			HasERC165:   true,
+			MetadataURI: metaURI,
 		}, nil
 	}
 

--- a/QRL2MongoDB/rpc/tokenscalls_test.go
+++ b/QRL2MongoDB/rpc/tokenscalls_test.go
@@ -517,6 +517,24 @@ func TestParseDynamicString(t *testing.T) {
 			result:  "0x" + word("20") + word("ff") + strings.Repeat("00", 16),
 			wantErr: true,
 		},
+		{
+			// Adversarial: offset is filled with the maximum signed-int64
+			// value (after the leading zero in the 64-hex-char word).
+			// IsInt64 passes; without the explicit `offset > len(stripped)`
+			// guard, `offset * 2` would overflow to a negative number and
+			// the subsequent slice would panic. With the guard, we return
+			// a clean error.
+			name: "max-int64 offset rejected before multiplication overflow",
+			result: "0x" + "0" + strings.Repeat("7", 1) + strings.Repeat("f", 62) +
+				strings.Repeat("00", 32),
+			wantErr: true,
+		},
+		{
+			// uint256 max as offset trips the IsInt64() branch (>2^63-1).
+			name:    "uint256-max offset rejected (overflows int64)",
+			result:  "0x" + strings.Repeat("f", 64) + strings.Repeat("00", 32),
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/QRL2MongoDB/rpc/tokenscalls_test.go
+++ b/QRL2MongoDB/rpc/tokenscalls_test.go
@@ -456,6 +456,99 @@ func expectedBalanceOf1155Calldata(holder string, id *big.Int) string {
 	return SIG_BALANCE_OF_1155 + encodeAddressForABI(holder) + w
 }
 
+func TestParseDynamicString(t *testing.T) {
+	// Helper: build an ABI-encoded dynamic string from a Go string.
+	// Layout: [offset=0x20 || length || data right-padded to 32B].
+	encode := func(s string) string {
+		raw := []byte(s)
+		length := len(raw)
+		// Right-pad to next 32-byte boundary.
+		padLen := (32 - length%32) % 32
+		padded := make([]byte, length+padLen)
+		copy(padded, raw)
+		offsetWord := word("20")
+		lengthWord := word(new(big.Int).SetInt64(int64(length)).Text(16))
+		return "0x" + offsetWord + lengthWord + hexEncode(padded)
+	}
+
+	tests := []struct {
+		name    string
+		result  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "happy path short",
+			result: encode("ipfs://Qm.../"),
+			want:   "ipfs://Qm.../",
+		},
+		{
+			name:   "happy path 32 bytes exactly",
+			result: encode("0123456789abcdef0123456789abcdef"),
+			want:   "0123456789abcdef0123456789abcdef",
+		},
+		{
+			name:   "happy path long URI",
+			result: encode("https://example.com/collections/my-nfts/metadata.json?v=2026"),
+			want:   "https://example.com/collections/my-nfts/metadata.json?v=2026",
+		},
+		{
+			name:   "empty string (method exists, returned empty)",
+			result: "0x" + word("20") + word("0"),
+			want:   "",
+		},
+		{
+			name:   "all-zero payload returns empty (no error)",
+			result: "0x" + strings.Repeat("0", 128),
+			want:   "",
+		},
+		{
+			name:    "too-short payload",
+			result:  "0x" + word("20"),
+			wantErr: true,
+		},
+		{
+			name:    "offset points past payload",
+			result:  "0x" + word("ff") + strings.Repeat("0", 64),
+			wantErr: true,
+		},
+		{
+			name:    "length exceeds payload",
+			result:  "0x" + word("20") + word("ff") + strings.Repeat("00", 16),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDynamicString(tt.result)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// hexEncode is an inline lower-case hex.EncodeToString without importing.
+func hexEncode(b []byte) string {
+	const hexd = "0123456789abcdef"
+	out := make([]byte, len(b)*2)
+	for i, v := range b {
+		out[i*2] = hexd[v>>4]
+		out[i*2+1] = hexd[v&0x0f]
+	}
+	return string(out)
+}
+
 func TestExpectedCalldataSelectors(t *testing.T) {
 	// Sanity: selector + padded uint256 = "0x" + 8 + 64 = 74 chars.
 	got := expectedOwnerOfCalldata(big.NewInt(1))

--- a/QRL2MongoDB/synchroniser/metadata_service.go
+++ b/QRL2MongoDB/synchroniser/metadata_service.go
@@ -32,12 +32,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"go.uber.org/zap"
@@ -108,12 +110,107 @@ func NewMetadataService() *MetadataService {
 	}
 	return &MetadataService{
 		gatewayURL:   cfg.gatewayURL,
-		httpClient:   &http.Client{Timeout: cfg.fetchTimeout},
+		httpClient:   newSafeHTTPClient(cfg.fetchTimeout),
 		pollInterval: cfg.pollInterval,
 		batchSize:    cfg.batchSize,
 		maxBodyBytes: cfg.maxBodyBytes,
 		stopCh:       make(chan struct{}),
 	}
+}
+
+// newSafeHTTPClient builds an http.Client whose Transport refuses to connect
+// to private / loopback / link-local / multicast / unspecified IPs. The
+// Dialer's Control hook fires after DNS resolution and before the socket
+// connects, so it also catches DNS-rebinding attacks where a hostname
+// resolves to a public IP at validation time but a private one when the
+// dial actually runs.
+//
+// This is the SSRF perimeter for the metadata fetcher: any URL whose host
+// resolves to a forbidden range gets a connection error from net.Dial,
+// surfaced as a normal HTTP error to fetchBody. We never reach the
+// dangerous endpoint.
+func newSafeHTTPClient(timeout time.Duration) *http.Client {
+	dialer := &net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 30 * time.Second,
+		Control: func(network, address string, _ syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return err
+			}
+			ip := net.ParseIP(host)
+			if ip == nil {
+				return fmt.Errorf("ssrf-guard: unresolvable host %q", host)
+			}
+			if isForbiddenIP(ip) {
+				return fmt.Errorf("ssrf-guard: refusing to connect to %s", ip.String())
+			}
+			return nil
+		},
+	}
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			DialContext:         dialer.DialContext,
+			TLSHandshakeTimeout: timeout,
+			// Disable connection reuse so a previously-allowed IP can't be
+			// re-targeted by a later DNS rebind for the same hostname.
+			DisableKeepAlives: true,
+		},
+	}
+}
+
+// extraBlockedCIDRs lists ranges Go's net.IP.IsPrivate / IsLoopback /
+// IsLinkLocal* don't cover but that we still don't want a server-side
+// fetcher hitting. Kept as a package var so tests can extend it.
+var extraBlockedCIDRs = mustParseCIDRs(
+	"100.64.0.0/10",   // CGNAT
+	"192.0.0.0/24",    // IETF Protocol Assignments
+	"198.18.0.0/15",   // Network interconnect device benchmark
+	"192.0.2.0/24",    // TEST-NET-1
+	"198.51.100.0/24", // TEST-NET-2
+	"203.0.113.0/24",  // TEST-NET-3
+	"240.0.0.0/4",     // Reserved
+	"fc00::/7",        // IPv6 ULA
+	"fe80::/10",       // IPv6 link-local
+	"100::/64",        // IPv6 discard prefix
+	"2001:db8::/32",   // IPv6 docs prefix
+)
+
+func mustParseCIDRs(s ...string) []*net.IPNet {
+	nets := make([]*net.IPNet, 0, len(s))
+	for _, c := range s {
+		_, n, err := net.ParseCIDR(c)
+		if err != nil {
+			panic(fmt.Sprintf("invalid extra-blocked CIDR %q: %v", c, err))
+		}
+		nets = append(nets, n)
+	}
+	return nets
+}
+
+// isForbiddenIP returns true if `ip` is in a range the metadata fetcher must
+// never connect to. Combines Go's stdlib helpers with explicit additional
+// CIDRs (CGNAT, IETF reserved, IPv6 ULA, etc) that the stdlib doesn't flag.
+func isForbiddenIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified() ||
+		ip.IsInterfaceLocalMulticast() {
+		return true
+	}
+	for _, n := range extraBlockedCIDRs {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 // Start launches the polling goroutine. Idempotent in the sense that
@@ -165,7 +262,7 @@ func (s *MetadataService) Stop() {
 // tick runs one batch of metadata fetches. Errors per row are logged and
 // recorded on the contractCode document; the tick itself never fails.
 func (s *MetadataService) tick(ctx context.Context) {
-	rows, err := db.GetContractsAwaitingMetadata(s.batchSize)
+	rows, err := db.GetContractsAwaitingMetadata(ctx, s.batchSize)
 	if err != nil {
 		configs.Logger.Warn("metadata fetcher: failed to read work queue", zap.Error(err))
 		return
@@ -192,7 +289,7 @@ func (s *MetadataService) tick(ctx context.Context) {
 func (s *MetadataService) fetchOne(ctx context.Context, address, uri string) {
 	resolved, err := resolveMetadataURI(uri, s.gatewayURL)
 	if err != nil {
-		s.recordFailure(address, fmt.Sprintf("resolve: %v", err))
+		s.recordFailure(ctx, address, fmt.Sprintf("resolve: %v", err))
 		return
 	}
 
@@ -203,13 +300,13 @@ func (s *MetadataService) fetchOne(ctx context.Context, address, uri string) {
 
 	body, fetchErr := s.fetchBody(ctx, resolved)
 	if fetchErr != nil {
-		s.recordFailure(address, fmt.Sprintf("fetch: %v", fetchErr))
+		s.recordFailure(ctx, address, fmt.Sprintf("fetch: %v", fetchErr))
 		return
 	}
 
 	parsed, parseErr := parseMetadataJSON(body)
 	if parseErr != nil {
-		s.recordFailure(address, fmt.Sprintf("parse: %v", parseErr))
+		s.recordFailure(ctx, address, fmt.Sprintf("parse: %v", parseErr))
 		return
 	}
 
@@ -234,6 +331,7 @@ func (s *MetadataService) fetchOne(ctx context.Context, address, uri string) {
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	if err := db.UpdateContractMetadata(
+		ctx,
 		address,
 		parsed.Name,
 		parsed.Description,
@@ -254,10 +352,10 @@ func (s *MetadataService) fetchOne(ctx context.Context, address, uri string) {
 		zap.Bool("hasImage", imageResolved != ""))
 }
 
-func (s *MetadataService) recordFailure(address, reason string) {
+func (s *MetadataService) recordFailure(ctx context.Context, address, reason string) {
 	// Pass empty content args so the existing name/image survives a transient
 	// gateway error.
-	if err := db.UpdateContractMetadata(address, "", "", "", "", "", reason); err != nil {
+	if err := db.UpdateContractMetadata(ctx, address, "", "", "", "", "", reason); err != nil {
 		configs.Logger.Warn("metadata fetcher: failed to record fetch error",
 			zap.String("address", address),
 			zap.String("reason", reason),
@@ -314,12 +412,26 @@ type metadataDocument struct {
 // map, then pull out the string fields we care about, ignoring any non-
 // string variants. This lets a malformed `description: ["foo", "bar"]`
 // reduce to an empty description rather than failing the entire record.
+//
+// Two sentinel cases for which we still return an empty doc + nil error
+// rather than a JSON-shape error:
+//
+//   - the JSON literal `null`, which unmarshals into a nil map; reading
+//     `raw[key]` from a nil map is safe in Go but the explicit check keeps
+//     the intent obvious and silences static analysis warnings;
+//   - top-level scalars or arrays, where Unmarshal fails with a type
+//     mismatch error - those still fail loudly.
 func parseMetadataJSON(body []byte) (metadataDocument, error) {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return metadataDocument{}, err
 	}
 	stringField := func(key string) string {
+		// Reading from a nil map is safe in Go, but the explicit branch
+		// avoids any ambiguity for future readers.
+		if raw == nil {
+			return ""
+		}
 		v, ok := raw[key]
 		if !ok || v == nil {
 			return ""

--- a/QRL2MongoDB/synchroniser/metadata_service.go
+++ b/QRL2MongoDB/synchroniser/metadata_service.go
@@ -1,0 +1,421 @@
+// Package services / metadata_service.go
+//
+// Background fetcher for collection-level off-chain NFT metadata (Phase 3a).
+//
+// Polls `contractCode` for NFT contracts that have a `metadataURI` populated
+// by the classifier but no `metadataFetchedAt` yet (or a previous fetch
+// error), resolves the URI through the configured IPFS gateway, parses the
+// JSON, and persists the off-chain `name` / `description` / `image` /
+// `external_url` fields via `db.UpdateContractMetadata`.
+//
+// Design notes
+//
+//   - We deliberately don't run this on the hot block-processing path. A
+//     stuck IPFS gateway must not block block indexing.
+//   - Default gateway is the myqrlwallet backend's IPFS proxy
+//     (https://qrlwallet.com/api/ipfs/), which already enforces a 10 MiB
+//     cap, 8 s timeout, CID validation, and strict CSP on responses. The
+//     env var IPFS_GATEWAY_URL overrides for local dev / staging /
+//     self-hosting; if blank the service self-disables.
+//   - Image URLs are resolved through the same gateway so the frontend can
+//     render them via next/image without an additional proxy hop.
+//   - The fetcher updates `metadataFetchError` on transient failures so an
+//     operator can see what went wrong without grepping logs. The error
+//     does NOT clear previously-fetched content fields; a yesterday-good
+//     name survives a today-bad gateway.
+package synchroniser
+
+import (
+	"QRL2MongoDB/configs"
+	"QRL2MongoDB/db"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// MetadataService is the background fetcher; one instance per syncer process.
+type MetadataService struct {
+	gatewayURL   string
+	httpClient   *http.Client
+	pollInterval time.Duration
+	batchSize    int
+	maxBodyBytes int64
+
+	stopCh chan struct{}
+}
+
+// metadataServiceConfig holds the tunables sourced from the environment.
+type metadataServiceConfig struct {
+	gatewayURL   string
+	pollInterval time.Duration
+	fetchTimeout time.Duration
+	maxBodyBytes int64
+	batchSize    int
+	enabled      bool
+}
+
+// envInt parses an integer env var with a fallback default.
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
+// loadMetadataServiceConfig reads the metadata-fetcher tunables from env.
+// All values have safe defaults so the service runs out of the box; only
+// IPFS_GATEWAY_URL must be explicitly set or default to the wallet
+// backend's proxy.
+func loadMetadataServiceConfig() metadataServiceConfig {
+	cfg := metadataServiceConfig{
+		gatewayURL:   strings.TrimSpace(os.Getenv("IPFS_GATEWAY_URL")),
+		pollInterval: time.Duration(envInt("METADATA_POLL_INTERVAL_MS", 30000)) * time.Millisecond,
+		fetchTimeout: time.Duration(envInt("METADATA_FETCH_TIMEOUT_MS", 8000)) * time.Millisecond,
+		maxBodyBytes: int64(envInt("METADATA_MAX_BODY_BYTES", 1<<20)), // 1 MiB
+		batchSize:    envInt("METADATA_BATCH_SIZE", 25),
+		enabled:      strings.ToLower(os.Getenv("METADATA_FETCHER_ENABLED")) != "false",
+	}
+	// Default to the myqrlwallet backend's IPFS proxy. It already enforces
+	// CID validation + size caps + timeouts; pointing zondscan at it gives
+	// the indexer the same protections without re-implementing them.
+	if cfg.gatewayURL == "" {
+		cfg.gatewayURL = "https://qrlwallet.com/api/ipfs/"
+	}
+	// Normalise: gateway must end in a single trailing slash so
+	// resolveMetadataURI can concatenate `<gateway><cid>/<path>` cleanly.
+	cfg.gatewayURL = strings.TrimRight(cfg.gatewayURL, "/") + "/"
+	return cfg
+}
+
+// NewMetadataService constructs (but does not start) a metadata fetcher.
+func NewMetadataService() *MetadataService {
+	cfg := loadMetadataServiceConfig()
+	if !cfg.enabled {
+		configs.Logger.Warn("Metadata fetcher service disabled by env (METADATA_FETCHER_ENABLED=false)")
+		return nil
+	}
+	return &MetadataService{
+		gatewayURL:   cfg.gatewayURL,
+		httpClient:   &http.Client{Timeout: cfg.fetchTimeout},
+		pollInterval: cfg.pollInterval,
+		batchSize:    cfg.batchSize,
+		maxBodyBytes: cfg.maxBodyBytes,
+		stopCh:       make(chan struct{}),
+	}
+}
+
+// Start launches the polling goroutine. Idempotent in the sense that
+// calling Start twice will spawn two pollers; callers should construct one
+// service per process. The caller-passed context cancels the loop in
+// addition to Stop().
+func (s *MetadataService) Start(ctx context.Context) {
+	if s == nil {
+		return
+	}
+	configs.Logger.Info("Starting metadata fetcher service",
+		zap.String("gateway", s.gatewayURL),
+		zap.Duration("pollInterval", s.pollInterval),
+		zap.Int64("maxBodyBytes", s.maxBodyBytes),
+		zap.Int("batchSize", s.batchSize))
+
+	go func() {
+		// First tick immediately so the first batch lands without waiting
+		// for the full pollInterval after startup.
+		s.tick(ctx)
+		t := time.NewTicker(s.pollInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-s.stopCh:
+				return
+			case <-t.C:
+				s.tick(ctx)
+			}
+		}
+	}()
+}
+
+// Stop signals the polling goroutine to exit. Safe to call multiple times.
+func (s *MetadataService) Stop() {
+	if s == nil {
+		return
+	}
+	select {
+	case <-s.stopCh:
+		// already closed
+	default:
+		close(s.stopCh)
+	}
+}
+
+// tick runs one batch of metadata fetches. Errors per row are logged and
+// recorded on the contractCode document; the tick itself never fails.
+func (s *MetadataService) tick(ctx context.Context) {
+	rows, err := db.GetContractsAwaitingMetadata(s.batchSize)
+	if err != nil {
+		configs.Logger.Warn("metadata fetcher: failed to read work queue", zap.Error(err))
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+	configs.Logger.Info("metadata fetcher: processing batch", zap.Int("rows", len(rows)))
+
+	for _, c := range rows {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.stopCh:
+			return
+		default:
+		}
+		s.fetchOne(ctx, c.Address, c.MetadataURI)
+	}
+}
+
+// fetchOne resolves and parses one contract's metadata URI, persisting the
+// outcome (success or failure) on the contractCode document.
+func (s *MetadataService) fetchOne(ctx context.Context, address, uri string) {
+	resolved, err := resolveMetadataURI(uri, s.gatewayURL)
+	if err != nil {
+		s.recordFailure(address, fmt.Sprintf("resolve: %v", err))
+		return
+	}
+
+	configs.Logger.Debug("metadata fetcher: fetching",
+		zap.String("address", address),
+		zap.String("uri", uri),
+		zap.String("resolved", resolved))
+
+	body, fetchErr := s.fetchBody(ctx, resolved)
+	if fetchErr != nil {
+		s.recordFailure(address, fmt.Sprintf("fetch: %v", fetchErr))
+		return
+	}
+
+	parsed, parseErr := parseMetadataJSON(body)
+	if parseErr != nil {
+		s.recordFailure(address, fmt.Sprintf("parse: %v", parseErr))
+		return
+	}
+
+	// Image URLs are resolved through the same gateway so the persisted
+	// value is directly renderable via next/image. If the image is an
+	// HTTPS URL we keep it as-is; the next/image allow-list takes care of
+	// any extra origins.
+	imageResolved := ""
+	if parsed.Image != "" {
+		if img, err := resolveMetadataURI(parsed.Image, s.gatewayURL); err == nil {
+			imageResolved = img
+		} else {
+			// Image URI couldn't be resolved (unsupported scheme, etc).
+			// We still record the rest of the metadata; the missing image
+			// just shows as a placeholder in the UI.
+			configs.Logger.Debug("metadata fetcher: image URI unresolved",
+				zap.String("address", address),
+				zap.String("image", parsed.Image),
+				zap.Error(err))
+		}
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := db.UpdateContractMetadata(
+		address,
+		parsed.Name,
+		parsed.Description,
+		imageResolved,
+		parsed.ExternalURL,
+		now,
+		"", // clear any prior error on success
+	); err != nil {
+		configs.Logger.Warn("metadata fetcher: persist failed",
+			zap.String("address", address),
+			zap.Error(err))
+		return
+	}
+
+	configs.Logger.Info("metadata fetcher: stored",
+		zap.String("address", address),
+		zap.String("name", parsed.Name),
+		zap.Bool("hasImage", imageResolved != ""))
+}
+
+func (s *MetadataService) recordFailure(address, reason string) {
+	// Pass empty content args so the existing name/image survives a transient
+	// gateway error.
+	if err := db.UpdateContractMetadata(address, "", "", "", "", "", reason); err != nil {
+		configs.Logger.Warn("metadata fetcher: failed to record fetch error",
+			zap.String("address", address),
+			zap.String("reason", reason),
+			zap.Error(err))
+		return
+	}
+	configs.Logger.Warn("metadata fetcher: fetch failed",
+		zap.String("address", address),
+		zap.String("reason", reason))
+}
+
+// fetchBody issues an HTTP GET with the configured timeout and size cap.
+func (s *MetadataService) fetchBody(ctx context.Context, resolvedURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, resolvedURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json,text/plain,*/*")
+	req.Header.Set("User-Agent", "zondscan-metadata-fetcher/3a")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	limited := io.LimitReader(resp.Body, s.maxBodyBytes+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > s.maxBodyBytes {
+		return nil, fmt.Errorf("body exceeds %d bytes", s.maxBodyBytes)
+	}
+	return body, nil
+}
+
+// metadataDocument is the minimal subset of the NFT metadata schema we
+// care about for Phase 3a. Unknown fields are ignored. Each field is
+// optional; the parser coerces wrong-typed fields to the empty string so
+// one bad entry can't fail the whole record.
+type metadataDocument struct {
+	Name        string `json:"-"`
+	Description string `json:"-"`
+	Image       string `json:"-"`
+	ExternalURL string `json:"-"`
+}
+
+// parseMetadataJSON does a defensive JSON parse: unmarshal into a generic
+// map, then pull out the string fields we care about, ignoring any non-
+// string variants. This lets a malformed `description: ["foo", "bar"]`
+// reduce to an empty description rather than failing the entire record.
+func parseMetadataJSON(body []byte) (metadataDocument, error) {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return metadataDocument{}, err
+	}
+	stringField := func(key string) string {
+		v, ok := raw[key]
+		if !ok || v == nil {
+			return ""
+		}
+		s, ok := v.(string)
+		if !ok {
+			return ""
+		}
+		return strings.TrimSpace(s)
+	}
+	doc := metadataDocument{
+		Name:        stringField("name"),
+		Description: stringField("description"),
+		Image:       stringField("image"),
+		ExternalURL: stringField("external_url"),
+	}
+	return doc, nil
+}
+
+// CID validation mirrors the wallet backend's IPFS proxy so callers fail
+// fast on malformed CIDs instead of round-tripping to the gateway.
+var (
+	cidV0Re = regexp.MustCompile(`^Qm[1-9A-HJ-NP-Za-km-z]{44}$`)
+	cidV1Re = regexp.MustCompile(`^b[A-Za-z2-7]{58,}$`)
+)
+
+func looksLikeCID(s string) bool {
+	return cidV0Re.MatchString(s) || cidV1Re.MatchString(s)
+}
+
+// resolveMetadataURI normalises a metadata URI into a fetchable HTTPS URL.
+//
+// Supported schemes:
+//
+//   - https://...           returned as-is.
+//   - http://...            returned as-is (legacy support; the syncer is
+//     server-side so plain HTTP is acceptable).
+//   - ipfs://CID[/path]     -> gatewayURL + CID + "/" + path
+//   - <bare CID>[/path]     -> gatewayURL + CID + "/" + path  (some
+//     contracts emit the bare CID without scheme).
+//
+// Anything else (ar://, ipns://, data:, file:, javascript:) returns an
+// error. The wallet backend's IPFS proxy already validates CID + path
+// shape, so we reuse the same regexes here to fail fast.
+func resolveMetadataURI(uri, gatewayURL string) (string, error) {
+	uri = strings.TrimSpace(uri)
+	if uri == "" {
+		return "", fmt.Errorf("empty URI")
+	}
+
+	// https / http: return as-is. We don't fetch via the IPFS gateway in
+	// this case, that's intentional, the gateway only knows how to
+	// resolve CIDs.
+	if strings.HasPrefix(uri, "https://") || strings.HasPrefix(uri, "http://") {
+		// Validate it's parseable so we don't pass garbage to http.NewRequest.
+		if _, err := url.Parse(uri); err != nil {
+			return "", fmt.Errorf("malformed http(s) URI: %w", err)
+		}
+		return uri, nil
+	}
+
+	// ipfs://CID[/path]
+	if strings.HasPrefix(uri, "ipfs://") {
+		rest := strings.TrimPrefix(uri, "ipfs://")
+		// Some contracts emit `ipfs://ipfs/CID`; collapse it.
+		rest = strings.TrimPrefix(rest, "ipfs/")
+		return joinGateway(gatewayURL, rest)
+	}
+
+	// Bare CID with optional path.
+	first := strings.SplitN(uri, "/", 2)[0]
+	if looksLikeCID(first) {
+		return joinGateway(gatewayURL, uri)
+	}
+
+	return "", fmt.Errorf("unsupported URI scheme: %s", truncate(uri, 80))
+}
+
+// joinGateway pastes the path onto the gateway URL. The gateway is
+// guaranteed (by loadMetadataServiceConfig) to end in "/", so a clean
+// concatenation is correct.
+func joinGateway(gateway, path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("empty CID/path")
+	}
+	// Sanity: the CID portion must validate.
+	first := strings.SplitN(path, "/", 2)[0]
+	if !looksLikeCID(first) {
+		return "", fmt.Errorf("invalid CID: %s", truncate(first, 80))
+	}
+	return gateway + path, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/QRL2MongoDB/synchroniser/metadata_service_test.go
+++ b/QRL2MongoDB/synchroniser/metadata_service_test.go
@@ -1,0 +1,198 @@
+package synchroniser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveMetadataURI(t *testing.T) {
+	gateway := "https://qrlwallet.com/api/ipfs/"
+	cidV0 := "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG"
+	// A valid CIDv1 (base32, sha-256, dag-pb) for /ipfs/bafy....
+	cidV1 := "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"
+
+	tests := []struct {
+		name    string
+		uri     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "https URL returns as-is",
+			uri:  "https://example.com/collection.json",
+			want: "https://example.com/collection.json",
+		},
+		{
+			name: "http URL returns as-is",
+			uri:  "http://nft-host.test/foo.json",
+			want: "http://nft-host.test/foo.json",
+		},
+		{
+			name: "ipfs:// CIDv0 + path resolves through gateway",
+			uri:  "ipfs://" + cidV0 + "/metadata.json",
+			want: gateway + cidV0 + "/metadata.json",
+		},
+		{
+			name: "ipfs:// bare CIDv0 resolves through gateway",
+			uri:  "ipfs://" + cidV0,
+			want: gateway + cidV0,
+		},
+		{
+			name: "ipfs://ipfs/CID legacy form collapses correctly",
+			uri:  "ipfs://ipfs/" + cidV0 + "/img.png",
+			want: gateway + cidV0 + "/img.png",
+		},
+		{
+			name: "ipfs:// CIDv1 resolves through gateway",
+			uri:  "ipfs://" + cidV1 + "/collection.json",
+			want: gateway + cidV1 + "/collection.json",
+		},
+		{
+			name: "bare CIDv0 with path resolves through gateway",
+			uri:  cidV0 + "/contract.json",
+			want: gateway + cidV0 + "/contract.json",
+		},
+		{
+			name: "bare CIDv0 without path resolves through gateway",
+			uri:  cidV0,
+			want: gateway + cidV0,
+		},
+		{
+			name:    "empty URI",
+			uri:     "",
+			wantErr: true,
+		},
+		{
+			name:    "ar:// unsupported scheme",
+			uri:     "ar://AR12345-FOO",
+			wantErr: true,
+		},
+		{
+			name:    "data: rejected",
+			uri:     "data:application/json,{\"name\":\"x\"}",
+			wantErr: true,
+		},
+		{
+			name:    "ipfs:// with invalid CID",
+			uri:     "ipfs://not-a-cid/path",
+			wantErr: true,
+		},
+		{
+			name:    "bare junk",
+			uri:     "definitely-not-a-cid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveMetadataURI(tt.uri, gateway)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseMetadataJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		wantName    string
+		wantDesc    string
+		wantImage   string
+		wantExtURL  string
+		wantErr     bool
+	}{
+		{
+			name:       "OpenSea-style happy path",
+			body:       `{"name":"My NFT","description":"It's nice.","image":"ipfs://QmFoo/img.png","external_url":"https://example.com"}`,
+			wantName:   "My NFT",
+			wantDesc:   "It's nice.",
+			wantImage:  "ipfs://QmFoo/img.png",
+			wantExtURL: "https://example.com",
+		},
+		{
+			name:     "extra fields ignored",
+			body:     `{"name":"Foo","attributes":[{"trait_type":"x","value":"y"}],"image":"ipfs://Q"}`,
+			wantName: "Foo",
+			wantImage: "ipfs://Q",
+		},
+		{
+			name: "missing fields produce empty strings, not error",
+			body: `{}`,
+		},
+		{
+			name:     "wrong-typed description coerces to empty",
+			body:     `{"name":"Foo","description":["array","not","string"]}`,
+			wantName: "Foo",
+		},
+		{
+			name:     "whitespace trimmed",
+			body:     `{"name":"  Trim me  ","description":"\nhi\n"}`,
+			wantName: "Trim me",
+			wantDesc: "hi",
+		},
+		{
+			name:    "malformed JSON returns error",
+			body:    `{"name":"unterminated`,
+			wantErr: true,
+		},
+		{
+			name:    "non-object JSON returns error",
+			body:    `["just","an","array"]`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseMetadataJSON([]byte(tt.body))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", got.Name, tt.wantName)
+			}
+			if got.Description != tt.wantDesc {
+				t.Errorf("Description = %q, want %q", got.Description, tt.wantDesc)
+			}
+			if got.Image != tt.wantImage {
+				t.Errorf("Image = %q, want %q", got.Image, tt.wantImage)
+			}
+			if got.ExternalURL != tt.wantExtURL {
+				t.Errorf("ExternalURL = %q, want %q", got.ExternalURL, tt.wantExtURL)
+			}
+		})
+	}
+}
+
+func TestLooksLikeCID(t *testing.T) {
+	cases := map[string]bool{
+		"QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG":             true,
+		"bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi": true,
+		"definitely-not-a-cid":                                       false,
+		"Qm-too-short":                                               false,
+		"":                                                           false,
+		strings.Repeat("X", 60):                                       false,
+	}
+	for in, want := range cases {
+		if got := looksLikeCID(in); got != want {
+			t.Errorf("looksLikeCID(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/QRL2MongoDB/synchroniser/metadata_service_test.go
+++ b/QRL2MongoDB/synchroniser/metadata_service_test.go
@@ -1,6 +1,7 @@
 package synchroniser
 
 import (
+	"net"
 	"strings"
 	"testing"
 )
@@ -178,6 +179,86 @@ func TestParseMetadataJSON(t *testing.T) {
 				t.Errorf("ExternalURL = %q, want %q", got.ExternalURL, tt.wantExtURL)
 			}
 		})
+	}
+}
+
+func TestParseMetadataJSONNullLiteral(t *testing.T) {
+	// JSON literal `null` unmarshals into a nil map. The defensive nil
+	// check in stringField keeps the parser from panicking; we just
+	// return an empty doc + nil error.
+	doc, err := parseMetadataJSON([]byte("null"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Name != "" || doc.Description != "" || doc.Image != "" || doc.ExternalURL != "" {
+		t.Errorf("expected empty doc, got %+v", doc)
+	}
+}
+
+func TestIsForbiddenIP(t *testing.T) {
+	tests := []struct {
+		ip   string
+		want bool
+	}{
+		// Public, allowed
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+		{"209.250.255.226", false}, // QRL Foundation public RPC
+		{"46.62.169.114", false},   // Our testnet node
+		{"2606:4700:4700::1111", false}, // Cloudflare DNS over IPv6
+
+		// Loopback
+		{"127.0.0.1", true},
+		{"127.0.0.53", true},
+		{"::1", true},
+
+		// RFC1918 private
+		{"10.0.0.1", true},
+		{"172.16.0.1", true},
+		{"172.31.255.255", true},
+		{"192.168.1.1", true},
+
+		// Link-local
+		{"169.254.169.254", true}, // AWS/GCP metadata!
+		{"fe80::1", true},
+
+		// CGNAT
+		{"100.64.0.1", true},
+		{"100.127.255.254", true},
+
+		// Multicast / unspecified
+		{"224.0.0.1", true},
+		{"0.0.0.0", true},
+		{"::", true},
+
+		// IPv6 ULA
+		{"fc00::1", true},
+		{"fd12:3456::1", true},
+
+		// IETF reserved / docs
+		{"192.0.2.1", true},
+		{"198.51.100.1", true},
+		{"203.0.113.5", true},
+		{"240.0.0.1", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ip, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			if ip == nil {
+				t.Fatalf("bad test fixture: cannot parse %q", tt.ip)
+			}
+			if got := isForbiddenIP(ip); got != tt.want {
+				t.Errorf("isForbiddenIP(%s) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestForbiddenIPRejectsNil documents the nil-input behaviour: refuse,
+// don't crash, callers that fail to resolve a hostname must not dial.
+func TestForbiddenIPRejectsNil(t *testing.T) {
+	if !isForbiddenIP(nil) {
+		t.Error("isForbiddenIP(nil) = false, want true (refuse-by-default)")
 	}
 }
 

--- a/backendAPI/db/contract.go
+++ b/backendAPI/db/contract.go
@@ -53,16 +53,18 @@ func ReturnContracts(page int64, limit int64, search string, isTokenFilter *bool
 		nameRegex := bson.D{{Key: "$regex", Value: escaped}, {Key: "$options", Value: "i"}}
 
 		// Search by exact address, exact creator address, OR partial
-		// case-insensitive match against name + symbol. Symbol was
-		// previously absent, searching "MQW" missed tokens whose `name`
-		// field held the full project label instead of the ticker (and
-		// vice versa).
+		// case-insensitive match against name + symbol + metadataName.
+		// Symbol was previously absent, searching "MQW" missed tokens whose
+		// `name` field held the full project label instead of the ticker.
+		// Phase 3a adds metadataName so a user searching by the off-chain
+		// display title hits the row even when on-chain name() is empty.
 		searchFilter := bson.D{
 			{Key: "$or", Value: bson.A{
 				bson.D{{Key: "address", Value: normalizedSearch}},
 				bson.D{{Key: "creatorAddress", Value: normalizedSearch}},
 				bson.D{{Key: "name", Value: nameRegex}},
 				bson.D{{Key: "symbol", Value: nameRegex}},
+				bson.D{{Key: "metadataName", Value: nameRegex}},
 			}},
 		}
 		// Combine with existing filter

--- a/backendAPI/models/contract.go
+++ b/backendAPI/models/contract.go
@@ -34,6 +34,17 @@ type ContractInfo struct {
 	HasERC165     bool   `json:"hasERC165,omitempty" bson:"hasERC165,omitempty"`
 	BaseURI       string `json:"baseURI,omitempty" bson:"baseURI,omitempty"`
 
+	// Collection-level off-chain metadata (Phase 3a). Mirrors
+	// QRL2MongoDB/models/contract.go. Written by the syncer's metadata
+	// fetcher service; the backend holds them for read-through to clients.
+	MetadataURI         string `json:"metadataURI,omitempty" bson:"metadataURI,omitempty"`
+	MetadataName        string `json:"metadataName,omitempty" bson:"metadataName,omitempty"`
+	MetadataDescription string `json:"metadataDescription,omitempty" bson:"metadataDescription,omitempty"`
+	MetadataImage       string `json:"metadataImage,omitempty" bson:"metadataImage,omitempty"`
+	MetadataExternalURL string `json:"metadataExternalURL,omitempty" bson:"metadataExternalURL,omitempty"`
+	MetadataFetchedAt   string `json:"metadataFetchedAt,omitempty" bson:"metadataFetchedAt,omitempty"`
+	MetadataFetchError  string `json:"metadataFetchError,omitempty" bson:"metadataFetchError,omitempty"`
+
 	// Source-verification fields. `verified` defaults to false (omitted from
 	// omitempty so it is always present in the JSON shape clients consume).
 	// Everything else uses omitempty so unverified contracts stay clean.


### PR DESCRIPTION
## Summary

Phase 3a of zondscan NFT support: fetch + render off-chain collection metadata from `contractURI()`. NFT collections with empty on-chain `name()` (most ERC-1155s) now show their proper title, description, and image throughout the explorer.

Three logical commits:

1. **`feat(rpc): GetContractURI helper`** (356a0e9 → 56541f9 chain): adds `SIG_CONTRACT_URI = 0xe8a3d485`, extracts a shared `parseDynamicString` ABI decoder, and wraps the call with the same 3-way error contract as the rest of the tokens helpers (revert / transport / malformed). 8 table-driven test cases.

2. **`feat(syncer): collection metadata fetcher service`**: extends `ContractInfo` with `MetadataURI` + 6 resolved fields; hooks `DetectContractType` to probe `contractURI()` on NFT classification; new `synchroniser.MetadataService` goroutine polls a work queue every 30s, resolves URIs through a configurable IPFS gateway, fetches JSON with a 1 MiB cap + 8s timeout, parses defensively, and persists the result via `db.UpdateContractMetadata`. Two separate write paths (classifier writes URI, fetcher writes resolved fields) keep transient failures from clobbering yesterday's good data. 21 test cases on resolver + 7 on JSON parser.

3. **`feat(zondscan): render off-chain collection metadata`**: contracts list + token-contract page prefer `metadataName` over on-chain `name()`, render the metadata image via `next/image` with the gateway origin allow-listed, surface the description + external URL on the header card. Backend `/contracts` search now matches against `metadataName`.

## IPFS gateway reuse

Default `IPFS_GATEWAY_URL=https://qrlwallet.com/api/ipfs/` - the myqrlwallet backend's existing IPFS proxy. It already enforces CID validation, 10 MiB cap, 8 s timeout, rate limiting, and a hardened CSP. Reusing it gives the indexer those protections for free and lets `next/image`'s allow-list trust a single origin we control. Public gateways (`ipfs.io`, `cloudflare-ipfs.com`, `nftstorage.link`) are still in the allow-list for the rare contract whose metadata `image` points outside the proxy.

## Env

| Var | Default | Purpose |
|---|---|---|
| `IPFS_GATEWAY_URL` | `https://qrlwallet.com/api/ipfs/` | Upstream gateway |
| `METADATA_POLL_INTERVAL_MS` | `30000` | Fetcher tick |
| `METADATA_FETCH_TIMEOUT_MS` | `8000` | Per-request timeout |
| `METADATA_MAX_BODY_BYTES` | `1048576` (1 MiB) | Response cap |
| `METADATA_BATCH_SIZE` | `25` | Rows per tick |
| `METADATA_FETCHER_ENABLED` | `true` | Kill switch |

## Out of scope (Phase 3b / 3c)

- Per-token metadata (`tokenURI` / `uri(id)`) - separate PR
- Per-token detail page `/token/[addr]/[id]` - separate PR
- Mutable-metadata refresh / admin endpoint - Phase 4
- `Approval` / `ApprovalForAll` tracking - separate PR

## Test plan

- [x] `cd QRL2MongoDB && go build .` green
- [x] `cd backendAPI && go build .` green
- [x] `MONGOURI=mongodb://localhost:27017 go test ./QRL2MongoDB/rpc ./QRL2MongoDB/synchroniser` green
- [x] `cd ExplorerFrontend && npx tsc --noEmit && npm run build` green
- [ ] Post-merge: set `IPFS_GATEWAY_URL` on prod, redeploy, watch IpfsERC721 fixture `Qa17b2cdf3c...4732` populate `metadataName` within ~60 s
- [ ] Smoke-test https://zondscan.com/address/Qa17b2cdf3ce84887216dcde5d81fa9b02e654732 - header should show off-chain title + image; description and external URL should render