### PR TITLE
feat(backendAPI): split per-account holdings into tokens + nfts

### DIFF
--- a/ExplorerFrontend/app/api-explorer/api-explorer-client.tsx
+++ b/ExplorerFrontend/app/api-explorer/api-explorer-client.tsx
@@ -122,8 +122,16 @@ const endpointGroups: EndpointGroup[] = [
       {
         method: 'GET',
         path: '/address/:address/tokens',
-        description: 'Returns all token balances held by an address. Useful for wallet integration and token auto-discovery. Phase 2: NFT holdings expand to one row per (collection, tokenID), each row carries `tokenStandard` and (for NFTs) `tokenID`. ERC-20 rows continue to return one row per collection with the existing balance string.',
-        example: '/address/Q6153d37fa4da7193e6219dcbd2bbe62fa12905b1/tokens',
+        description: 'Returns all token balances held by an address. Useful for wallet integration and token auto-discovery. Phase 2: NFT holdings expand to one row per (collection, tokenID), each row carries `tokenStandard` and (for NFTs) `tokenID`. ERC-20 rows continue to return one row per collection with the existing balance string. Phase 3b adds an optional `?standard=` filter: pass `ERC-20` to scope to fungibles (wallets should do this when populating an ERC-20-aware Tokens card so NFT rows do not get treated as zero-balance fungibles).',
+        params: 'standard (query, optional, ERC-20|ERC-721|ERC-1155, invalid value → 400)',
+        example: '/address/Q6153d37fa4da7193e6219dcbd2bbe62fa12905b1/tokens?standard=ERC-20',
+      },
+      {
+        method: 'GET',
+        path: '/address/:address/nfts',
+        description: 'Phase 3b: per-(contract, tokenID) NFT holdings for an address, joined with both the collection-level contractCode row (collectionName, collectionSymbol) and the per-tokenID tokenMetadata row (name, image, description, attributes). Designed for the wallet\'s "Add NFT" picker so a single response is enough to render thumbnails + names without follow-up roundtrips. Optional `?standard=ERC-721|ERC-1155` to scope further; default returns both NFT standards. ERC-20 is rejected with 400, use /address/:addr/tokens?standard=ERC-20 for that.',
+        params: 'standard (query, optional, ERC-721|ERC-1155, invalid value → 400)',
+        example: '/address/Q6153d37fa4da7193e6219dcbd2bbe62fa12905b1/nfts',
       },
       {
         method: 'POST',

--- a/backendAPI/db/token.go
+++ b/backendAPI/db/token.go
@@ -12,9 +12,16 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-// GetTokenBalancesByAddress returns all token balances for a given wallet address
-// with token metadata (name, symbol, decimals) included
-func GetTokenBalancesByAddress(address string) ([]models.TokenBalance, error) {
+// GetTokenBalancesByAddress returns token balances for a given wallet address
+// with token metadata (name, symbol, decimals) included.
+//
+// `standardFilter`, when non-nil and non-empty, narrows the result to one
+// of "ERC-20" / "ERC-721" / "ERC-1155". A nil filter keeps the legacy
+// behaviour of returning every standard, important because the wallet
+// auto-discovery flow still defaults to "give me everything you know".
+// The wallet's per-card flows pass an explicit filter via the route's
+// `?standard=` query param.
+func GetTokenBalancesByAddress(address string, standardFilter *string) ([]models.TokenBalance, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -23,13 +30,18 @@ func GetTokenBalancesByAddress(address string) ([]models.TokenBalance, error) {
 
 	collection := configs.GetCollection(configs.DB, "tokenBalances")
 
+	matchStage := bson.M{
+		"holderAddress": bson.M{"$in": searchAddresses},
+	}
+	if standardFilter != nil && *standardFilter != "" {
+		matchStage["tokenStandard"] = *standardFilter
+	}
+
 	// Aggregation pipeline to join with contractCode for token metadata
 	pipeline := []bson.M{
 		// Match token balances for this address (case-insensitive)
 		{
-			"$match": bson.M{
-				"holderAddress": bson.M{"$in": searchAddresses},
-			},
+			"$match": matchStage,
 		},
 		// Add lowercase version of contractAddress for case-insensitive lookup
 		{

--- a/backendAPI/db/token.go
+++ b/backendAPI/db/token.go
@@ -555,3 +555,131 @@ func GetTokenTransferByTxHash(txHash string) (*models.TokenTransfer, error) {
 
 	return nil, nil
 }
+
+// GetNFTBalancesByAddress returns per-(contract, tokenID) NFT holdings for
+// a given wallet address, joined with both the collection-level
+// `contractCode` row and the per-tokenID `tokenMetadata` row so the wallet
+// can render a names+thumbnails picker without a round-trip per token.
+//
+// `standardFilter`, when non-nil, scopes to ERC-721 or ERC-1155. Default
+// is "both NFT standards". The caller is expected to have already
+// rejected ERC-20 (the route handler does this) since this function
+// only matches on NFT standards.
+//
+// Sort: collection, then tokenID by (string length, lex) so uint256 ids
+// past Decimal128's 34-digit limit still sort correctly without a
+// $toDecimal cast.
+func GetNFTBalancesByAddress(address string, standardFilter *string) ([]models.NFTBalance, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	searchAddresses := normalizeAddressBoth(address)
+
+	standards := []string{"ERC-721", "ERC-1155"}
+	if standardFilter != nil && *standardFilter != "" {
+		standards = []string{*standardFilter}
+	}
+
+	matchStage := bson.M{
+		"holderAddress": bson.M{"$in": searchAddresses},
+		"tokenStandard": bson.M{"$in": standards},
+	}
+
+	collection := configs.GetCollection(configs.DB, "tokenBalances")
+
+	pipeline := []bson.M{
+		{"$match": matchStage},
+		// Join the collection-level row (name/symbol/metadataName/etc) from
+		// contractCode. Case-insensitive lookup on the lowercase address to
+		// match the existing GetTokenBalancesByAddress pattern.
+		{
+			"$addFields": bson.M{
+				"contractAddressLower": bson.M{"$toLower": "$contractAddress"},
+			},
+		},
+		{
+			"$lookup": bson.M{
+				"from": "contractCode",
+				"let":  bson.M{"contractAddr": "$contractAddressLower"},
+				"pipeline": []bson.M{
+					{"$match": bson.M{"$expr": bson.M{"$eq": []interface{}{
+						bson.M{"$toLower": "$address"}, "$$contractAddr",
+					}}}},
+				},
+				"as": "contractInfo",
+			},
+		},
+		{"$unwind": bson.M{"path": "$contractInfo", "preserveNullAndEmptyArrays": true}},
+		// Join the per-tokenID metadata row (Phase 3b). $lookup on the
+		// (contract, tokenID) compound key.
+		{
+			"$lookup": bson.M{
+				"from": "tokenMetadata",
+				"let":  bson.M{"contractAddr": "$contractAddress", "tokenID": "$tokenID"},
+				"pipeline": []bson.M{
+					{"$match": bson.M{"$expr": bson.M{"$and": []interface{}{
+						bson.M{"$eq": []interface{}{"$contractAddress", "$$contractAddr"}},
+						bson.M{"$eq": []interface{}{"$tokenID", "$$tokenID"}},
+					}}}},
+				},
+				"as": "tokenMeta",
+			},
+		},
+		{"$unwind": bson.M{"path": "$tokenMeta", "preserveNullAndEmptyArrays": true}},
+		// Project the final NFTBalance shape. Prefer the off-chain
+		// metadataName for the collection label when present; falls back
+		// to the on-chain name().
+		{
+			"$project": bson.M{
+				"_id":             0,
+				"contractAddress": 1,
+				"holderAddress":   1,
+				"tokenID":         1,
+				"tokenStandard":   1,
+				"balance":         1,
+				"blockNumber":     1,
+				"updatedAt":       1,
+				"collectionName": bson.M{
+					"$cond": []interface{}{
+						bson.M{"$and": []interface{}{
+							bson.M{"$ne": []interface{}{"$contractInfo.metadataName", nil}},
+							bson.M{"$ne": []interface{}{"$contractInfo.metadataName", ""}},
+						}},
+						"$contractInfo.metadataName",
+						"$contractInfo.name",
+					},
+				},
+				"collectionSymbol": "$contractInfo.symbol",
+				"name":             "$tokenMeta.name",
+				"description":      "$tokenMeta.description",
+				"image":            "$tokenMeta.image",
+				"externalURL":      "$tokenMeta.externalURL",
+				"attributes":       "$tokenMeta.attributes",
+				"tokenIDLen":       bson.M{"$strLenCP": bson.M{"$ifNull": []interface{}{"$tokenID", ""}}},
+			},
+		},
+		// (length, lex) sort handles uint256 ids past Decimal128's 34-digit
+		// limit. Same pattern as Phase 2's GetTokenIDs.
+		{"$sort": bson.D{
+			{Key: "contractAddress", Value: 1},
+			{Key: "tokenIDLen", Value: 1},
+			{Key: "tokenID", Value: 1},
+		}},
+		{"$project": bson.M{"tokenIDLen": 0}},
+	}
+
+	cursor, err := collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var out []models.NFTBalance
+	if err := cursor.All(ctx, &out); err != nil {
+		return nil, err
+	}
+	if out == nil {
+		out = make([]models.NFTBalance, 0)
+	}
+	return out, nil
+}

--- a/backendAPI/models/token_balance.go
+++ b/backendAPI/models/token_balance.go
@@ -43,6 +43,41 @@ type TokenTransfer struct {
 	TransferType    string `json:"transferType" bson:"transferType"`
 }
 
+// NFTBalance is one row of GET /address/:addr/nfts: the holder's
+// claim on a specific (collection, tokenID) pair, joined with the
+// collection-level contractCode metadata AND the per-tokenID
+// tokenMetadata document (Phase 3b) so the wallet can render a name
+// + thumbnail + attributes in a single response.
+//
+// The collection-level fields are renamed to make the projection
+// unambiguous (collectionName vs the per-token name from
+// tokenMetadata).
+type NFTBalance struct {
+	ContractAddress  string           `json:"contractAddress" bson:"contractAddress"`
+	HolderAddress    string           `json:"holderAddress" bson:"holderAddress"`
+	TokenID          string           `json:"tokenID" bson:"tokenID"`
+	TokenStandard    string           `json:"tokenStandard" bson:"tokenStandard"`
+	Balance          string           `json:"balance" bson:"balance"`
+	BlockNumber      string           `json:"blockNumber,omitempty" bson:"blockNumber,omitempty"`
+	UpdatedAt        string           `json:"updatedAt,omitempty" bson:"updatedAt,omitempty"`
+	CollectionName   string           `json:"collectionName,omitempty" bson:"collectionName,omitempty"`
+	CollectionSymbol string           `json:"collectionSymbol,omitempty" bson:"collectionSymbol,omitempty"`
+	Name             string           `json:"name,omitempty" bson:"name,omitempty"`
+	Description      string           `json:"description,omitempty" bson:"description,omitempty"`
+	Image            string           `json:"image,omitempty" bson:"image,omitempty"`
+	ExternalURL      string           `json:"externalURL,omitempty" bson:"externalURL,omitempty"`
+	Attributes       []TokenAttribute `json:"attributes,omitempty" bson:"attributes,omitempty"`
+}
+
+// NFTBalancesResponse is the wrapper for GET /address/:addr/nfts. Mirrors
+// the TokenBalancesResponse shape so wallet clients can share their
+// list-payload handling.
+type NFTBalancesResponse struct {
+	Address string       `json:"address"`
+	NFTs    []NFTBalance `json:"nfts"`
+	Count   int          `json:"count"`
+}
+
 // TokenHoldersResponse is the API response for token holders
 type TokenHoldersResponse struct {
 	ContractAddress string         `json:"contractAddress"`

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -806,15 +806,37 @@ func UserRoute(router *gin.Engine) {
 		})
 	})
 
-	// Get all token balances for a wallet address
-	// This endpoint is designed for wallet integration (e.g., qrlwallet)
-	// to auto-discover tokens held by an address on import
+	// Get all token balances for a wallet address.
+	//
+	// Default behaviour returns every standard the explorer indexes for
+	// this account (ERC-20 + ERC-721 + ERC-1155 per-id rows), useful for
+	// wallet auto-discovery and unchanged from the original contract so
+	// existing third-party callers don't break.
+	//
+	// Optional `?standard=` (ERC-20|ERC-721|ERC-1155) scopes the response
+	// to one token standard. The wallet's "Tokens" card uses this with
+	// `standard=ERC-20` so its ERC-20-aware renderer (which divides by
+	// `decimals`) doesn't accidentally render NFT rows as zero-balance
+	// fungibles.
 	router.GET("/address/:address/tokens", func(c *gin.Context) {
 		address := c.Param("address")
 
-		tokens, err := db.GetTokenBalancesByAddress(address)
+		var standardFilter *string
+		if s := c.Query("standard"); s != "" {
+			switch s {
+			case "ERC-20", "ERC-721", "ERC-1155":
+				standardFilter = &s
+			default:
+				c.JSON(http.StatusBadRequest, gin.H{
+					"error": "invalid standard; expected one of ERC-20, ERC-721, ERC-1155",
+				})
+				return
+			}
+		}
+
+		tokens, err := db.GetTokenBalancesByAddress(address, standardFilter)
 		if err != nil {
-			log.Printf("Error fetching token balances for %s: %v", address, err)
+			log.Printf("Error fetching token balances for %s (standard=%v): %v", address, standardFilter, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Failed to fetch token balances",
 			})

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -850,6 +850,45 @@ func UserRoute(router *gin.Engine) {
 		})
 	})
 
+	// Per-(contract, tokenID) NFT holdings for a wallet address. Joins both
+	// the collection-level contractCode row and the Phase 3b tokenMetadata
+	// row so the wallet's "Add NFT" picker can render names + thumbnails +
+	// attributes in one call. Optional ?standard= scopes to ERC-721 or
+	// ERC-1155; default returns both NFT standards. ERC-20 is rejected as
+	// invalid here so the route's intent is explicit; ERC-20 holdings live
+	// on the sibling /tokens?standard=ERC-20.
+	router.GET("/address/:address/nfts", func(c *gin.Context) {
+		address := c.Param("address")
+
+		var standardFilter *string
+		if s := c.Query("standard"); s != "" {
+			switch s {
+			case "ERC-721", "ERC-1155":
+				standardFilter = &s
+			default:
+				c.JSON(http.StatusBadRequest, gin.H{
+					"error": "invalid standard; expected ERC-721 or ERC-1155",
+				})
+				return
+			}
+		}
+
+		nfts, err := db.GetNFTBalancesByAddress(address, standardFilter)
+		if err != nil {
+			log.Printf("Error fetching NFT balances for %s (standard=%v): %v", address, standardFilter, err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to fetch NFT balances",
+			})
+			return
+		}
+
+		c.JSON(http.StatusOK, models.NFTBalancesResponse{
+			Address: address,
+			NFTs:    nfts,
+			Count:   len(nfts),
+		})
+	})
+
 	// Get token info (summary stats for a token contract)
 	router.GET("/token/:address/info", func(c *gin.Context) {
 		address := c.Param("address")


### PR DESCRIPTION
## Summary

The wallet at `qrlwallet.com` consumes `https://zondscan.com/api/address/:addr/tokens` to populate its Tokens card. Phase 2 of NFT support added per-(NFT contract, tokenID) rows to the response, but the wallet renders every row as an ERC-20 (applies `decimals`, formats as a divisible quantity). NFT rows with `balance="1"` come out as `1 / 10^18 ≈ 0`, so accounts with no real ERC-20s end up with a Tokens card full of zero-amount entries.

This PR gives the wallet team the API hooks they need for a cleaner UX (separate Tokens and NFTs cards, both behind a manual opt-in picker), without breaking any existing callers.

Three commits:

1. **`feat: ?standard= filter on /address/:addr/tokens`** — mirrors the existing `/contracts?standard=` validation pattern. Default returns mixed list as before; `?standard=ERC-20` scopes to fungibles for the wallet's ERC-20-aware renderer. Single internal callsite; `GetTokenBalancesByAddress` grows a `*string` filter param (nil = old behaviour).

2. **`feat: GET /address/:addr/nfts`** — dedicated NFT view. New `NFTBalance` struct. The aggregation `$match`es on NFT standards, `$lookup`s `contractCode` for `collectionName` / `collectionSymbol`, then `$lookup`s `tokenMetadata` (Phase 3b) for `name` / `image` / `description` / `attributes`. Per-row sort is `(strLen, lex)` on tokenID so uint256 ids past Decimal128's 34-digit limit stay correctly ordered. `?standard=ERC-721|ERC-1155` is optional; ERC-20 is rejected with 400 so callers can't accidentally double-up against `/tokens?standard=ERC-20`.

3. **`docs: api-explorer`** — document the new filter + the new endpoint.

## Wallet integration flow (out of scope for this PR)

The wallet calls the filtered endpoints only when the user opens a picker ("Add token" / "Add NFT"). The picker shows the list returned by the explorer plus a manual-CA fallback for anything not in the list. Nothing is auto-imported. This neutralises the spam-airdrop vector: an attacker can airdrop a token to any address, but the wallet never lists it in the Tokens card unless the user opts in.

## Test plan
- [x] `cd backendAPI && go build .` green
- [x] `cd ExplorerFrontend && npx tsc --noEmit` green
- [ ] Post-merge: smoke against `Q6153d37fa4da7193e6219dcbd2bbe62fa12905b1` on prod
  - `GET /address/.../tokens` (no filter) → 5 rows (mix of NFT rows, backwards-compat)
  - `GET /address/.../tokens?standard=ERC-20` → 0 rows
  - `GET /address/.../nfts` → 5 NFT rows with `name` / `image` / `attributes` populated for the 3 Zondscan / IPFS Proxy Test tokens that already have Phase 3b metadata
  - `GET /address/.../nfts?standard=ERC-20` → 400