### PR TITLE
fix(syncer): backfill metadataURI on reprocess for legacy NFT rows

### DIFF
--- a/QRL2MongoDB/db/contracts.go
+++ b/QRL2MongoDB/db/contracts.go
@@ -646,6 +646,22 @@ func ReprocessIncompleteContracts() error {
 			}
 		}
 
+		// Phase 3a backfill: NFT contracts that were classified before the
+		// metadataURI probe shipped have an empty MetadataURI. The fetcher
+		// service needs a populated URI to enqueue work, so the hourly
+		// reprocess pass also re-probes contractURI() for any NFT row
+		// missing it. Best-effort: a contract-revert (most collections
+		// don't implement contractURI) returns ("", nil) and we leave the
+		// field empty; transient failures don't demote existing state.
+		if (contract.TokenStandard == rpc.StandardERC721 || contract.TokenStandard == rpc.StandardERC1155) && contract.MetadataURI == "" {
+			if uri, err := rpc.GetContractURI(contract.Address); err == nil && uri != "" {
+				contract.MetadataURI = uri
+				configs.Logger.Info("Backfilled contractURI for NFT collection",
+					zap.String("address", contract.Address),
+					zap.String("metadataURI", uri))
+			}
+		}
+
 		// Restore original creation information to ensure it's not lost
 		// Only restore if the original had values and current values are empty
 		if creatorAddress != "" && creatorAddress != "Q" && contract.CreatorAddress == "" {


### PR DESCRIPTION
## Summary

Hotfix surfaced during Phase 3a prod deploy: NFT contracts classified before Phase 3a shipped have empty \`metadataURI\` on \`contractCode\`. The fetcher service's work-queue filter excludes them, so they never get collection metadata.

Extend the hourly reprocess job to re-probe \`contractURI()\` for any ERC-721 / ERC-1155 row missing \`metadataURI\`. Reuses the existing 3-way error contract; contracts that don't implement \`contractURI\` (most collections) leave the field empty (best-effort), transient transport errors don't demote existing state.

## Test plan
- [x] \`cd QRL2MongoDB && go build .\` green
- [ ] Post-merge: restart syncer on prod, watch \`metadataURI\` get populated for existing NFT collections within one reprocess cycle (or immediately on startup)