### PR TITLE
fix(tx-page): correct NFT/multi-token rendering on confirmed + pending views

### DIFF
--- a/ExplorerFrontend/app/lib/helpers.ts
+++ b/ExplorerFrontend/app/lib/helpers.ts
@@ -309,90 +309,198 @@ export function formatAddress(address: string | undefined | null): string {
 }
 
 /**
- * Decoded token transfer information from input data
+ * Decoded token call (transfer-like or approval) from a transaction's
+ * input data. The `standard` discriminator drives the badge in
+ * pending-transaction-view; per-call shape is sparse: only the fields
+ * that apply to the matched selector are populated. ERC-1155 batch is
+ * the only path that fills `ids` + `values`.
+ *
+ * Caveat: 0x23b872dd is shared by ERC-20 transferFrom and ERC-721
+ * transferFrom. Without the target contract we can't tell them apart,
+ * so we tag it as ERC-20 (its original meaning) and leave the
+ * ambiguity visible via the raw amount field. The user lands on the
+ * confirmed tx page once mined, where the syncer's tokenStandard tag
+ * resolves it correctly.
  */
+export type DecodedTokenStandard = 'ERC-20' | 'ERC-721' | 'ERC-1155';
+
 export interface DecodedTokenTransfer {
-  to: string;
-  amount: string;
-  methodName: string;
+  standard: DecodedTokenStandard;
+  methodName: 'transfer' | 'transferFrom' | 'safeTransferFrom' | 'safeBatchTransferFrom' | 'setApprovalForAll';
+  to?: string;
+  from?: string;
+  /** ERC-20 raw uint256 amount, as a decimal string. */
+  amount?: string;
+  /** ERC-721 / ERC-1155 single tokenID, as a decimal string. */
+  tokenID?: string;
+  /** ERC-1155 single transfer value (qty), as a decimal string. */
+  value?: string;
+  /** ERC-1155 batch ids and per-id values (decimal strings). */
+  ids?: string[];
+  values?: string[];
+  /** setApprovalForAll operator + flag. */
+  operator?: string;
+  approved?: boolean;
+}
+
+// Decode one 32-byte ABI slot as Q-prefixed address (last 20 bytes).
+function abiAddress(data: string, offset: number): string {
+  return 'Q' + data.slice(offset, offset + 64).slice(-40);
+}
+
+// Decode one 32-byte ABI slot as a uint256 decimal string.
+function abiUint(data: string, offset: number): string {
+  return BigInt('0x' + data.slice(offset, offset + 64)).toString();
+}
+
+// Decode a dynamic uint256[] starting at byte offset `arrOffset` (in
+// chars from the start of the calldata, not from the args block).
+// Returns the decoded values as decimal strings.
+function abiUintArray(data: string, arrOffset: number): string[] {
+  const lenHex = data.slice(arrOffset, arrOffset + 64);
+  const len = Number(BigInt('0x' + lenHex));
+  const out: string[] = [];
+  for (let i = 0; i < len; i++) {
+    out.push(abiUint(data, arrOffset + 64 + i * 64));
+  }
+  return out;
 }
 
 /**
- * Decodes ERC20 transfer input data
- * ERC20 transfer method signature: 0xa9059cbb
- * Format: 0xa9059cbb + 32 bytes (to address, padded) + 32 bytes (amount)
- * @param inputData - The transaction input data
- * @returns Decoded transfer info or null if not a transfer
+ * Decode a transaction's input data into a structured token-call descriptor.
+ * Returns null for any non-token-call input. Selectors covered:
+ *
+ *   ERC-20:   transfer (0xa9059cbb), transferFrom (0x23b872dd)
+ *   ERC-721:  safeTransferFrom (0x42842e0e, 0xb88d4fde)
+ *   ERC-1155: safeTransferFrom (0xf242432a), safeBatchTransferFrom (0x2eb2c2d6)
+ *   Both NFT: setApprovalForAll (0xa22cb465)
  */
 export function decodeTokenTransferInput(inputData: string | undefined | null): DecodedTokenTransfer | null {
   if (!inputData || inputData === '0x' || inputData.length < 10) {
     return null;
   }
 
-  // Normalize input
   const data = inputData.toLowerCase();
+  const selector = data.slice(0, 10);
+  // ABI args start at byte 10 (skip "0x" + 4-byte selector).
+  const args = 10;
 
-  // Check for ERC20 transfer method signature (0xa9059cbb)
-  if (data.startsWith('0xa9059cbb')) {
-    // transfer(address,uint256)
-    // Expected length: 0x (2) + method (8) + address (64) + amount (64) = 138
-    if (data.length !== 138) {
-      return null;
+  try {
+    switch (selector) {
+      // ─── ERC-20 ────────────────────────────────────────────────────────
+      case '0xa9059cbb': {
+        // transfer(address,uint256), 4 + 32 + 32 = 68 bytes → 138 chars
+        if (data.length !== 138) return null;
+        return {
+          standard: 'ERC-20',
+          methodName: 'transfer',
+          to: abiAddress(data, args),
+          amount: abiUint(data, args + 64),
+        };
+      }
+      case '0x23b872dd': {
+        // transferFrom(address,address,uint256), 4 + 32*3 = 100 bytes → 202 chars.
+        // Shared selector with ERC-721 transferFrom, see DecodedTokenTransfer
+        // docstring: we tag it as ERC-20 because we lack the contract's
+        // standard in mempool context.
+        if (data.length !== 202) return null;
+        return {
+          standard: 'ERC-20',
+          methodName: 'transferFrom',
+          from: abiAddress(data, args),
+          to: abiAddress(data, args + 64),
+          amount: abiUint(data, args + 128),
+        };
+      }
+
+      // ─── ERC-721 ───────────────────────────────────────────────────────
+      case '0x42842e0e': {
+        // safeTransferFrom(address,address,uint256), same shape as 0x23b872dd
+        // but ERC-721-only by selector, so the tokenID slot is unambiguous.
+        if (data.length !== 202) return null;
+        return {
+          standard: 'ERC-721',
+          methodName: 'safeTransferFrom',
+          from: abiAddress(data, args),
+          to: abiAddress(data, args + 64),
+          tokenID: abiUint(data, args + 128),
+        };
+      }
+      case '0xb88d4fde': {
+        // safeTransferFrom(address,address,uint256,bytes). Static head is
+        // 4 + 32*4 = 132 bytes; the trailing bytes payload is dynamic and
+        // we don't surface it.
+        if (data.length < args + 64 * 4) return null;
+        return {
+          standard: 'ERC-721',
+          methodName: 'safeTransferFrom',
+          from: abiAddress(data, args),
+          to: abiAddress(data, args + 64),
+          tokenID: abiUint(data, args + 128),
+        };
+      }
+
+      // ─── ERC-1155 ──────────────────────────────────────────────────────
+      case '0xf242432a': {
+        // safeTransferFrom(address,address,uint256,uint256,bytes). Static
+        // head is 4 + 32*5 = 164 bytes; data payload trails.
+        if (data.length < args + 64 * 5) return null;
+        return {
+          standard: 'ERC-1155',
+          methodName: 'safeTransferFrom',
+          from: abiAddress(data, args),
+          to: abiAddress(data, args + 64),
+          tokenID: abiUint(data, args + 128),
+          value: abiUint(data, args + 192),
+        };
+      }
+      case '0x2eb2c2d6': {
+        // safeBatchTransferFrom(address,address,uint256[],uint256[],bytes).
+        // Static head: from, to, ids_offset, values_offset, data_offset.
+        // Both arrays are dynamic and their offsets are relative to the
+        // start of the *args block*, not the calldata. Convert to char
+        // positions in the calldata.
+        if (data.length < args + 64 * 5) return null;
+        const from = abiAddress(data, args);
+        const to = abiAddress(data, args + 64);
+        const idsOff = Number(BigInt('0x' + data.slice(args + 128, args + 192))) * 2;
+        const valsOff = Number(BigInt('0x' + data.slice(args + 192, args + 256))) * 2;
+        const ids = abiUintArray(data, args + idsOff);
+        const values = abiUintArray(data, args + valsOff);
+        if (ids.length !== values.length) return null;
+        return {
+          standard: 'ERC-1155',
+          methodName: 'safeBatchTransferFrom',
+          from,
+          to,
+          ids,
+          values,
+        };
+      }
+
+      // ─── Both NFT standards ────────────────────────────────────────────
+      case '0xa22cb465': {
+        // setApprovalForAll(address,bool). Same selector for ERC-721 and
+        // ERC-1155; we can't disambiguate from mempool input alone, so
+        // we mark it ERC-721 (the older standard). Cosmetic only.
+        if (data.length !== 138) return null;
+        const operator = abiAddress(data, args);
+        const flagSlot = BigInt('0x' + data.slice(args + 64, args + 128));
+        return {
+          standard: 'ERC-721',
+          methodName: 'setApprovalForAll',
+          operator,
+          approved: flagSlot !== BigInt(0),
+        };
+      }
+
+      default:
+        return null;
     }
-
-    try {
-      // Extract recipient address (bytes 10-74, last 40 chars are the address)
-      const toAddressPadded = data.slice(10, 74);
-      const toAddress = 'Q' + toAddressPadded.slice(-40);
-
-      // Extract amount (bytes 74-138)
-      const amountHex = '0x' + data.slice(74);
-      const amount = BigInt(amountHex).toString();
-
-      return {
-        to: toAddress,
-        amount: amount,
-        methodName: 'transfer'
-      };
-    } catch (error) {
-      console.error('Error decoding transfer input:', error);
-      return null;
-    }
+  } catch (error) {
+    console.error('Error decoding token input:', selector, error);
+    return null;
   }
-
-  // Check for ERC20 transferFrom method signature (0x23b872dd)
-  if (data.startsWith('0x23b872dd')) {
-    // transferFrom(address,address,uint256)
-    // Expected length: 0x (2) + method (8) + from (64) + to (64) + amount (64) = 202
-    if (data.length !== 202) {
-      return null;
-    }
-
-    try {
-      // Extract from address (bytes 10-74)
-      const fromAddressPadded = data.slice(10, 74);
-      const fromAddress = 'Q' + fromAddressPadded.slice(-40);
-
-      // Extract to address (bytes 74-138)
-      const toAddressPadded = data.slice(74, 138);
-      const toAddress = 'Q' + toAddressPadded.slice(-40);
-
-      // Extract amount (bytes 138-202)
-      const amountHex = '0x' + data.slice(138);
-      const amount = BigInt(amountHex).toString();
-
-      return {
-        to: toAddress,
-        amount: amount,
-        methodName: 'transferFrom'
-      };
-    } catch (error) {
-      console.error('Error decoding transferFrom input:', error);
-      return null;
-    }
-  }
-
-  return null;
 }
 
 /**

--- a/ExplorerFrontend/app/lib/helpers.ts
+++ b/ExplorerFrontend/app/lib/helpers.ts
@@ -356,9 +356,22 @@ function abiUint(data: string, offset: number): string {
 // Decode a dynamic uint256[] starting at byte offset `arrOffset` (in
 // chars from the start of the calldata, not from the args block).
 // Returns the decoded values as decimal strings.
+//
+// Defence-in-depth: the length prefix comes from attacker-controlled
+// calldata, so we cap it at 1024 (real ERC-1155 batches are
+// orders of magnitude smaller, the largest mainnet batches we've
+// seen are dozens of entries) and bound-check the declared payload
+// against the actual data length. Without the cap a crafted tx
+// could declare a 2^256-sized array and freeze the browser tab
+// when this runs in the pending-tx view.
 function abiUintArray(data: string, arrOffset: number): string[] {
   const lenHex = data.slice(arrOffset, arrOffset + 64);
-  const len = Number(BigInt('0x' + lenHex));
+  if (lenHex.length < 64) return [];
+  const lenBig = BigInt('0x' + lenHex);
+  const MAX_BATCH = 1024;
+  if (lenBig > BigInt(MAX_BATCH)) return [];
+  const len = Number(lenBig);
+  if (arrOffset + 64 + len * 64 > data.length) return [];
   const out: string[] = [];
   for (let i = 0; i < len; i++) {
     out.push(abiUint(data, arrOffset + 64 + i * 64));

--- a/ExplorerFrontend/app/pending/tx/[hash]/pending-transaction-view.tsx
+++ b/ExplorerFrontend/app/pending/tx/[hash]/pending-transaction-view.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import type { PendingTransaction } from '@/app/types';
 import config from '../../../../config';
-import { formatAmount, formatGasPrice, decodeTokenTransferInput, formatTokenAmount, hexToBigInt } from '../../../lib/helpers';
+import { formatAmount, formatGasPrice, decodeTokenTransferInput, formatTokenAmount, hexToBigInt, type DecodedTokenTransfer } from '../../../lib/helpers';
 import Badge from '../../../components/Badge';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import DetailRow from '../../../components/DetailRow';
@@ -34,6 +34,37 @@ function formatElapsed(seconds: number): string {
   const m = Math.floor(seconds / 60);
   const s = seconds % 60;
   return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+// QRC badge label + variant per decoded standard. Kept symmetric with
+// tx page's qrcBadgeText so a tx looks consistent before vs after mining.
+function badgeForDecoded(dt: DecodedTokenTransfer): { text: string; variant: 'brand' | 'warning' | 'info' } {
+  if (dt.methodName === 'setApprovalForAll') {
+    return { text: dt.standard === 'ERC-1155' ? 'QRC-1155 Approval' : 'NFT Approval', variant: 'info' };
+  }
+  if (dt.standard === 'ERC-721') return { text: 'QRC-721', variant: 'warning' };
+  if (dt.standard === 'ERC-1155') return { text: 'QRC-1155', variant: 'warning' };
+  return { text: 'QRC-20', variant: 'brand' };
+}
+
+function headerLabelFor(dt: DecodedTokenTransfer): string {
+  if (dt.methodName === 'setApprovalForAll') return 'Token Approval (Pending)';
+  if (dt.methodName === 'safeBatchTransferFrom') return 'Multi-Token Batch Transfer (Pending)';
+  if (dt.standard === 'ERC-721') return 'NFT Transfer (Pending)';
+  if (dt.standard === 'ERC-1155') return 'Multi-Token Transfer (Pending)';
+  return 'Token Transfer (Pending)';
+}
+
+function methodSignatureFor(dt: DecodedTokenTransfer): string {
+  switch (dt.methodName) {
+    case 'transfer':              return 'transfer(address, uint256)';
+    case 'transferFrom':          return 'transferFrom(address, address, uint256)';
+    case 'safeTransferFrom':      return dt.standard === 'ERC-1155'
+      ? 'safeTransferFrom(address, address, uint256, uint256, bytes)'
+      : 'safeTransferFrom(address, address, uint256)';
+    case 'safeBatchTransferFrom': return 'safeBatchTransferFrom(address, address, uint256[], uint256[], bytes)';
+    case 'setApprovalForAll':     return 'setApprovalForAll(address, bool)';
+  }
 }
 
 export default function PendingTransactionView({ pendingTx }: PendingTransactionViewProps): JSX.Element {
@@ -180,7 +211,10 @@ export default function PendingTransactionView({ pendingTx }: PendingTransaction
               <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
             </svg>
             <h1 className="text-xl sm:text-2xl font-bold text-[#ffa729]">Pending Transaction</h1>
-            {isTokenTransfer && <Badge variant="brand">Token Transfer</Badge>}
+            {decodedTransfer && (() => {
+              const b = badgeForDecoded(decodedTransfer);
+              return <Badge variant={b.variant}>{b.text}</Badge>;
+            })()}
           </div>
           <Badge variant="warning" size="md" dot>Pending</Badge>
         </div>
@@ -248,44 +282,117 @@ export default function PendingTransactionView({ pendingTx }: PendingTransaction
         </div>
       </div>
 
-      {/* Token Transfer Section */}
-      {isTokenTransfer && decodedTransfer && (
-        <div className="rounded-xl bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f] border border-[#3d3d3d] shadow-xl overflow-hidden mb-6">
-          <div className="px-4 sm:px-6 py-4 border-b border-[#3d3d3d]">
-            <div className="flex items-center gap-2">
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 text-[#ffa729]">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
-              </svg>
-              <h2 className="text-[15px] font-semibold text-[#ffa729]">Token Transfer (Pending)</h2>
-              <Badge variant="brand">QRC-20</Badge>
+      {/* Token call section. Layout branches on the decoded shape: ERC-20
+          shows recipient + raw amount (decimals unknown until confirmed);
+          ERC-721 / ERC-1155 surface tokenID(s) + value(s); setApprovalForAll
+          shows operator + on/off. Token name/symbol fill in once mined. */}
+      {decodedTransfer && (() => {
+        const b = badgeForDecoded(decodedTransfer);
+        const isApproval = decodedTransfer.methodName === 'setApprovalForAll';
+        const isBatch = decodedTransfer.methodName === 'safeBatchTransferFrom';
+        return (
+          <div className="rounded-xl bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f] border border-[#3d3d3d] shadow-xl overflow-hidden mb-6">
+            <div className="px-4 sm:px-6 py-4 border-b border-[#3d3d3d]">
+              <div className="flex items-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 text-[#ffa729]">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
+                </svg>
+                <h2 className="text-[15px] font-semibold text-[#ffa729]">{headerLabelFor(decodedTransfer)}</h2>
+                <Badge variant={b.variant}>{b.text}</Badge>
+              </div>
+            </div>
+            <div className="p-4 sm:p-6">
+              <DetailRow label="Method">
+                <span className="font-mono text-sm">{methodSignatureFor(decodedTransfer)}</span>
+              </DetailRow>
+
+              {/* setApprovalForAll(operator, approved) */}
+              {isApproval && (
+                <>
+                  <DetailRow label="Operator" mono>
+                    <Link
+                      href={`/address/${decodedTransfer.operator}`}
+                      className="text-[#ffa729] hover:text-[#ffb84d] transition-colors break-all"
+                    >
+                      {decodedTransfer.operator}
+                    </Link>
+                  </DetailRow>
+                  <DetailRow label="Approved">
+                    <Badge variant={decodedTransfer.approved ? 'success' : 'error'}>
+                      {decodedTransfer.approved ? 'true (granted)' : 'false (revoked)'}
+                    </Badge>
+                  </DetailRow>
+                </>
+              )}
+
+              {/* Transfer-like calls: From (when present) → To */}
+              {!isApproval && decodedTransfer.from && (
+                <DetailRow label="From" mono>
+                  <Link
+                    href={`/address/${decodedTransfer.from}`}
+                    className="text-gray-200 hover:text-[#ffa729] transition-colors break-all"
+                  >
+                    {decodedTransfer.from}
+                  </Link>
+                </DetailRow>
+              )}
+              {!isApproval && decodedTransfer.to && (
+                <DetailRow label={decodedTransfer.from ? 'To' : 'Recipient'} mono>
+                  <Link
+                    href={`/address/${decodedTransfer.to}`}
+                    className="text-[#ffa729] hover:text-[#ffb84d] transition-colors break-all"
+                  >
+                    {decodedTransfer.to}
+                  </Link>
+                </DetailRow>
+              )}
+
+              {/* ERC-20: raw amount (decimals unknown pre-confirmation) */}
+              {decodedTransfer.standard === 'ERC-20' && decodedTransfer.amount && (
+                <DetailRow label="Amount">
+                  <span className="font-semibold">{formatTokenAmount(decodedTransfer.amount, 18)}</span>
+                  <span className="text-gray-500 ml-2 text-xs">(raw: {decodedTransfer.amount}, assumes 18 decimals)</span>
+                </DetailRow>
+              )}
+
+              {/* ERC-721 / ERC-1155 single */}
+              {!isBatch && decodedTransfer.tokenID && (
+                <DetailRow label="Token ID" mono>
+                  <span className="font-semibold text-white">#{decodedTransfer.tokenID}</span>
+                </DetailRow>
+              )}
+              {decodedTransfer.standard === 'ERC-1155' && !isBatch && decodedTransfer.value && (
+                <DetailRow label="Quantity">
+                  <span className="font-semibold text-white">
+                    {(() => { try { return BigInt(decodedTransfer.value).toLocaleString('en-US'); } catch { return decodedTransfer.value; } })()}
+                  </span>
+                </DetailRow>
+              )}
+
+              {/* ERC-1155 batch: list each (id, qty) row */}
+              {isBatch && decodedTransfer.ids && decodedTransfer.values && (
+                <DetailRow label="Batch">
+                  <div className="flex flex-col gap-1 mt-1">
+                    {decodedTransfer.ids.map((id, i) => (
+                      <div key={`${id}-${i}`} className="font-mono text-xs text-gray-200">
+                        <span className="text-[#ffa729]">#{id}</span>
+                        <span className="text-gray-500"> x </span>
+                        <span>{(() => { try { return BigInt(decodedTransfer.values![i]).toLocaleString('en-US'); } catch { return decodedTransfer.values![i]; } })()}</span>
+                      </div>
+                    ))}
+                  </div>
+                </DetailRow>
+              )}
+
+              <p className="text-xs text-gray-500 mt-3">
+                {isApproval
+                  ? 'Approval will take effect once the transaction is confirmed.'
+                  : 'Token name and symbol will be available once the transaction is confirmed.'}
+              </p>
             </div>
           </div>
-          <div className="p-4 sm:p-6">
-            <DetailRow label="Method">
-              <span className="font-mono text-sm">
-                {decodedTransfer.methodName === 'transferFrom'
-                  ? `${decodedTransfer.methodName}(address, address, uint256)`
-                  : `${decodedTransfer.methodName}(address, uint256)`}
-              </span>
-            </DetailRow>
-            <DetailRow label="Amount">
-              <span className="font-semibold">{formatTokenAmount(decodedTransfer.amount, 18)}</span>
-              <span className="text-gray-500 ml-2 text-xs">(raw: {decodedTransfer.amount})</span>
-            </DetailRow>
-            <DetailRow label="Recipient" mono>
-              <Link
-                href={`/address/${decodedTransfer.to}`}
-                className="text-[#ffa729] hover:text-[#ffb84d] transition-colors break-all"
-              >
-                {decodedTransfer.to}
-              </Link>
-            </DetailRow>
-            <p className="text-xs text-gray-500 mt-3">
-              Token name and symbol will be available once the transaction is confirmed.
-            </p>
-          </div>
-        </div>
-      )}
+        );
+      })()}
 
       {/* Input Data Section */}
       {pendingTx.input && pendingTx.input !== '0x' && (

--- a/ExplorerFrontend/app/tx/[query]/page.tsx
+++ b/ExplorerFrontend/app/tx/[query]/page.tsx
@@ -68,7 +68,7 @@ async function getTransaction(txHash: string): Promise<TransactionDetails> {
     latestBlock: data.latestBlock,
     PaidFees: txData.PaidFees ? Number(txData.PaidFees) : undefined,
     contractCreated: data.contractCreated || undefined,
-    tokenTransfer: data.tokenTransfer || undefined
+    tokenTransfers: Array.isArray(data.tokenTransfers) ? data.tokenTransfers : undefined,
   };
 
   return transaction;

--- a/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
+++ b/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
@@ -48,6 +48,28 @@ const formatTimestamp = (timestamp: number): string => {
 const isZeroAddress = (addr: string): boolean =>
   addr === 'Q0' || addr === 'Q' + '0'.repeat(40);
 
+// QRC badge label for a token standard. Keeps the contract-created header
+// and per-row transfer header in lock-step, both branch on the same
+// syncer-supplied tokenStandard value (mirrors backendAPI ContractInfo +
+// TokenTransfer). Anything we don't recognise falls back to QRC-20 so the
+// UI stays usable on legacy un-tagged rows.
+function qrcBadgeText(standard?: string): string {
+  if (standard === 'ERC-721') return 'QRC-721';
+  if (standard === 'ERC-1155') return 'QRC-1155';
+  return 'QRC-20';
+}
+
+// ERC-1155 amounts are integer counts (no decimals on chain) but still
+// benefit from thousands separators on multi-digit values. Falls back to
+// the raw string if BigInt rejects it.
+function formatErc1155Amount(amount: string): string {
+  try {
+    return BigInt(amount).toLocaleString('en-US');
+  } catch {
+    return amount;
+  }
+}
+
 interface TransactionViewProps {
   transaction: TransactionDetails;
 }
@@ -180,7 +202,19 @@ export default function TransactionView({ transaction }: TransactionViewProps): 
       </div>
 
       {/* Contract Creation Section */}
-      {transaction.contractCreated && (
+      {transaction.contractCreated && (() => {
+        const cc = transaction.contractCreated;
+        const ccStandard = cc.tokenStandard;
+        // ERC-1155 contracts often leave name()/symbol() unimplemented, the
+        // standard requires neither. Fall back to a placeholder rather than
+        // hiding the row, since the badge already tells the user it's a
+        // token contract.
+        const tokenLabel = cc.name
+          ? `${cc.name}${cc.symbol && cc.symbol !== cc.name ? ` (${cc.symbol})` : ''}`
+          : cc.symbol
+            ? `(${cc.symbol})`
+            : 'Unnamed Collection';
+        return (
         <div className="rounded-xl bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f] border border-[#3d3d3d] shadow-xl overflow-hidden mb-6">
           <div className="px-4 sm:px-6 py-4 border-b border-[#3d3d3d]">
             <div className="flex items-center gap-2">
@@ -188,55 +222,53 @@ export default function TransactionView({ transaction }: TransactionViewProps): 
                 <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               <h2 className="text-[15px] font-semibold text-green-400">Contract Created</h2>
-              {transaction.contractCreated.isToken && <Badge variant="brand">QRC-20 Token</Badge>}
+              {cc.isToken && (
+                <Badge variant={ccStandard === 'ERC-721' || ccStandard === 'ERC-1155' ? 'warning' : 'brand'}>
+                  {qrcBadgeText(ccStandard)} Token
+                </Badge>
+              )}
             </div>
           </div>
           <div className="p-4 sm:p-6">
             <DetailRow label="Contract Address" mono>
               <Link
-                href={`/address/${transaction.contractCreated.address}`}
+                href={`/address/${cc.address}`}
                 className="text-[#ffa729] hover:text-[#ffb84d] transition-colors break-all"
               >
-                {displayAddr(transaction.contractCreated.address)}
+                {displayAddr(cc.address)}
               </Link>
             </DetailRow>
-            {transaction.contractCreated.isToken && transaction.contractCreated.name && (
+            {cc.isToken && (
               <DetailRow label="Token">
-                <span className="font-medium text-white">
-                  {transaction.contractCreated.name} ({transaction.contractCreated.symbol})
-                </span>
+                <span className="font-medium text-white">{tokenLabel}</span>
               </DetailRow>
             )}
           </div>
         </div>
-      )}
+        );
+      })()}
 
-      {/* Token Transfer Section */}
-      {transaction.tokenTransfer && (() => {
-        const tt = transaction.tokenTransfer;
-        // Per-standard presentation. The header badge reflects the chain
-        // standard (QRC-20 / QRC-721 / QRC-1155); ERC-721 transfers always
-        // move exactly one token, so we surface the tokenID rather than an
-        // ABI-encoded amount.
-        const standard = tt.tokenStandard;
-        const headerLabel =
-          standard === 'ERC-721' ? 'NFT Transfer'
-          : standard === 'ERC-1155' ? 'Multi-Token Transfer'
-          : 'Token Transfer';
-        const badgeText =
-          standard === 'ERC-721' ? 'QRC-721'
-          : standard === 'ERC-1155' ? 'QRC-1155'
-          : 'QRC-20';
-        const isNFT = standard === 'ERC-721' || standard === 'ERC-1155';
-        return (
-        <div className="rounded-xl bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f] border border-[#3d3d3d] shadow-xl overflow-hidden mb-6">
+      {/* Token Transfer Section(s). A single tx can emit several Transfer
+          events (DEX swaps, ERC-1155 TransferBatch fan-out), each persisted
+          as its own row, so we render one card per row. */}
+      {transaction.tokenTransfers && transaction.tokenTransfers.length > 0 &&
+        transaction.tokenTransfers.map((tt, idx) => {
+          const standard = tt.tokenStandard;
+          const headerLabel =
+            standard === 'ERC-721' ? 'NFT Transfer'
+            : standard === 'ERC-1155' ? 'Multi-Token Transfer'
+            : 'Token Transfer';
+          const isNFT = standard === 'ERC-721' || standard === 'ERC-1155';
+          const rowKey = tt.logIndex || `${tt.contractAddress}-${idx}`;
+          return (
+        <div key={rowKey} className="rounded-xl bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f] border border-[#3d3d3d] shadow-xl overflow-hidden mb-6">
           <div className="px-4 sm:px-6 py-4 border-b border-[#3d3d3d]">
             <div className="flex items-center gap-2">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 text-[#ffa729]">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
               </svg>
               <h2 className="text-[15px] font-semibold text-[#ffa729]">{headerLabel}</h2>
-              <Badge variant={isNFT ? 'warning' : 'brand'}>{badgeText}</Badge>
+              <Badge variant={isNFT ? 'warning' : 'brand'}>{qrcBadgeText(standard)}</Badge>
             </div>
           </div>
           <div className="p-4 sm:p-6">
@@ -258,7 +290,7 @@ export default function TransactionView({ transaction }: TransactionViewProps): 
               <DetailRow label="Amount">
                 <span className="font-semibold text-white">
                   {standard === 'ERC-1155'
-                    ? tt.amount
+                    ? formatErc1155Amount(tt.amount)
                     : formatTokenAmount(tt.amount, tt.tokenDecimals)}
                 </span>
                 {tt.tokenSymbol && (
@@ -303,8 +335,8 @@ export default function TransactionView({ transaction }: TransactionViewProps): 
             </DetailRow>
           </div>
         </div>
-        );
-      })()}
+          );
+        })}
     </div>
   );
 }

--- a/ExplorerFrontend/app/types/transaction.ts
+++ b/ExplorerFrontend/app/types/transaction.ts
@@ -98,6 +98,8 @@ export interface TokenTransferInfo {
   tokenStandard?: TokenStandard | string;
   /** uint256 decimal string. Populated for ERC-721 + ERC-1155 transfers. */
   tokenID?: string;
+  /** Hex log index, used as a stable React key when a tx emits several events. */
+  logIndex?: string;
 }
 
 /**
@@ -124,7 +126,7 @@ export interface TransactionDetails {
     decimals: number;
     tokenStandard?: TokenStandard | string;
   };
-  tokenTransfer?: TokenTransferInfo;
+  tokenTransfers?: TokenTransferInfo[];
 }
 
 /**

--- a/backendAPI/db/token.go
+++ b/backendAPI/db/token.go
@@ -4,6 +4,8 @@ import (
 	"backendAPI/configs"
 	"backendAPI/models"
 	"context"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -553,13 +555,7 @@ func GetTokenTransfersByTxHash(txHash string) ([]models.TokenTransfer, error) {
 		normalizedHash = "0x" + normalizedHash
 	}
 
-	// Stable order: logIndex ascending preserves event emission order within
-	// the tx. Legacy direct-calldata rows (logIndex == "") sort first, which
-	// matches what users expect when both a synthetic row and event rows
-	// exist for the same call.
-	opts := options.Find().SetSort(bson.D{{Key: "logIndex", Value: 1}})
-
-	cursor, err := collection.Find(ctx, bson.M{"txHash": normalizedHash}, opts)
+	cursor, err := collection.Find(ctx, bson.M{"txHash": normalizedHash})
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
 			return []models.TokenTransfer{}, nil
@@ -575,7 +571,36 @@ func GetTokenTransfersByTxHash(txHash string) ([]models.TokenTransfer, error) {
 	if transfers == nil {
 		transfers = []models.TokenTransfer{}
 	}
+
+	// Sort by logIndex ascending so emission order is preserved within the
+	// tx. logIndex is persisted as a "0x..." hex string, sorting it as a
+	// BSON string would put "0xa" after "0x10" because string comparison is
+	// lexicographic. Sort numerically here instead. Legacy direct-calldata
+	// rows have an empty logIndex and we pin them to the front (sort key -1)
+	// so a synthetic row and any later event rows for the same call stay
+	// in a stable, intuitive order.
+	sort.SliceStable(transfers, func(i, j int) bool {
+		return logIndexSortKey(transfers[i].LogIndex) < logIndexSortKey(transfers[j].LogIndex)
+	})
+
 	return transfers, nil
+}
+
+// logIndexSortKey turns a "0x..." hex string into an int64 for ascending
+// sort. Empty input maps to -1 to keep legacy synthetic rows first.
+// Malformed input falls back to 0, the worst case is a stable but slightly
+// out-of-order row (never a panic, the syncer's own data path is the only
+// writer of this field and always emits a clean hex string).
+func logIndexSortKey(s string) int64 {
+	if s == "" {
+		return -1
+	}
+	trimmed := strings.TrimPrefix(strings.ToLower(s), "0x")
+	v, err := strconv.ParseInt(trimmed, 16, 64)
+	if err != nil {
+		return 0
+	}
+	return v
 }
 
 // GetNFTBalancesByAddress returns per-(contract, tokenID) NFT holdings for

--- a/backendAPI/db/token.go
+++ b/backendAPI/db/token.go
@@ -529,31 +529,53 @@ func GetTokenInfo(contractAddress string) (*models.TokenInfo, error) {
 	}, nil
 }
 
-// GetTokenTransferByTxHash returns token transfer info for a given transaction hash.
-// Returns nil, nil if no token transfer is associated with this transaction.
-// The syncer stores txHash with a lowercase 0x prefix; we normalize to that form.
-func GetTokenTransferByTxHash(txHash string) (*models.TokenTransfer, error) {
+// GetTokenTransfersByTxHash returns every token transfer row associated with
+// a given transaction hash. A single tx can produce multiple rows:
+//
+//   - DEX swaps emit several ERC-20 Transfer events (router, pool, recipient).
+//   - ERC-1155 TransferBatch is fanned out one row per (id, value) tuple by
+//     the syncer.
+//
+// FindOne-style readers silently dropped everything past the first row, so
+// only the first transfer ever rendered on the tx page. Returns an empty
+// slice (not nil) when nothing matches.
+//
+// The syncer stores txHash lowercase with a 0x prefix; we normalize input
+// the same way before querying.
+func GetTokenTransfersByTxHash(txHash string) ([]models.TokenTransfer, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	collection := configs.GetCollection(configs.DB, "tokenTransfers")
 
-	// Canonical storage format: lowercase with 0x prefix.
 	normalizedHash := strings.ToLower(txHash)
 	if !strings.HasPrefix(normalizedHash, "0x") {
 		normalizedHash = "0x" + normalizedHash
 	}
 
-	var transfer models.TokenTransfer
-	err := collection.FindOne(ctx, bson.M{"txHash": normalizedHash}).Decode(&transfer)
-	if err == nil {
-		return &transfer, nil
-	}
-	if err != mongo.ErrNoDocuments {
+	// Stable order: logIndex ascending preserves event emission order within
+	// the tx. Legacy direct-calldata rows (logIndex == "") sort first, which
+	// matches what users expect when both a synthetic row and event rows
+	// exist for the same call.
+	opts := options.Find().SetSort(bson.D{{Key: "logIndex", Value: 1}})
+
+	cursor, err := collection.Find(ctx, bson.M{"txHash": normalizedHash}, opts)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return []models.TokenTransfer{}, nil
+		}
 		return nil, err
 	}
+	defer cursor.Close(ctx)
 
-	return nil, nil
+	var transfers []models.TokenTransfer
+	if err := cursor.All(ctx, &transfers); err != nil {
+		return nil, err
+	}
+	if transfers == nil {
+		transfers = []models.TokenTransfer{}
+	}
+	return transfers, nil
 }
 
 // GetNFTBalancesByAddress returns per-(contract, tokenID) NFT holdings for

--- a/backendAPI/models/token_balance.go
+++ b/backendAPI/models/token_balance.go
@@ -28,7 +28,14 @@ type TokenBalancesResponse struct {
 	Count   int            `json:"count"`
 }
 
-// TokenTransfer represents a token transfer event
+// TokenTransfer represents a token transfer event.
+//
+// TokenStandard / TokenID / LogIndex mirror the syncer's struct
+// (QRL2MongoDB/models/tokentransfer.go). Without them the BSON decoder
+// silently strips the fields off the persisted document and the tx page
+// can't tell an NFT transfer from a fungible one. LogIndex is required
+// to disambiguate multiple events in the same tx (DEX swaps, ERC-1155
+// TransferBatch fan-out).
 type TokenTransfer struct {
 	ContractAddress string `json:"contractAddress" bson:"contractAddress"`
 	From            string `json:"from" bson:"from"`
@@ -36,11 +43,14 @@ type TokenTransfer struct {
 	Amount          string `json:"amount" bson:"amount"`
 	BlockNumber     string `json:"blockNumber" bson:"blockNumber"`
 	TxHash          string `json:"txHash" bson:"txHash"`
+	LogIndex        string `json:"logIndex,omitempty" bson:"logIndex,omitempty"`
 	Timestamp       string `json:"timestamp" bson:"timestamp"`
 	TokenSymbol     string `json:"tokenSymbol" bson:"tokenSymbol"`
 	TokenDecimals   int    `json:"tokenDecimals" bson:"tokenDecimals"`
 	TokenName       string `json:"tokenName" bson:"tokenName"`
 	TransferType    string `json:"transferType" bson:"transferType"`
+	TokenStandard   string `json:"tokenStandard,omitempty" bson:"tokenStandard,omitempty"`
+	TokenID         string `json:"tokenID,omitempty" bson:"tokenID,omitempty"`
 }
 
 // NFTBalance is one row of GET /address/:addr/nfts: the holder's

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -411,10 +411,12 @@ func UserRoute(router *gin.Engine) {
 			log.Printf("Error checking for contract creation tx %s: %v", value, err)
 		}
 
-		// Check if this transaction is a token transfer
-		tokenTransfer, err := db.GetTokenTransferByTxHash(value)
+		// Check if this transaction is a token transfer. A single tx can
+		// emit multiple Transfer events (DEX swaps, ERC-1155 TransferBatch
+		// fan-out), so we surface them all as an array.
+		tokenTransfers, err := db.GetTokenTransfersByTxHash(value)
 		if err != nil {
-			log.Printf("Error checking for token transfer tx %s: %v", value, err)
+			log.Printf("Error checking for token transfers tx %s: %v", value, err)
 		}
 
 		response := gin.H{
@@ -424,24 +426,32 @@ func UserRoute(router *gin.Engine) {
 
 		if contractCreated != nil {
 			response["contractCreated"] = gin.H{
-				"address":  contractCreated.ContractAddress,
-				"isToken":  contractCreated.IsToken,
-				"name":     contractCreated.TokenName,
-				"symbol":   contractCreated.TokenSymbol,
-				"decimals": contractCreated.TokenDecimals,
+				"address":       contractCreated.ContractAddress,
+				"isToken":       contractCreated.IsToken,
+				"name":          contractCreated.TokenName,
+				"symbol":        contractCreated.TokenSymbol,
+				"decimals":      contractCreated.TokenDecimals,
+				"tokenStandard": contractCreated.TokenStandard,
 			}
 		}
 
-		if tokenTransfer != nil {
-			response["tokenTransfer"] = gin.H{
-				"contractAddress": tokenTransfer.ContractAddress,
-				"from":            tokenTransfer.From,
-				"to":              tokenTransfer.To,
-				"amount":          tokenTransfer.Amount,
-				"tokenName":       tokenTransfer.TokenName,
-				"tokenSymbol":     tokenTransfer.TokenSymbol,
-				"tokenDecimals":   tokenTransfer.TokenDecimals,
+		if len(tokenTransfers) > 0 {
+			rows := make([]gin.H, 0, len(tokenTransfers))
+			for _, t := range tokenTransfers {
+				rows = append(rows, gin.H{
+					"contractAddress": t.ContractAddress,
+					"from":            t.From,
+					"to":              t.To,
+					"amount":          t.Amount,
+					"tokenName":       t.TokenName,
+					"tokenSymbol":     t.TokenSymbol,
+					"tokenDecimals":   t.TokenDecimals,
+					"tokenStandard":   t.TokenStandard,
+					"tokenID":         t.TokenID,
+					"logIndex":        t.LogIndex,
+				})
 			}
+			response["tokenTransfers"] = rows
 		}
 
 		c.JSON(http.StatusOK, response)


### PR DESCRIPTION
## Summary

The recent NFT support tagged contracts and transfer rows with `tokenStandard` / `tokenID`, but the transaction page (`/tx/[query]` and `/pending/tx/[hash]`) was never updated to read it. Every NFT deploy still rendered as "QRC-20 Token" and every NFT transfer rendered with ERC-20 semantics. Surfaced by [zondscan.com/tx/0xb5736f42...](https://zondscan.com/tx/0xb5736f42f8e6e2e6877d9a07040c4cae8d1f231d3d88b127ade4db60a29a3817) showing "Contract Created QRC-20 Token" for [`Q9b974af2...`](https://zondscan.com/address/Q9b974af258805b3b4254eab61a80c250e1b7f9f8), which is actually an ERC-1155.

## Backend (`/tx/:hash`)
- Add `TokenStandard` / `TokenID` / `LogIndex` to `models.TokenTransfer` so the BSON decode stops silently stripping the syncer's fields.
- Rename `GetTokenTransferByTxHash` → `GetTokenTransfersByTxHash` and return all matching rows. Multi-event txs (DEX swaps emit 3, ERC-1155 `TransferBatch` is fanned out one row per `(id, value)` tuple) were hidden behind a `FindOne`.
- Emit `tokenTransfers` as an array, include `tokenStandard` / `tokenID` / `logIndex` per row. Add `tokenStandard` to the `contractCreated` payload.

## Frontend confirmed tx page
- Branch the Contract Created badge on `tokenStandard` (was hardcoded "QRC-20 Token" even for ERC-1155 deploys, the report case).
- Render the Token row even when `name`/`symbol` are empty (ERC-1155 contracts commonly leave them unimplemented).
- Map `tokenTransfers` as an array so multi-row txs render every event.
- Format ERC-1155 amounts with `toLocaleString` instead of dumping the raw integer.

## Frontend pending tx page
- Extend `decodeTokenTransferInput` with ERC-721 `safeTransferFrom` (`0x42842e0e`, `0xb88d4fde`), ERC-1155 `safeTransferFrom` (`0xf242432a`), `safeBatchTransferFrom` (`0x2eb2c2d6`), and `setApprovalForAll` (`0xa22cb465`).
- Rework the pending Token Transfer card to branch on the decoded standard + method: ERC-20 keeps amount + recipient, ERC-721 shows `tokenID`, ERC-1155 shows `tokenID` + quantity (and a batch table for the batch variant), `setApprovalForAll` shows operator + on/off.

## Test plan

- [x] `go build ./...` + `go vet ./...` clean (backendAPI)
- [x] `npx tsc --noEmit` clean (ExplorerFrontend)
- [x] `npx next build` succeeds
- [x] `npm run lint` introduces no new errors or warnings on the edited files (one pre-existing error in `contracts-client.tsx:178` unrelated to this PR)
- [ ] Manual smoke on prod after deploy: open the reported tx (`0xb5736f42...`) and confirm "QRC-1155 Token" badge + collection address render correctly.
- [ ] Manual smoke: open a confirmed QRC-20 transfer tx and confirm formatted amount + symbol still render as before.
- [ ] Manual smoke: open a confirmed ERC-1155 mint tx and confirm tokenID + quantity render with thousands-separator.

## Breaking change
The `/tx/:hash` response now emits `tokenTransfers: [...]` (array) instead of `tokenTransfer: {...}` (single). Only the explorer frontend consumes this; no external API contract.