### PR TITLE
feat(syncer): per-tokenID NFT metadata (Phase 3b)

### DIFF
--- a/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
@@ -41,6 +41,12 @@ interface TokenIDSummary {
     tokenStandard?: string;
     blockNumber?: string;
     updatedAt?: string;
+    // Phase 3b: off-chain per-token metadata pulled from contractURI /
+    // tokenURI / uri(id). Absent on tokens whose metadata fetcher pass
+    // hasn't completed or whose contract doesn't implement the getter.
+    name?: string;
+    description?: string;
+    image?: string;
 }
 
 interface TokenTransfer {
@@ -792,30 +798,53 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                     <table aria-label="Token IDs" className="w-full">
                                         <thead className="bg-black/30">
                                             <tr>
-                                                <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">Token ID</th>
+                                                <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase w-16"></th>
+                                                <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">Token</th>
                                                 <th scope="col" className="px-4 py-3 text-right text-xs font-medium text-gray-400 uppercase">Holders</th>
                                                 <th scope="col" className="px-4 py-3 text-right text-xs font-medium text-gray-400 uppercase hidden md:table-cell">Standard</th>
                                             </tr>
                                         </thead>
                                         <tbody className="divide-y divide-gray-700/50">
-                                            {tokensList.map((t) => (
-                                                <tr
-                                                    key={t.tokenID}
-                                                    className="hover:bg-white/5 cursor-pointer"
-                                                    onClick={() => {
-                                                        setHolderTokenIDInput(t.tokenID);
-                                                        setHolderTokenIDFilter(t.tokenID);
-                                                        setHoldersPage(0);
-                                                        setActiveTab('holders');
-                                                    }}
-                                                >
-                                                    <td className="px-4 py-3 text-sm font-mono text-accent">#{t.tokenID}</td>
-                                                    <td className="px-4 py-3 text-right text-sm text-white">{t.holderCount}</td>
-                                                    <td className="px-4 py-3 text-right text-xs text-gray-400 hidden md:table-cell">
-                                                        {t.tokenStandard ? t.tokenStandard.replace(/^ERC-/, 'QRC-') : '-'}
-                                                    </td>
-                                                </tr>
-                                            ))}
+                                            {tokensList.map((t) => {
+                                                // Phase 3b: render the off-chain image if the fetcher has
+                                                // populated it; fall back to a #N monogram tile. The "Token"
+                                                // column shows the metadata name when present, otherwise
+                                                // just "#<id>" — keeps unfetched / no-metadata cases clean.
+                                                const tokenLabel = t.name?.trim() || `#${t.tokenID}`;
+                                                const subLabel = t.name?.trim() ? `#${t.tokenID}` : null;
+                                                return (
+                                                    <tr
+                                                        key={t.tokenID}
+                                                        className="hover:bg-white/5 cursor-pointer"
+                                                        onClick={() => {
+                                                            setHolderTokenIDInput(t.tokenID);
+                                                            setHolderTokenIDFilter(t.tokenID);
+                                                            setHoldersPage(0);
+                                                            setActiveTab('holders');
+                                                        }}
+                                                    >
+                                                        <td className="px-4 py-3">
+                                                            {t.image ? (
+                                                                <div className="relative w-10 h-10 rounded-md overflow-hidden border border-gray-700/60 bg-black/30">
+                                                                    <Image src={t.image} alt={tokenLabel} fill sizes="40px" className="object-cover" unoptimized />
+                                                                </div>
+                                                            ) : (
+                                                                <div className="w-10 h-10 rounded-md bg-gradient-to-br from-[#3a3a3a] to-[#1f1f1f] flex items-center justify-center text-xs font-mono text-gray-300">
+                                                                    #{(t.tokenID.length > 4 ? t.tokenID.slice(-3) : t.tokenID)}
+                                                                </div>
+                                                            )}
+                                                        </td>
+                                                        <td className="px-4 py-3 text-sm">
+                                                            <div className="text-white">{tokenLabel}</div>
+                                                            {subLabel && <div className="text-xs text-gray-500 font-mono">{subLabel}</div>}
+                                                        </td>
+                                                        <td className="px-4 py-3 text-right text-sm text-white">{t.holderCount}</td>
+                                                        <td className="px-4 py-3 text-right text-xs text-gray-400 hidden md:table-cell">
+                                                            {t.tokenStandard ? t.tokenStandard.replace(/^ERC-/, 'QRC-') : '-'}
+                                                        </td>
+                                                    </tr>
+                                                );
+                                            })}
                                         </tbody>
                                     </table>
                                 </div>

--- a/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
@@ -8,7 +8,7 @@ import QRCodeButton from "../../components/QRCodeButton";
 import ContractTabs from "../../components/ContractTabs";
 import VerifiedBadge from "../../components/VerifiedBadge";
 import type { ContractData } from "../../types/address";
-import { formatAmount } from "../../lib/helpers";
+import { compactTokenIDLabel, formatAmount } from "../../lib/helpers";
 import Breadcrumbs from "../../components/Breadcrumbs";
 
 interface TokenInfo {
@@ -829,8 +829,11 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                                                     <Image src={t.image} alt={tokenLabel} fill sizes="40px" className="object-cover" unoptimized />
                                                                 </div>
                                                             ) : (
-                                                                <div className="w-10 h-10 rounded-md bg-gradient-to-br from-[#3a3a3a] to-[#1f1f1f] flex items-center justify-center text-xs font-mono text-gray-300">
-                                                                    #{(t.tokenID.length > 4 ? t.tokenID.slice(-3) : t.tokenID)}
+                                                                <div
+                                                                    className="w-10 h-10 rounded-md bg-gradient-to-br from-[#3a3a3a] to-[#1f1f1f] flex items-center justify-center text-xs font-mono text-gray-300"
+                                                                    title={`#${t.tokenID}`}
+                                                                >
+                                                                    #{compactTokenIDLabel(t.tokenID)}
                                                                 </div>
                                                             )}
                                                         </td>

--- a/ExplorerFrontend/app/api-explorer/api-explorer-client.tsx
+++ b/ExplorerFrontend/app/api-explorer/api-explorer-client.tsx
@@ -221,9 +221,15 @@ const endpointGroups: EndpointGroup[] = [
       {
         method: 'GET',
         path: '/token/:address/tokens',
-        description: 'Phase 2: returns the distinct tokenID list minted on an NFT contract with holder count per id. Empty list for ERC-20 contracts. Useful for browsing the catalog of an ERC-721/1155 collection or for downstream Phase 3 metadata lookups.',
+        description: 'Phase 2 + 3b: returns the distinct tokenID list minted on an NFT contract with holder count per id. Each row also carries `name` + `image` + `description` from the per-token off-chain metadata when the metadata fetcher has resolved it (otherwise those fields are absent and the UI falls back to a "#<id>" label). Empty list for ERC-20 contracts.',
         params: 'page (query, default: 0), limit (query, default: 25, max: 100)',
         example: '/token/Q539f73306bdd4288f93a5e50b4d5bf1a9b07f147/tokens?page=0&limit=25',
+      },
+      {
+        method: 'GET',
+        path: '/token/:address/:id',
+        description: 'Phase 3b: per-token metadata document for one (contract, tokenID) tuple. Returns the resolved name / description / image / external_url plus the OpenSea-style attribute list. 400 if id is not a decimal integer, 404 if the token has no stub yet (contract isn\'t an NFT, or that id has never been transferred).',
+        example: '/token/Q539f73306bdd4288f93a5e50b4d5bf1a9b07f147/1',
       },
       {
         method: 'GET',

--- a/ExplorerFrontend/app/lib/helpers.ts
+++ b/ExplorerFrontend/app/lib/helpers.ts
@@ -469,6 +469,26 @@ export function formatTokenAmount(amount: string | undefined | null, decimals: n
 }
 
 /**
+ * Compact representation of a long decimal tokenID for a small fixed-size
+ * tile (e.g. a 40px monogram). Returns the id unchanged when it already
+ * fits, otherwise an ellipsis-suffix form like "1234…78" that preserves
+ * the most significant + least significant digits and signals truncation
+ * explicitly. Empty input becomes "?".
+ *
+ * Used by the Tokens tab when a token's off-chain metadata image hasn't
+ * been fetched yet and we render an id-based placeholder.
+ */
+export function compactTokenIDLabel(tokenID: string, maxLen = 5): string {
+  const s = (tokenID ?? '').trim();
+  if (!s) return '?';
+  if (s.length <= maxLen) return s;
+  // Show the first chunk + the last 2 chars + an ellipsis between them.
+  const tail = 2;
+  const head = Math.max(1, maxLen - tail - 1); // -1 for the ellipsis char
+  return s.slice(0, head) + '…' + s.slice(-tail);
+}
+
+/**
  * Normalise an ABI-decoded value tree to use the canonical Q-prefix for
  * QRL v2 addresses. The 0.3.x @theqrl/web3-zond-abi decoder still emits
  * the legacy Z prefix for `address` outputs; every other surface in

--- a/QRL2MongoDB/db/token_metadata.go
+++ b/QRL2MongoDB/db/token_metadata.go
@@ -190,10 +190,14 @@ func UpdateTokenMetadata(
 }
 
 // GetTokensAwaitingMetadata returns up to `limit` token stubs that need a
-// metadata fetch (no FetchedAt and no FetchError). Same "don't auto-retry
-// errors" stance as the contract path: an operator triggers re-fetch in
-// Phase 4; for now an errored row stays put until the next stub-upsert
-// pass overwrites the fetchError on a future transfer.
+// metadata fetch (no FetchedAt and no FetchError).
+//
+// Same "don't auto-retry errors" stance as the contract path: an operator
+// triggers re-fetch in Phase 4. An errored row stays put indefinitely
+// because StubTokenMetadata uses $setOnInsert and is therefore a no-op
+// on every transfer after the first, the upsert never clears the error.
+// Auto-retrying every poll cycle would just clog the queue with the same
+// failure since the underlying URL doesn't change.
 func GetTokensAwaitingMetadata(ctx context.Context, limit int) ([]models.TokenMetadata, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()

--- a/QRL2MongoDB/db/token_metadata.go
+++ b/QRL2MongoDB/db/token_metadata.go
@@ -1,0 +1,273 @@
+// Package db / token_metadata.go
+//
+// Per-tokenID NFT metadata storage. Phase 3b sits on top of Phase 3a:
+//
+//   - The transfer dispatch loop (db/tokentransfers.go) calls StubTokenMetadata
+//     on every NFT transfer with `$setOnInsert` so a row exists as soon as the
+//     token is seen on chain.
+//   - The metadata fetcher service polls GetTokensAwaitingMetadata for stubs
+//     whose URI hasn't been resolved (no FetchedAt and no FetchError), calls
+//     tokenURI(id) or uri(id), resolves through the IPFS gateway, parses the
+//     JSON, and writes the result via UpdateTokenMetadata.
+//
+// Same single-writer-per-concern boundary as the contract-metadata path:
+// the stub writer owns URI + initial classification fields, the fetcher
+// owns the resolved content fields. A transient fetch failure preserves
+// last-good content (UpdateTokenMetadata only writes a content field
+// when its argument is non-empty).
+package db
+
+import (
+	"QRL2MongoDB/configs"
+	"QRL2MongoDB/models"
+	"QRL2MongoDB/validation"
+	"context"
+	"strings"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.uber.org/zap"
+)
+
+const tokenMetadataCollection = "tokenMetadata"
+
+// InitializeTokenMetadataCollection sets up the tokenMetadata indexes.
+// Idempotent; safe to call on every startup. Mirrors the pattern used by
+// InitializeTokenBalancesCollection (Phase 2).
+func InitializeTokenMetadataCollection() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	collection := configs.GetCollection(configs.DB, tokenMetadataCollection)
+
+	configs.Logger.Info("Initializing tokenMetadata collection and indexes")
+
+	indexes := []mongo.IndexModel{
+		{
+			// Phase 3b primary key. Unique because each (contract, tokenID)
+			// has one off-chain metadata document.
+			Keys: bson.D{
+				{Key: "contractAddress", Value: 1},
+				{Key: "tokenID", Value: 1},
+			},
+			Options: options.Index().
+				SetName("contract_tokenID_idx").
+				SetUnique(true).
+				SetBackground(true),
+		},
+		{
+			// Drives the fetcher's work-queue scan (rows missing FetchedAt
+			// and FetchError). Partial-index hint isn't needed at the
+			// volume we're dealing with; the scan is bounded by batchSize.
+			Keys: bson.D{
+				{Key: "fetchedAt", Value: 1},
+			},
+			Options: options.Index().SetName("fetchedAt_idx").SetBackground(true),
+		},
+		{
+			// Per-collection enumeration for /token/:addr/tokens enrichment.
+			Keys: bson.D{
+				{Key: "contractAddress", Value: 1},
+			},
+			Options: options.Index().SetName("contract_idx").SetBackground(true),
+		},
+	}
+
+	if _, err := collection.Indexes().CreateMany(ctx, indexes); err != nil {
+		configs.Logger.Error("Failed to create indexes for tokenMetadata", zap.Error(err))
+		return err
+	}
+	configs.Logger.Info("Successfully initialized tokenMetadata collection and indexes")
+	return nil
+}
+
+// StubTokenMetadata upserts a stub row for one (contract, tokenID) using
+// $setOnInsert so repeated calls from the transfer dispatch loop are
+// cheap no-ops. The fetcher service later fills in the resolved fields.
+//
+// tokenStandard is recorded in the stub so the fetcher can pick the right
+// URI getter (tokenURI vs uri) without re-reading contractCode.
+//
+// Called from db/tokentransfers.go on every NFT transfer; must be cheap.
+func StubTokenMetadata(ctx context.Context, contractAddress, tokenID, tokenStandard string) error {
+	contractAddress = validation.ConvertToQAddress(contractAddress)
+	if tokenID == "" {
+		return nil // nothing to key off
+	}
+
+	collection := configs.GetCollection(configs.DB, tokenMetadataCollection)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	filter := bson.M{"contractAddress": contractAddress, "tokenID": tokenID}
+	update := bson.M{
+		"$setOnInsert": bson.M{
+			"contractAddress": contractAddress,
+			"tokenID":         tokenID,
+			"tokenStandard":   tokenStandard,
+			"updatedAt":       now,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_, err := collection.UpdateOne(ctx, filter, update, options.Update().SetUpsert(true))
+	if err != nil && !mongo.IsDuplicateKeyError(err) {
+		// Duplicate key on the (contract, tokenID) unique is expected on
+		// repeated transfers of the same id; not an error worth logging.
+		configs.Logger.Debug("Failed to upsert tokenMetadata stub",
+			zap.String("contract", contractAddress),
+			zap.String("tokenID", tokenID),
+			zap.Error(err))
+		return err
+	}
+	return nil
+}
+
+// UpdateTokenMetadata writes the resolved per-token metadata. Same
+// "preserve last-good" semantics as UpdateContractMetadata: empty content
+// args do NOT clear existing values; only FetchedAt and FetchError are
+// always written.
+func UpdateTokenMetadata(
+	ctx context.Context,
+	contractAddress, tokenID string,
+	uri, name, description, image, externalURL string,
+	attributes []models.TokenAttribute,
+	fetchedAt, fetchError string,
+) error {
+	contractAddress = validation.ConvertToQAddress(contractAddress)
+	if tokenID == "" {
+		return nil
+	}
+
+	collection := configs.GetCollection(configs.DB, tokenMetadataCollection)
+
+	set := bson.M{
+		"fetchedAt":  fetchedAt,
+		"fetchError": fetchError,
+		"updatedAt":  time.Now().UTC().Format(time.RFC3339),
+	}
+	// URI is gap-fill: the stub writer doesn't know it, the fetcher
+	// populates it the first time it's resolved. Re-resolution overwrites
+	// because contracts can legitimately update their metadata URI scheme.
+	if uri != "" {
+		set["uri"] = uri
+	}
+	if name != "" {
+		set["name"] = name
+	}
+	if description != "" {
+		set["description"] = description
+	}
+	if image != "" {
+		set["image"] = image
+	}
+	if externalURL != "" {
+		set["externalURL"] = externalURL
+	}
+	// Attributes is treated as "all or nothing", an empty slice means
+	// "preserve previous". An explicit empty list from a successful fetch
+	// is uncommon enough not to optimise for.
+	if len(attributes) > 0 {
+		set["attributes"] = attributes
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	filter := bson.M{"contractAddress": contractAddress, "tokenID": tokenID}
+	_, err := collection.UpdateOne(ctx, filter, bson.M{"$set": set})
+	if err != nil {
+		configs.Logger.Warn("Failed to update token metadata",
+			zap.String("contract", contractAddress),
+			zap.String("tokenID", tokenID),
+			zap.Error(err))
+		return err
+	}
+	return nil
+}
+
+// GetTokensAwaitingMetadata returns up to `limit` token stubs that need a
+// metadata fetch (no FetchedAt and no FetchError). Same "don't auto-retry
+// errors" stance as the contract path: an operator triggers re-fetch in
+// Phase 4; for now an errored row stays put until the next stub-upsert
+// pass overwrites the fetchError on a future transfer.
+func GetTokensAwaitingMetadata(ctx context.Context, limit int) ([]models.TokenMetadata, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	filter := bson.M{
+		"tokenStandard": bson.M{"$in": []string{"ERC-721", "ERC-1155"}},
+		"$and": []bson.M{
+			{"$or": []bson.M{
+				{"fetchedAt": bson.M{"$exists": false}},
+				{"fetchedAt": ""},
+			}},
+			{"$or": []bson.M{
+				{"fetchError": bson.M{"$exists": false}},
+				{"fetchError": ""},
+			}},
+		},
+	}
+	opts := options.Find().SetLimit(int64(limit))
+
+	collection := configs.GetCollection(configs.DB, tokenMetadataCollection)
+	cur, err := collection.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer cur.Close(ctx)
+
+	var out []models.TokenMetadata
+	if err := cur.All(ctx, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetTokenMetadataByContract returns all per-token metadata rows for one
+// collection. Used by /token/:addr/tokens enrichment.
+func GetTokenMetadataByContract(ctx context.Context, contractAddress string) ([]models.TokenMetadata, error) {
+	contractAddress = validation.ConvertToQAddress(contractAddress)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	collection := configs.GetCollection(configs.DB, tokenMetadataCollection)
+	cur, err := collection.Find(ctx, bson.M{"contractAddress": contractAddress})
+	if err != nil {
+		return nil, err
+	}
+	defer cur.Close(ctx)
+
+	var out []models.TokenMetadata
+	if err := cur.All(ctx, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetTokenMetadata returns the metadata document for one specific
+// (contract, tokenID) pair, or nil if no stub exists.
+func GetTokenMetadata(ctx context.Context, contractAddress, tokenID string) (*models.TokenMetadata, error) {
+	contractAddress = validation.ConvertToQAddress(contractAddress)
+	tokenID = strings.TrimSpace(tokenID)
+	if tokenID == "" {
+		return nil, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	collection := configs.GetCollection(configs.DB, tokenMetadataCollection)
+	var out models.TokenMetadata
+	err := collection.FindOne(ctx, bson.M{"contractAddress": contractAddress, "tokenID": tokenID}).Decode(&out)
+	if err == mongo.ErrNoDocuments {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/QRL2MongoDB/db/tokentransfers.go
+++ b/QRL2MongoDB/db/tokentransfers.go
@@ -313,6 +313,15 @@ func ProcessBlockTokenTransfers(blockNumber string, blockTimestamp string) error
 							zap.String("tokenID", row.TokenID),
 							zap.Error(err))
 					}
+					// Phase 3b: $setOnInsert a stub so the metadata fetcher
+					// finds this token on its next poll. Hot path; failure
+					// is non-fatal, the row already lives in tokenTransfers.
+					if err := StubTokenMetadata(context.Background(), contractAddress, row.TokenID, rpc.StandardERC721); err != nil {
+						configs.Logger.Debug("ERC-721 metadata stub upsert failed",
+							zap.String("contractAddress", contractAddress),
+							zap.String("tokenID", row.TokenID),
+							zap.Error(err))
+					}
 				} else {
 					configs.Logger.Warn("ERC-721 transfer row has unparseable tokenID; skipping ownership refresh",
 						zap.String("contractAddress", contractAddress),
@@ -331,6 +340,12 @@ func ProcessBlockTokenTransfers(blockNumber string, blockTimestamp string) error
 						configs.Logger.Warn("ERC-1155 recipient balance refresh failed",
 							zap.String("contractAddress", contractAddress),
 							zap.String("holder", row.To),
+							zap.String("tokenID", row.TokenID),
+							zap.Error(err))
+					}
+					if err := StubTokenMetadata(context.Background(), contractAddress, row.TokenID, rpc.StandardERC1155); err != nil {
+						configs.Logger.Debug("ERC-1155 metadata stub upsert failed",
+							zap.String("contractAddress", contractAddress),
 							zap.String("tokenID", row.TokenID),
 							zap.Error(err))
 					}

--- a/QRL2MongoDB/models/token_metadata.go
+++ b/QRL2MongoDB/models/token_metadata.go
@@ -1,0 +1,43 @@
+package models
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+// TokenMetadata stores off-chain per-tokenID NFT metadata for an
+// (ERC-721 / ERC-1155) collection. One row per (contractAddress, tokenID).
+//
+// Phase 3b writes one stub row on every NFT transfer via $setOnInsert so
+// the metadata fetcher service has a work queue to chew through; the
+// fetcher then resolves the per-token URI (tokenURI(id) / uri(id)) via
+// the configured IPFS gateway, parses the JSON, and writes back into
+// the same row.
+//
+// All resolved fields use omitempty so stubs stay clean until populated
+// and the fetcher's "preserve last-good" semantics work cleanly when a
+// later refresh fails.
+type TokenMetadata struct {
+	ID              primitive.ObjectID `bson:"_id"`
+	ContractAddress string             `bson:"contractAddress" json:"contractAddress"`
+	TokenID         string             `bson:"tokenID" json:"tokenID"`
+	TokenStandard   string             `bson:"tokenStandard,omitempty" json:"tokenStandard,omitempty"`
+	URI             string             `bson:"uri,omitempty" json:"uri,omitempty"`
+
+	Name        string           `bson:"name,omitempty" json:"name,omitempty"`
+	Description string           `bson:"description,omitempty" json:"description,omitempty"`
+	Image       string           `bson:"image,omitempty" json:"image,omitempty"`
+	ExternalURL string           `bson:"externalURL,omitempty" json:"externalURL,omitempty"`
+	Attributes  []TokenAttribute `bson:"attributes,omitempty" json:"attributes,omitempty"`
+
+	FetchedAt  string `bson:"fetchedAt,omitempty" json:"fetchedAt,omitempty"`
+	FetchError string `bson:"fetchError,omitempty" json:"fetchError,omitempty"`
+	UpdatedAt  string `bson:"updatedAt" json:"updatedAt"`
+}
+
+// TokenAttribute is one OpenSea-style trait. The spec is loose about the
+// value's type (often string, sometimes number, sometimes object), so the
+// parser stringifies any non-object value at fetch time for storage
+// uniformity; consumers can re-parse as needed.
+type TokenAttribute struct {
+	TraitType   string `bson:"trait_type" json:"trait_type"`
+	Value       string `bson:"value" json:"value"`
+	DisplayType string `bson:"display_type,omitempty" json:"display_type,omitempty"`
+}

--- a/QRL2MongoDB/rpc/tokenscalls.go
+++ b/QRL2MongoDB/rpc/tokenscalls.go
@@ -1084,6 +1084,90 @@ func GetContractURI(contractAddress string) (string, error) {
 	return uri, nil
 }
 
+// GetTokenURI queries `tokenURI(uint256)` on an ERC-721 contract and returns
+// the raw URI string. Same three-way error contract as the rest of the
+// tokens helpers:
+//   - Contract revert (id never minted, or contract doesn't implement
+//     ERC-721 Metadata): returns ("", nil) so the caller records "no URI"
+//     without treating it as a fetch failure.
+//   - Transport error: returns ("", err); callers preserve existing state.
+//   - Malformed return: returns ("", nil), same "no URI" semantic.
+//
+// The URI is returned exactly as the contract emitted it; the metadata
+// fetcher service handles IPFS gateway resolution + JSON parsing.
+func GetTokenURI(contractAddress string, tokenID *big.Int) (string, error) {
+	idWord, err := encodeUint256ForABI(tokenID)
+	if err != nil {
+		return "", fmt.Errorf("encode tokenID: %w", err)
+	}
+	calldata := SIG_TOKEN_URI + idWord
+
+	result, callErr := CallContractMethod(contractAddress, calldata)
+	if callErr != nil {
+		if strings.HasPrefix(callErr.Error(), "RPC error:") {
+			return "", nil
+		}
+		return "", callErr
+	}
+	uri, decErr := parseDynamicString(result)
+	if decErr != nil {
+		// Same defensive posture as GetContractURI: a malformed return
+		// from one contract must not knock subsequent fetches off course.
+		return "", nil
+	}
+	return uri, nil
+}
+
+// GetERC1155URI queries `uri(uint256)` on an ERC-1155 contract.
+//
+// ERC-1155 spec note: the returned URI may contain the substring `{id}`,
+// which clients must substitute with the lowercase 64-char hex form of the
+// tokenID (so id 42 becomes "000...02a"). This function does that
+// substitution before returning, so the caller can pass the result
+// straight to the metadata fetcher without knowing the spec quirk.
+//
+// Same three-way error contract as GetTokenURI.
+func GetERC1155URI(contractAddress string, tokenID *big.Int) (string, error) {
+	idWord, err := encodeUint256ForABI(tokenID)
+	if err != nil {
+		return "", fmt.Errorf("encode tokenID: %w", err)
+	}
+	calldata := SIG_URI + idWord
+
+	result, callErr := CallContractMethod(contractAddress, calldata)
+	if callErr != nil {
+		if strings.HasPrefix(callErr.Error(), "RPC error:") {
+			return "", nil
+		}
+		return "", callErr
+	}
+	uri, decErr := parseDynamicString(result)
+	if decErr != nil {
+		return "", nil
+	}
+	return substituteERC1155IDTemplate(uri, tokenID), nil
+}
+
+// substituteERC1155IDTemplate replaces the `{id}` placeholder per the
+// ERC-1155 spec: "Clients MUST replace any occurrences of the substring
+// `{id}` in the URI with the actual token ID, in lowercase hexadecimal
+// (with no 0x prefix) and leading-zero-padded to 64 hex characters".
+//
+// Empty input or no placeholder => return unchanged.
+func substituteERC1155IDTemplate(uri string, tokenID *big.Int) string {
+	if uri == "" || !strings.Contains(uri, "{id}") {
+		return uri
+	}
+	h := tokenID.Text(16)
+	if len(h) > 64 {
+		// Shouldn't happen for any realistic tokenID (uint256 max is 64
+		// hex), but truncate-from-left rather than panic if it does.
+		h = h[len(h)-64:]
+	}
+	padded := strings.Repeat("0", 64-len(h)) + h
+	return strings.ReplaceAll(uri, "{id}", padded)
+}
+
 // GetERC1155Balance queries `balanceOf(address,uint256)` on an ERC-1155
 // contract and returns the holder's current per-id balance.
 //

--- a/QRL2MongoDB/rpc/tokenscalls_test.go
+++ b/QRL2MongoDB/rpc/tokenscalls_test.go
@@ -567,6 +567,61 @@ func hexEncode(b []byte) string {
 	return string(out)
 }
 
+func TestSubstituteERC1155IDTemplate(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		tokenID *big.Int
+		want    string
+	}{
+		{
+			name:    "spec happy path: id=42 padded to 64 hex chars",
+			uri:     "ipfs://Qm.../{id}.json",
+			tokenID: big.NewInt(42),
+			want:    "ipfs://Qm.../" + strings.Repeat("0", 62) + "2a" + ".json",
+		},
+		{
+			name:    "id=0 fully zero-padded",
+			uri:     "https://api.example.com/metadata/{id}",
+			tokenID: big.NewInt(0),
+			want:    "https://api.example.com/metadata/" + strings.Repeat("0", 64),
+		},
+		{
+			name:    "uint256 max stays exactly 64 chars",
+			uri:     "ipfs://{id}",
+			tokenID: new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)),
+			want:    "ipfs://" + strings.Repeat("f", 64),
+		},
+		{
+			name:    "multiple placeholders all replaced",
+			uri:     "https://h.test/{id}/contents/{id}.png",
+			tokenID: big.NewInt(1),
+			want:    "https://h.test/" + strings.Repeat("0", 63) + "1/contents/" + strings.Repeat("0", 63) + "1.png",
+		},
+		{
+			name:    "no placeholder, URI unchanged",
+			uri:     "ipfs://Qm.../fixed",
+			tokenID: big.NewInt(1),
+			want:    "ipfs://Qm.../fixed",
+		},
+		{
+			name:    "empty URI stays empty",
+			uri:     "",
+			tokenID: big.NewInt(1),
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := substituteERC1155IDTemplate(tt.uri, tt.tokenID)
+			if got != tt.want {
+				t.Errorf("got %q\nwant %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExpectedCalldataSelectors(t *testing.T) {
 	// Sanity: selector + padded uint256 = "0x" + 8 + 64 = 74 chars.
 	got := expectedOwnerOfCalldata(big.NewInt(1))
@@ -584,6 +639,20 @@ func TestExpectedCalldataSelectors(t *testing.T) {
 	}
 	if !strings.HasPrefix(got1155, SIG_BALANCE_OF_1155) {
 		t.Errorf("balanceOf(addr,id) calldata missing selector prefix: %q", got1155)
+	}
+
+	// Phase 3b: tokenURI(uint256) selector. Same shape as ownerOf:
+	// 8 hex char selector + 64 hex char tokenID word = 72 + "0x" = 74.
+	idWord, _ := encodeUint256ForABI(big.NewInt(1))
+	tokenURI := SIG_TOKEN_URI + idWord
+	if len(tokenURI) != 74 || !strings.HasPrefix(tokenURI, SIG_TOKEN_URI) {
+		t.Errorf("tokenURI calldata malformed: %q (len %d)", tokenURI, len(tokenURI))
+	}
+
+	// Phase 3b: uri(uint256) selector. Same shape.
+	uri1155 := SIG_URI + idWord
+	if len(uri1155) != 74 || !strings.HasPrefix(uri1155, SIG_URI) {
+		t.Errorf("uri(uint256) calldata malformed: %q (len %d)", uri1155, len(uri1155))
 	}
 }
 

--- a/QRL2MongoDB/synchroniser/metadata_service.go
+++ b/QRL2MongoDB/synchroniser/metadata_service.go
@@ -30,6 +30,7 @@ import (
 	"QRL2MongoDB/db"
 	"QRL2MongoDB/models"
 	"QRL2MongoDB/rpc"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -621,9 +622,16 @@ func parseMetadataJSON(body []byte) (metadataDocument, error) {
 // `attributes` array (OpenSea convention: each entry has `trait_type`,
 // `value`, optionally `display_type`). Anything that isn't a clean array
 // of objects is dropped silently, one bad NFT shouldn't fail the rest.
+//
+// Uses json.Decoder.UseNumber() rather than vanilla json.Unmarshal so
+// trait values that are large integers (e.g. token IDs as attribute
+// values, common in game NFT schemas) keep their full precision instead
+// of being rounded through float64 at 2^53.
 func parseTokenMetadataJSON(body []byte) (tokenMetadataDocument, error) {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
 	var raw map[string]interface{}
-	if err := json.Unmarshal(body, &raw); err != nil {
+	if err := dec.Decode(&raw); err != nil {
 		return tokenMetadataDocument{}, err
 	}
 	stringField := func(key string) string {
@@ -678,10 +686,14 @@ func parseTokenMetadataJSON(body []byte) (tokenMetadataDocument, error) {
 }
 
 // stringifyAttrField coerces an arbitrary JSON value to a string for
-// storage uniformity. Strings pass through trimmed; numbers and bools
-// use their natural representation; nil and objects collapse to "".
-// We deliberately don't json.Marshal nested objects, the attribute
-// model only stores scalars.
+// storage uniformity. Strings pass through trimmed; numbers (preserved as
+// json.Number via Decoder.UseNumber so we keep full precision for big
+// uint256-shaped trait values) pass through verbatim; bools become
+// "true"/"false"; nil and objects collapse to "".
+//
+// Older callers may still feed float64 values when the JSON came from
+// json.Unmarshal instead of json.Decoder.UseNumber; the float64 branch
+// is kept for that compatibility path.
 func stringifyAttrField(v interface{}) string {
 	switch t := v.(type) {
 	case nil:
@@ -693,9 +705,12 @@ func stringifyAttrField(v interface{}) string {
 			return "true"
 		}
 		return "false"
+	case json.Number:
+		// Decoder.UseNumber path: keep the original textual form, no
+		// float64 round-trip. Covers ints past 2^53.
+		return t.String()
 	case float64:
-		// json.Unmarshal yields float64 for numeric values; preserve
-		// integer-ness when possible.
+		// Vanilla Unmarshal fallback; preserve integer-ness when possible.
 		if t == float64(int64(t)) {
 			return strconv.FormatInt(int64(t), 10)
 		}

--- a/QRL2MongoDB/synchroniser/metadata_service.go
+++ b/QRL2MongoDB/synchroniser/metadata_service.go
@@ -28,10 +28,13 @@ package synchroniser
 import (
 	"QRL2MongoDB/configs"
 	"QRL2MongoDB/db"
+	"QRL2MongoDB/models"
+	"QRL2MongoDB/rpc"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"net/http"
 	"net/url"
@@ -261,16 +264,27 @@ func (s *MetadataService) Stop() {
 
 // tick runs one batch of metadata fetches. Errors per row are logged and
 // recorded on the contractCode document; the tick itself never fails.
+//
+// Phase 3b: every tick also processes a batch of per-token metadata stubs
+// alongside the collection-level batch, sharing the same poll interval +
+// HTTP client + SSRF guard. The two work queues are independent (no
+// cross-row dependencies), so a slow contract-URI fetch doesn't block
+// per-token progress and vice versa.
 func (s *MetadataService) tick(ctx context.Context) {
+	s.tickContracts(ctx)
+	s.tickTokens(ctx)
+}
+
+func (s *MetadataService) tickContracts(ctx context.Context) {
 	rows, err := db.GetContractsAwaitingMetadata(ctx, s.batchSize)
 	if err != nil {
-		configs.Logger.Warn("metadata fetcher: failed to read work queue", zap.Error(err))
+		configs.Logger.Warn("metadata fetcher: failed to read contract work queue", zap.Error(err))
 		return
 	}
 	if len(rows) == 0 {
 		return
 	}
-	configs.Logger.Info("metadata fetcher: processing batch", zap.Int("rows", len(rows)))
+	configs.Logger.Info("metadata fetcher: processing contract batch", zap.Int("rows", len(rows)))
 
 	for _, c := range rows {
 		select {
@@ -282,6 +296,146 @@ func (s *MetadataService) tick(ctx context.Context) {
 		}
 		s.fetchOne(ctx, c.Address, c.MetadataURI)
 	}
+}
+
+// tickTokens runs one batch of per-tokenID metadata fetches. For each stub
+// the fetcher calls tokenURI(id) or uri(id) depending on the contract's
+// recorded standard, resolves the resulting URI through the gateway, parses
+// the JSON, and writes the result. Same "preserve last-good" semantics as
+// the contract path.
+func (s *MetadataService) tickTokens(ctx context.Context) {
+	rows, err := db.GetTokensAwaitingMetadata(ctx, s.batchSize)
+	if err != nil {
+		configs.Logger.Warn("metadata fetcher: failed to read token work queue", zap.Error(err))
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+	configs.Logger.Info("metadata fetcher: processing token batch", zap.Int("rows", len(rows)))
+
+	for _, r := range rows {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.stopCh:
+			return
+		default:
+		}
+		s.fetchOneToken(ctx, r)
+	}
+}
+
+// fetchOneToken resolves the URI for one (contract, tokenID), parses the
+// metadata JSON, and persists the outcome. Same three-step pipeline as
+// fetchOne: resolve scheme -> HTTP GET (SSRF-guarded) -> JSON parse.
+func (s *MetadataService) fetchOneToken(ctx context.Context, stub models.TokenMetadata) {
+	id, ok := new(big.Int).SetString(stub.TokenID, 10)
+	if !ok {
+		s.recordTokenFailure(ctx, stub.ContractAddress, stub.TokenID, "parse tokenID: not a decimal integer")
+		return
+	}
+
+	var (
+		uri    string
+		uriErr error
+	)
+	switch stub.TokenStandard {
+	case rpc.StandardERC721:
+		uri, uriErr = rpc.GetTokenURI(stub.ContractAddress, id)
+	case rpc.StandardERC1155:
+		uri, uriErr = rpc.GetERC1155URI(stub.ContractAddress, id)
+	default:
+		s.recordTokenFailure(ctx, stub.ContractAddress, stub.TokenID,
+			fmt.Sprintf("unsupported standard %q", stub.TokenStandard))
+		return
+	}
+	if uriErr != nil {
+		// Transport error: preserve state, retry on the next tick (because
+		// fetchedAt + fetchError stay empty).
+		configs.Logger.Debug("token URI probe transport error; preserving state",
+			zap.String("contract", stub.ContractAddress),
+			zap.String("tokenID", stub.TokenID),
+			zap.Error(uriErr))
+		return
+	}
+	if uri == "" {
+		s.recordTokenFailure(ctx, stub.ContractAddress, stub.TokenID, "contract returned no URI")
+		return
+	}
+
+	resolved, err := resolveMetadataURI(uri, s.gatewayURL)
+	if err != nil {
+		s.recordTokenFailure(ctx, stub.ContractAddress, stub.TokenID, fmt.Sprintf("resolve: %v", err))
+		return
+	}
+
+	body, fetchErr := s.fetchBody(ctx, resolved)
+	if fetchErr != nil {
+		s.recordTokenFailure(ctx, stub.ContractAddress, stub.TokenID, fmt.Sprintf("fetch: %v", fetchErr))
+		return
+	}
+
+	parsed, parseErr := parseTokenMetadataJSON(body)
+	if parseErr != nil {
+		s.recordTokenFailure(ctx, stub.ContractAddress, stub.TokenID, fmt.Sprintf("parse: %v", parseErr))
+		return
+	}
+
+	imageResolved := ""
+	if parsed.Image != "" {
+		if img, err := resolveMetadataURI(parsed.Image, s.gatewayURL); err == nil {
+			imageResolved = img
+		} else {
+			configs.Logger.Debug("token image URI unresolved",
+				zap.String("contract", stub.ContractAddress),
+				zap.String("tokenID", stub.TokenID),
+				zap.String("image", parsed.Image),
+				zap.Error(err))
+		}
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := db.UpdateTokenMetadata(
+		ctx,
+		stub.ContractAddress,
+		stub.TokenID,
+		uri,
+		parsed.Name,
+		parsed.Description,
+		imageResolved,
+		parsed.ExternalURL,
+		parsed.Attributes,
+		now,
+		"",
+	); err != nil {
+		configs.Logger.Warn("metadata fetcher: token persist failed",
+			zap.String("contract", stub.ContractAddress),
+			zap.String("tokenID", stub.TokenID),
+			zap.Error(err))
+		return
+	}
+	configs.Logger.Info("metadata fetcher: token stored",
+		zap.String("contract", stub.ContractAddress),
+		zap.String("tokenID", stub.TokenID),
+		zap.String("name", parsed.Name),
+		zap.Bool("hasImage", imageResolved != ""),
+		zap.Int("attributes", len(parsed.Attributes)))
+}
+
+func (s *MetadataService) recordTokenFailure(ctx context.Context, contract, tokenID, reason string) {
+	if err := db.UpdateTokenMetadata(ctx, contract, tokenID, "", "", "", "", "", nil, "", reason); err != nil {
+		configs.Logger.Warn("metadata fetcher: failed to record token fetch error",
+			zap.String("contract", contract),
+			zap.String("tokenID", tokenID),
+			zap.String("reason", reason),
+			zap.Error(err))
+		return
+	}
+	configs.Logger.Warn("metadata fetcher: token fetch failed",
+		zap.String("contract", contract),
+		zap.String("tokenID", tokenID),
+		zap.String("reason", reason))
 }
 
 // fetchOne resolves and parses one contract's metadata URI, persisting the
@@ -398,14 +552,26 @@ func (s *MetadataService) fetchBody(ctx context.Context, resolvedURL string) ([]
 }
 
 // metadataDocument is the minimal subset of the NFT metadata schema we
-// care about for Phase 3a. Unknown fields are ignored. Each field is
-// optional; the parser coerces wrong-typed fields to the empty string so
-// one bad entry can't fail the whole record.
+// care about for Phase 3a (collection level). Unknown fields are ignored.
+// Each field is optional; the parser coerces wrong-typed fields to the
+// empty string so one bad entry can't fail the whole record.
 type metadataDocument struct {
 	Name        string `json:"-"`
 	Description string `json:"-"`
 	Image       string `json:"-"`
 	ExternalURL string `json:"-"`
+}
+
+// tokenMetadataDocument extends metadataDocument with the per-token
+// `attributes` array (Phase 3b). Values are coerced to strings for
+// storage uniformity since the OpenSea spec allows mixed types
+// (numeric, string, object) and downstream consumers can re-parse.
+type tokenMetadataDocument struct {
+	Name        string
+	Description string
+	Image       string
+	ExternalURL string
+	Attributes  []models.TokenAttribute
 }
 
 // parseMetadataJSON does a defensive JSON parse: unmarshal into a generic
@@ -449,6 +615,94 @@ func parseMetadataJSON(body []byte) (metadataDocument, error) {
 		ExternalURL: stringField("external_url"),
 	}
 	return doc, nil
+}
+
+// parseTokenMetadataJSON is the Phase 3b variant that also extracts the
+// `attributes` array (OpenSea convention: each entry has `trait_type`,
+// `value`, optionally `display_type`). Anything that isn't a clean array
+// of objects is dropped silently, one bad NFT shouldn't fail the rest.
+func parseTokenMetadataJSON(body []byte) (tokenMetadataDocument, error) {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return tokenMetadataDocument{}, err
+	}
+	stringField := func(key string) string {
+		if raw == nil {
+			return ""
+		}
+		v, ok := raw[key]
+		if !ok || v == nil {
+			return ""
+		}
+		s, ok := v.(string)
+		if !ok {
+			return ""
+		}
+		return strings.TrimSpace(s)
+	}
+
+	out := tokenMetadataDocument{
+		Name:        stringField("name"),
+		Description: stringField("description"),
+		Image:       stringField("image"),
+		ExternalURL: stringField("external_url"),
+	}
+
+	// attributes: []{trait_type, value, display_type?}
+	if raw != nil {
+		if attrsAny, ok := raw["attributes"]; ok {
+			if attrs, isArr := attrsAny.([]interface{}); isArr {
+				const maxAttrs = 64 // defensive: stop a malicious doc from blowing memory
+				for i, a := range attrs {
+					if i >= maxAttrs {
+						break
+					}
+					m, isMap := a.(map[string]interface{})
+					if !isMap {
+						continue
+					}
+					attr := models.TokenAttribute{
+						TraitType:   stringifyAttrField(m["trait_type"]),
+						Value:       stringifyAttrField(m["value"]),
+						DisplayType: stringifyAttrField(m["display_type"]),
+					}
+					if attr.TraitType == "" && attr.Value == "" {
+						continue // empty attr, skip
+					}
+					out.Attributes = append(out.Attributes, attr)
+				}
+			}
+		}
+	}
+	return out, nil
+}
+
+// stringifyAttrField coerces an arbitrary JSON value to a string for
+// storage uniformity. Strings pass through trimmed; numbers and bools
+// use their natural representation; nil and objects collapse to "".
+// We deliberately don't json.Marshal nested objects, the attribute
+// model only stores scalars.
+func stringifyAttrField(v interface{}) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(t)
+	case bool:
+		if t {
+			return "true"
+		}
+		return "false"
+	case float64:
+		// json.Unmarshal yields float64 for numeric values; preserve
+		// integer-ness when possible.
+		if t == float64(int64(t)) {
+			return strconv.FormatInt(int64(t), 10)
+		}
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	default:
+		return ""
+	}
 }
 
 // CID validation mirrors the wallet backend's IPFS proxy so callers fail

--- a/QRL2MongoDB/synchroniser/metadata_service_test.go
+++ b/QRL2MongoDB/synchroniser/metadata_service_test.go
@@ -182,6 +182,131 @@ func TestParseMetadataJSON(t *testing.T) {
 	}
 }
 
+func TestParseTokenMetadataJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		want    tokenMetadataDocument
+		wantErr bool
+	}{
+		{
+			// Attributes content is verified field-by-field in the
+			// name-keyed assertions below; this `want` only carries the
+			// scalar fields for the simple equality cases.
+			name: "OpenSea-style happy path with attributes",
+			body: `{
+				"name":"Sword of Truth #1",
+				"description":"Legendary weapon",
+				"image":"ipfs://QmFoo/1.png",
+				"external_url":"https://example.com/sword/1",
+				"attributes":[
+					{"trait_type":"Damage","value":50,"display_type":"number"},
+					{"trait_type":"Element","value":"Fire"},
+					{"trait_type":"Cursed","value":true}
+				]
+			}`,
+		},
+		{
+			name: "no attributes field",
+			body: `{"name":"Plain","image":"ipfs://x"}`,
+			want: tokenMetadataDocument{Name: "Plain", Image: "ipfs://x"},
+		},
+		{
+			name: "attributes not an array dropped silently",
+			body: `{"name":"X","attributes":"not-an-array"}`,
+			want: tokenMetadataDocument{Name: "X"},
+		},
+		{
+			name: "non-object attrs entries skipped",
+			body: `{"name":"X","attributes":["string", 42, {"trait_type":"OK","value":"v"}]}`,
+			want: tokenMetadataDocument{
+				Name: "X",
+			},
+		},
+		{
+			name:    "malformed JSON returns error",
+			body:    `{"name":`,
+			wantErr: true,
+		},
+		{
+			name: "null literal returns empty doc",
+			body: `null`,
+			want: tokenMetadataDocument{},
+		},
+		{
+			name: "float trait value preserves precision",
+			body: `{"attributes":[{"trait_type":"Rarity","value":0.5}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTokenMetadataJSON([]byte(tt.body))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			// Spot-check string fields.
+			if tt.name == "OpenSea-style happy path with attributes" {
+				if got.Name != "Sword of Truth #1" || got.Description != "Legendary weapon" ||
+					got.Image != "ipfs://QmFoo/1.png" || got.ExternalURL != "https://example.com/sword/1" {
+					t.Errorf("string fields wrong: %+v", got)
+				}
+				if len(got.Attributes) != 3 {
+					t.Fatalf("attributes count = %d, want 3", len(got.Attributes))
+				}
+				if got.Attributes[0].TraitType != "Damage" || got.Attributes[0].Value != "50" || got.Attributes[0].DisplayType != "number" {
+					t.Errorf("attr[0] = %+v", got.Attributes[0])
+				}
+				if got.Attributes[1].TraitType != "Element" || got.Attributes[1].Value != "Fire" {
+					t.Errorf("attr[1] = %+v", got.Attributes[1])
+				}
+				if got.Attributes[2].TraitType != "Cursed" || got.Attributes[2].Value != "true" {
+					t.Errorf("attr[2] = %+v", got.Attributes[2])
+				}
+			}
+			if tt.name == "non-object attrs entries skipped" {
+				if len(got.Attributes) != 1 {
+					t.Errorf("attributes count = %d, want 1 (the valid object)", len(got.Attributes))
+				}
+			}
+			if tt.name == "float trait value preserves precision" {
+				if len(got.Attributes) != 1 || got.Attributes[0].Value != "0.5" {
+					t.Errorf("float attr = %+v", got.Attributes)
+				}
+			}
+		})
+	}
+}
+
+func TestStringifyAttrField(t *testing.T) {
+	tests := []struct {
+		in   interface{}
+		want string
+	}{
+		{nil, ""},
+		{"hello", "hello"},
+		{"  trim me  ", "trim me"},
+		{true, "true"},
+		{false, "false"},
+		{float64(42), "42"},
+		{float64(0.5), "0.5"},
+		{float64(0), "0"},
+		{[]interface{}{1, 2}, ""},
+		{map[string]interface{}{"k": "v"}, ""},
+	}
+	for _, tt := range tests {
+		if got := stringifyAttrField(tt.in); got != tt.want {
+			t.Errorf("stringifyAttrField(%v) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
 func TestParseMetadataJSONNullLiteral(t *testing.T) {
 	// JSON literal `null` unmarshals into a nil map. The defensive nil
 	// check in stringField keeps the parser from panicking; we just

--- a/QRL2MongoDB/synchroniser/metadata_service_test.go
+++ b/QRL2MongoDB/synchroniser/metadata_service_test.go
@@ -1,6 +1,7 @@
 package synchroniser
 
 import (
+	"encoding/json"
 	"net"
 	"strings"
 	"testing"
@@ -237,6 +238,13 @@ func TestParseTokenMetadataJSON(t *testing.T) {
 			name: "float trait value preserves precision",
 			body: `{"attributes":[{"trait_type":"Rarity","value":0.5}]}`,
 		},
+		{
+			// json.Decoder.UseNumber preserves the exact textual form so
+			// huge integer trait values (e.g. token IDs used as traits in
+			// game NFT schemas) don't round through float64's 2^53 limit.
+			name: "large integer trait value retains full precision",
+			body: `{"attributes":[{"trait_type":"BoundTokenID","value":18446744073709551615}]}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -280,6 +288,13 @@ func TestParseTokenMetadataJSON(t *testing.T) {
 					t.Errorf("float attr = %+v", got.Attributes)
 				}
 			}
+			if tt.name == "large integer trait value retains full precision" {
+				// 18446744073709551615 = 2^64 - 1, well past 2^53.
+				// Without UseNumber this would round to 1.8446744073709552e+19.
+				if len(got.Attributes) != 1 || got.Attributes[0].Value != "18446744073709551615" {
+					t.Errorf("large-int attr = %+v (want value=\"18446744073709551615\")", got.Attributes)
+				}
+			}
 		})
 	}
 }
@@ -299,6 +314,11 @@ func TestStringifyAttrField(t *testing.T) {
 		{float64(0), "0"},
 		{[]interface{}{1, 2}, ""},
 		{map[string]interface{}{"k": "v"}, ""},
+		// json.Number variants (the UseNumber path).
+		{json.Number("42"), "42"},
+		{json.Number("0.5"), "0.5"},
+		// 2^64 - 1: lossless via json.Number, would lose precision via float64.
+		{json.Number("18446744073709551615"), "18446744073709551615"},
 	}
 	for _, tt := range tests {
 		if got := stringifyAttrField(tt.in); got != tt.want {

--- a/QRL2MongoDB/synchroniser/token_sync.go
+++ b/QRL2MongoDB/synchroniser/token_sync.go
@@ -217,6 +217,14 @@ func InitializeTokenCollections() error {
 		configs.Logger.Info("Successfully initialized token balances collection")
 	}
 
+	// Phase 3b: initialize per-tokenID metadata collection.
+	if err := db.InitializeTokenMetadataCollection(); err != nil {
+		configs.Logger.Error("Failed to initialize token metadata collection", zap.Error(err))
+		initErrors = append(initErrors, err)
+	} else {
+		configs.Logger.Info("Successfully initialized token metadata collection")
+	}
+
 	// Return combined errors if any occurred
 	if len(initErrors) > 0 {
 		configs.Logger.Error("Token collection initialization completed with errors",

--- a/backendAPI/db/token.go
+++ b/backendAPI/db/token.go
@@ -393,16 +393,45 @@ func GetTokenIDs(contractAddress string, page, limit int) ([]TokenIDSummary, int
 	if summaries == nil {
 		summaries = make([]TokenIDSummary, 0)
 	}
+
+	// Phase 3b enrichment: pull per-token name + image from tokenMetadata.
+	// One $in query against the paginated id list, then a per-row merge.
+	// Skipped silently if the lookup fails; the response is still useful
+	// without metadata.
+	if len(summaries) > 0 {
+		ids := make([]string, 0, len(summaries))
+		for _, s := range summaries {
+			ids = append(ids, s.TokenID)
+		}
+		if meta, mErr := GetTokenMetadataMap(contractAddress, ids); mErr == nil {
+			for i := range summaries {
+				if m, ok := meta[summaries[i].TokenID]; ok && m != nil {
+					summaries[i].Name = m.Name
+					summaries[i].Description = m.Description
+					summaries[i].Image = m.Image
+				}
+			}
+		}
+	}
+
 	return summaries, totalCount, nil
 }
 
 // TokenIDSummary is one row in the GET /token/:addr/tokens response.
+//
+// Phase 3b adds the optional metadata fields (Name + Image + Description)
+// pulled from the per-token tokenMetadata collection. They are populated
+// inline by GetTokenIDs after the distinct-id aggregation completes, so
+// the response is a single payload instead of a roundtrip per row.
 type TokenIDSummary struct {
 	TokenID       string `json:"tokenID" bson:"tokenID"`
 	HolderCount   int    `json:"holderCount" bson:"holderCount"`
 	TokenStandard string `json:"tokenStandard,omitempty" bson:"tokenStandard,omitempty"`
 	BlockNumber   string `json:"blockNumber,omitempty" bson:"blockNumber,omitempty"`
 	UpdatedAt     string `json:"updatedAt,omitempty" bson:"updatedAt,omitempty"`
+	Name          string `json:"name,omitempty" bson:"name,omitempty"`
+	Description   string `json:"description,omitempty" bson:"description,omitempty"`
+	Image         string `json:"image,omitempty" bson:"image,omitempty"`
 }
 
 // GetTokenTransfers returns all transfers for a specific token contract with pagination

--- a/backendAPI/db/token_metadata.go
+++ b/backendAPI/db/token_metadata.go
@@ -1,0 +1,80 @@
+// Package db / token_metadata.go (backend)
+//
+// Read helpers for the per-tokenID metadata persisted by the Phase 3b
+// metadata fetcher service. The syncer is the only writer; this backend
+// only reads.
+package db
+
+import (
+	"backendAPI/configs"
+	"backendAPI/models"
+	"context"
+	"strings"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+const tokenMetadataCollection = "tokenMetadata"
+
+// GetTokenMetadata returns the metadata document for a specific
+// (contract, tokenID). Returns nil, nil if no stub exists.
+func GetTokenMetadata(contractAddress, tokenID string) (*models.TokenMetadata, error) {
+	contractAddress = normalizeAddress(contractAddress)
+	tokenID = strings.TrimSpace(tokenID)
+	if tokenID == "" {
+		return nil, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	collection := configs.GetCollection(configs.DB, tokenMetadataCollection)
+	var out models.TokenMetadata
+	err := collection.FindOne(ctx, bson.M{
+		"contractAddress": contractAddress,
+		"tokenID":         tokenID,
+	}).Decode(&out)
+	if err == mongo.ErrNoDocuments {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetTokenMetadataMap returns a (contract, tokenID) -> metadata map for the
+// list of tokenIDs in one collection. Used to enrich /token/:addr/tokens
+// rows with per-token name + image without a second roundtrip per row.
+func GetTokenMetadataMap(contractAddress string, tokenIDs []string) (map[string]*models.TokenMetadata, error) {
+	contractAddress = normalizeAddress(contractAddress)
+	if len(tokenIDs) == 0 {
+		return map[string]*models.TokenMetadata{}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	collection := configs.GetCollection(configs.DB, tokenMetadataCollection)
+	cur, err := collection.Find(ctx, bson.M{
+		"contractAddress": contractAddress,
+		"tokenID":         bson.M{"$in": tokenIDs},
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer cur.Close(ctx)
+
+	out := make(map[string]*models.TokenMetadata, len(tokenIDs))
+	for cur.Next(ctx) {
+		var m models.TokenMetadata
+		if err := cur.Decode(&m); err != nil {
+			continue
+		}
+		copyOf := m
+		out[m.TokenID] = &copyOf
+	}
+	return out, nil
+}

--- a/backendAPI/models/token_metadata.go
+++ b/backendAPI/models/token_metadata.go
@@ -1,0 +1,25 @@
+package models
+
+// TokenMetadata mirrors QRL2MongoDB/models/token_metadata.go for
+// read-through on the backend. Same bson tags so whole-doc reads survive
+// the cross-process round trip.
+type TokenMetadata struct {
+	ContractAddress string           `json:"contractAddress" bson:"contractAddress"`
+	TokenID         string           `json:"tokenID" bson:"tokenID"`
+	TokenStandard   string           `json:"tokenStandard,omitempty" bson:"tokenStandard,omitempty"`
+	URI             string           `json:"uri,omitempty" bson:"uri,omitempty"`
+	Name            string           `json:"name,omitempty" bson:"name,omitempty"`
+	Description     string           `json:"description,omitempty" bson:"description,omitempty"`
+	Image           string           `json:"image,omitempty" bson:"image,omitempty"`
+	ExternalURL     string           `json:"externalURL,omitempty" bson:"externalURL,omitempty"`
+	Attributes      []TokenAttribute `json:"attributes,omitempty" bson:"attributes,omitempty"`
+	FetchedAt       string           `json:"fetchedAt,omitempty" bson:"fetchedAt,omitempty"`
+	FetchError      string           `json:"fetchError,omitempty" bson:"fetchError,omitempty"`
+	UpdatedAt       string           `json:"updatedAt" bson:"updatedAt"`
+}
+
+type TokenAttribute struct {
+	TraitType   string `json:"trait_type" bson:"trait_type"`
+	Value       string `json:"value" bson:"value"`
+	DisplayType string `json:"display_type,omitempty" bson:"display_type,omitempty"`
+}

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -874,6 +874,8 @@ func UserRoute(router *gin.Engine) {
 	// Phase 2: list distinct tokenIDs minted on an NFT contract, with the
 	// number of holders for each id. Paginated by `?page=&limit=` like the
 	// other token endpoints. Returns an empty list for ERC-20 contracts.
+	// Phase 3b: each row also carries `name` + `image` + `description`
+	// when off-chain metadata has been fetched.
 	router.GET("/token/:address/tokens", func(c *gin.Context) {
 		address := c.Param("address")
 		page, limit := getPaginationParams(c, 0, 25)
@@ -894,6 +896,35 @@ func UserRoute(router *gin.Engine) {
 			"page":            page,
 			"limit":           limit,
 		})
+	})
+
+	// Phase 3b: per-token off-chain metadata. Returns the full metadata
+	// document for one (contract, tokenID), including OpenSea-style
+	// attributes. 404 if no stub exists (e.g. the contract isn't an NFT
+	// or that id has never been transferred). 400 if `id` isn't a
+	// decimal integer, this also guards against accidental collision
+	// with the sibling static-segment routes (/info, /holders, etc),
+	// although Gin's router already gives them priority by tree shape.
+	router.GET("/token/:address/:id", func(c *gin.Context) {
+		address := c.Param("address")
+		tokenID := c.Param("id")
+
+		if _, ok := new(big.Int).SetString(tokenID, 10); !ok {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "tokenID must be a decimal integer"})
+			return
+		}
+
+		meta, err := db.GetTokenMetadata(address, tokenID)
+		if err != nil {
+			log.Printf("Error fetching token metadata for %s/%s: %v", address, tokenID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch token metadata"})
+			return
+		}
+		if meta == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Token not found"})
+			return
+		}
+		c.JSON(http.StatusOK, meta)
 	})
 
 	// Get token transfers with pagination


### PR DESCRIPTION
## Summary

Phase 3b of zondscan NFT support: persist + render per-tokenID metadata. Phase 3a got us the collection-level title + image; this gets us the same treatment per individual NFT (token #1 vs token #2 of the same collection can have different images + traits).

Four logical commits:

1. **`feat(rpc): GetTokenURI + GetERC1155URI helpers`** (3de74ca): pure ABI plumbing. ERC-721's `tokenURI(uint256)`, ERC-1155's `uri(uint256)` with the spec-mandated `{id}` -> 64-char-lowercase-hex substitution applied inside the helper so callers don't have to know the quirk. Same 3-way error contract as the rest of the tokens helpers. 6 tests on the substitution + selector sanity checks.

2. **`feat(syncer): per-tokenID metadata storage + fetcher`** (21661c9): new `tokenMetadata` collection keyed `(contract, tokenID)`; `$setOnInsert` stub written from the transfer dispatch loop; fetcher service gains a second tick that polls stubs, calls the right URI getter for the standard, resolves through the IPFS gateway (Phase 3a default `qrlwallet.com/api/ipfs/`), parses the JSON including the OpenSea-style `attributes` array, and persists. Same SSRF guard / 1 MiB cap / 8 s timeout as Phase 3a. 16 test cases on the JSON parser + attribute coercion.

3. **`feat(backendAPI): GET /token/:addr/:id + per-token enrichment`** (08b2354): new endpoint returning the full per-token document. `/token/:addr/tokens` rows now also carry `name` + `image` + `description` (single `$in` lookup against the paginated id list, no per-row roundtrip). Tokens collection routes are tree-disambiguated against the existing `/info` / `/holders` / `/transfers` / `/tokens` static segments; decimal-integer validation on the `:id` param belts the suspenders.

4. **`feat(zondscan): render per-token thumbnails + name on Tokens tab`** (f9772eb): Tokens tab grows a thumbnail column (`next/image`, 40px square) and prefers the off-chain `name` over `#<id>`. Tokens without metadata fall back to a monogram tile so the page reads cleanly during the fetcher's catch-up window.

## Behaviour summary

Before this PR, the Tokens tab on an NFT page was a bare 3-column list of ids + holder counts. After:

- Each token row renders its actual image + name (if the contract emits a `tokenURI` / `uri` and the JSON resolves).
- Each token has its own URL: `GET /token/:addr/:id` returns the metadata doc including the OpenSea attribute list.
- Per-token detail page UI (with the full attribute table) lands in Phase 3c.

## Out of scope

- Per-token detail page `/token/[addr]/[id]/page.tsx` (Phase 3c)
- Mutable-metadata refresh / admin endpoint (Phase 4)
- Approval / ApprovalForAll tracking (separate PR)

## Test plan
- [x] `cd QRL2MongoDB && go build .` green
- [x] `cd backendAPI && go build .` green
- [x] `MONGOURI=mongodb://localhost:27017 go test ./QRL2MongoDB/rpc ./QRL2MongoDB/synchroniser` green
- [x] `cd ExplorerFrontend && npx tsc --noEmit && npm run build` green
- [ ] Post-merge: deploy to prod, watch the Tokens tab on any existing NFT collection. Tokens without `tokenURI` show as monogram tiles (expected, existing testnet fixtures don't implement it). The new flow can be verified end-to-end against a fresh deploy with `CONTRACT_URI_*` / `BASE_URI_*` set against a pinned IPFS CID (see nft-deploy README).