### PR TITLE
feat(tx-page): add Event Logs panel + Input Data card

### DIFF
--- a/ExplorerFrontend/app/lib/helpers.ts
+++ b/ExplorerFrontend/app/lib/helpers.ts
@@ -666,8 +666,9 @@ export function decodeEventLog(topics: string[], data: string): DecodedEvent | n
     }
 
     case TOPIC_APPROVAL_FOR_ALL: {
-      // ERC-721 + ERC-1155 share this signature exactly; we don't try to
-      // tell them apart since the rendered fields are identical.
+      // ERC-721 + ERC-1155 share this signature exactly; we tag it as
+      // ERC-721 (the older standard) purely so the view picks the NFT
+      // badge variant. The rendered fields are identical for both.
       let approved = false;
       try {
         approved = BigInt('0x' + safeData.slice(2, 66)) !== BigInt(0);
@@ -677,6 +678,7 @@ export function decodeEventLog(topics: string[], data: string): DecodedEvent | n
       return {
         name: 'ApprovalForAll',
         signature: 'ApprovalForAll(address owner, address operator, bool approved)',
+        standard: 'ERC-721',
         args: [
           { label: 'owner', type: 'address', value: topicToAddress(topics[1]) },
           { label: 'operator', type: 'address', value: topicToAddress(topics[2]) },

--- a/ExplorerFrontend/app/lib/helpers.ts
+++ b/ExplorerFrontend/app/lib/helpers.ts
@@ -517,6 +517,219 @@ export function decodeTokenTransferInput(inputData: string | undefined | null): 
 }
 
 /**
+ * One decoded receipt-log argument. The frontend renders each arg per its
+ * `type`: addresses get a /address link, uint256 gets a mono-formatted
+ * value (locale-grouped when large), bool gets a badge, uint256[] gets a
+ * batch list. Unknown types fall back to the raw `value` string.
+ */
+export interface DecodedEventArg {
+  label: string;
+  type: 'address' | 'uint256' | 'bool' | 'uint256[]';
+  value?: string;
+  values?: string[];
+}
+
+export interface DecodedEvent {
+  /** Canonical event name (e.g. "Transfer", "ApprovalForAll"). */
+  name: string;
+  /** Event signature, e.g. "Transfer(address,address,uint256)". */
+  signature: string;
+  /** ERC-20 / ERC-721 / ERC-1155 hint for Transfer/Approval rendering. */
+  standard?: 'ERC-20' | 'ERC-721' | 'ERC-1155';
+  args: DecodedEventArg[];
+}
+
+// keccak256 topic hashes for the well-known token events. These are
+// stable across every EVM chain that follows the standards.
+const TOPIC_TRANSFER = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+const TOPIC_TRANSFER_SINGLE = '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62';
+const TOPIC_TRANSFER_BATCH = '0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb';
+const TOPIC_APPROVAL = '0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925';
+const TOPIC_APPROVAL_FOR_ALL = '0x17307eab39ab6107e8899845ad3d59bd9653f200f220920489ca2b5937696c31';
+
+// Decode a 32-byte address slot ("0x" + 64 hex chars) to Q-prefix form.
+function topicToAddress(t: string): string {
+  if (!t) return '';
+  const hex = t.startsWith('0x') ? t.slice(2) : t;
+  return 'Q' + hex.slice(-40);
+}
+
+// Decode a 32-byte uint256 slot to a decimal string. Safe on missing input.
+function topicToUint(t: string): string {
+  if (!t) return '0';
+  try {
+    return BigInt(t.startsWith('0x') ? t : '0x' + t).toString();
+  } catch {
+    return '0';
+  }
+}
+
+// Slice a uint256 out of an ABI-encoded data field at the given char offset
+// (`data` is "0x..." prefixed; offset is from the start of the string).
+function dataUint(data: string, charOffset: number): string {
+  try {
+    return BigInt('0x' + data.slice(charOffset, charOffset + 64)).toString();
+  } catch {
+    return '0';
+  }
+}
+
+// Decode a dynamic uint256[] starting at `arrCharOffset` in `data`. Same
+// bounded/safe shape as abiUintArray above. Returns [] on bad input.
+function dataUintArray(data: string, arrCharOffset: number): string[] {
+  const lenHex = data.slice(arrCharOffset, arrCharOffset + 64);
+  if (lenHex.length < 64) return [];
+  let lenBig: bigint;
+  try {
+    lenBig = BigInt('0x' + lenHex);
+  } catch {
+    return [];
+  }
+  const MAX_ITEMS = 1024;
+  if (lenBig > BigInt(MAX_ITEMS)) return [];
+  const len = Number(lenBig);
+  if (arrCharOffset + 64 + len * 64 > data.length) return [];
+  const out: string[] = [];
+  for (let i = 0; i < len; i++) {
+    out.push(dataUint(data, arrCharOffset + 64 + i * 64));
+  }
+  return out;
+}
+
+/**
+ * Decode a single receipt-log topics/data pair into a labelled event.
+ * Recognises the five well-known token signatures; returns null for
+ * anything else so the view can render a raw fallback (topics + data).
+ *
+ * Disambiguation:
+ *   - Transfer / Approval are shared between ERC-20 and ERC-721. ERC-721
+ *     indexes all three params (4 topics, empty data); ERC-20 indexes the
+ *     two addresses only (3 topics, value in data). We branch on
+ *     topics.length to pick the right decoder + standard tag.
+ */
+export function decodeEventLog(topics: string[], data: string): DecodedEvent | null {
+  if (!topics || topics.length === 0) return null;
+  const sig = (topics[0] || '').toLowerCase();
+  const safeData = (data || '0x').toLowerCase();
+
+  switch (sig) {
+    case TOPIC_TRANSFER: {
+      // ERC-721 indexes the tokenId → 4 topics; ERC-20 keeps value in data.
+      if (topics.length === 4) {
+        return {
+          name: 'Transfer',
+          signature: 'Transfer(address from, address to, uint256 tokenId)',
+          standard: 'ERC-721',
+          args: [
+            { label: 'from', type: 'address', value: topicToAddress(topics[1]) },
+            { label: 'to', type: 'address', value: topicToAddress(topics[2]) },
+            { label: 'tokenId', type: 'uint256', value: topicToUint(topics[3]) },
+          ],
+        };
+      }
+      return {
+        name: 'Transfer',
+        signature: 'Transfer(address from, address to, uint256 value)',
+        standard: 'ERC-20',
+        args: [
+          { label: 'from', type: 'address', value: topicToAddress(topics[1]) },
+          { label: 'to', type: 'address', value: topicToAddress(topics[2]) },
+          { label: 'value', type: 'uint256', value: dataUint(safeData, 2) },
+        ],
+      };
+    }
+
+    case TOPIC_APPROVAL: {
+      // Same ERC-20 vs ERC-721 split as Transfer.
+      if (topics.length === 4) {
+        return {
+          name: 'Approval',
+          signature: 'Approval(address owner, address approved, uint256 tokenId)',
+          standard: 'ERC-721',
+          args: [
+            { label: 'owner', type: 'address', value: topicToAddress(topics[1]) },
+            { label: 'approved', type: 'address', value: topicToAddress(topics[2]) },
+            { label: 'tokenId', type: 'uint256', value: topicToUint(topics[3]) },
+          ],
+        };
+      }
+      return {
+        name: 'Approval',
+        signature: 'Approval(address owner, address spender, uint256 value)',
+        standard: 'ERC-20',
+        args: [
+          { label: 'owner', type: 'address', value: topicToAddress(topics[1]) },
+          { label: 'spender', type: 'address', value: topicToAddress(topics[2]) },
+          { label: 'value', type: 'uint256', value: dataUint(safeData, 2) },
+        ],
+      };
+    }
+
+    case TOPIC_APPROVAL_FOR_ALL: {
+      // ERC-721 + ERC-1155 share this signature exactly; we don't try to
+      // tell them apart since the rendered fields are identical.
+      let approved = false;
+      try {
+        approved = BigInt('0x' + safeData.slice(2, 66)) !== BigInt(0);
+      } catch {
+        approved = false;
+      }
+      return {
+        name: 'ApprovalForAll',
+        signature: 'ApprovalForAll(address owner, address operator, bool approved)',
+        args: [
+          { label: 'owner', type: 'address', value: topicToAddress(topics[1]) },
+          { label: 'operator', type: 'address', value: topicToAddress(topics[2]) },
+          { label: 'approved', type: 'bool', value: approved ? 'true' : 'false' },
+        ],
+      };
+    }
+
+    case TOPIC_TRANSFER_SINGLE: {
+      // operator + from + to are indexed; data = abi.encode(id, value)
+      return {
+        name: 'TransferSingle',
+        signature: 'TransferSingle(address operator, address from, address to, uint256 id, uint256 value)',
+        standard: 'ERC-1155',
+        args: [
+          { label: 'operator', type: 'address', value: topicToAddress(topics[1]) },
+          { label: 'from', type: 'address', value: topicToAddress(topics[2]) },
+          { label: 'to', type: 'address', value: topicToAddress(topics[3]) },
+          { label: 'id', type: 'uint256', value: dataUint(safeData, 2) },
+          { label: 'value', type: 'uint256', value: dataUint(safeData, 66) },
+        ],
+      };
+    }
+
+    case TOPIC_TRANSFER_BATCH: {
+      // operator + from + to indexed; data = abi.encode(uint256[] ids, uint256[] values).
+      // Two leading offsets point to the length+elements of each array,
+      // measured in bytes from the start of the args block. data is
+      // "0x"-prefixed so we add 2 to convert byte offsets to char positions.
+      const idsOff = (() => { try { return Number(BigInt('0x' + safeData.slice(2, 66))) * 2 + 2; } catch { return -1; } })();
+      const valsOff = (() => { try { return Number(BigInt('0x' + safeData.slice(66, 130))) * 2 + 2; } catch { return -1; } })();
+      const ids = idsOff > 0 ? dataUintArray(safeData, idsOff) : [];
+      const values = valsOff > 0 ? dataUintArray(safeData, valsOff) : [];
+      return {
+        name: 'TransferBatch',
+        signature: 'TransferBatch(address operator, address from, address to, uint256[] ids, uint256[] values)',
+        standard: 'ERC-1155',
+        args: [
+          { label: 'operator', type: 'address', value: topicToAddress(topics[1]) },
+          { label: 'from', type: 'address', value: topicToAddress(topics[2]) },
+          { label: 'to', type: 'address', value: topicToAddress(topics[3]) },
+          { label: 'ids', type: 'uint256[]', values: ids },
+          { label: 'values', type: 'uint256[]', values: values },
+        ],
+      };
+    }
+
+    default:
+      return null;
+  }
+}
+
+/**
  * Converts a smallest-unit integer string to a decimal string using BigInt (no floating-point).
  * E.g. smallestUnitToDecimal("200000000000", 18) => "0.0000002"
  */

--- a/ExplorerFrontend/app/tx/[query]/page.tsx
+++ b/ExplorerFrontend/app/tx/[query]/page.tsx
@@ -69,6 +69,8 @@ async function getTransaction(txHash: string): Promise<TransactionDetails> {
     PaidFees: txData.PaidFees ? Number(txData.PaidFees) : undefined,
     contractCreated: data.contractCreated || undefined,
     tokenTransfers: Array.isArray(data.tokenTransfers) ? data.tokenTransfers : undefined,
+    input: txData.Input || undefined,
+    logs: Array.isArray(data.logs) ? data.logs : undefined,
   };
 
   return transaction;

--- a/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
+++ b/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { type TransactionDetails, getConfirmations, getTransactionStatus } from '@/app/types';
-import { formatAmount, formatTokenAmount } from '../../lib/helpers';
+import { formatAmount, formatTokenAmount, decodeEventLog, decodeTokenTransferInput } from '../../lib/helpers';
 import CopyButton from '../../components/CopyButton';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import DetailRow from '../../components/DetailRow';
@@ -337,6 +337,137 @@ export default function TransactionView({ transaction }: TransactionViewProps): 
         </div>
           );
         })}
+
+      {/* Event Logs Panel. Decodes the five well-known token signatures
+          (Transfer / TransferSingle / TransferBatch / Approval /
+          ApprovalForAll) inline; everything else falls back to topics +
+          data so users can copy them into a decoder. */}
+      {transaction.logs && transaction.logs.length > 0 && (
+        <div className="rounded-xl bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f] border border-[#3d3d3d] shadow-xl overflow-hidden mb-6">
+          <div className="px-4 sm:px-6 py-4 border-b border-[#3d3d3d]">
+            <div className="flex items-center gap-2">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 text-[#ffa729]">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+              </svg>
+              <h2 className="text-[15px] font-semibold text-[#ffa729]">Event Logs</h2>
+              <Badge variant="neutral">{transaction.logs.length}</Badge>
+            </div>
+          </div>
+          <div className="p-4 sm:p-6 space-y-4">
+            {transaction.logs.map((logEntry) => {
+              const decoded = decodeEventLog(logEntry.topics, logEntry.data);
+              const idxLabel = (() => { try { return parseInt(logEntry.logIndex || '0x0', 16).toString(); } catch { return logEntry.logIndex; } })();
+              return (
+                <div key={`${logEntry.address}-${logEntry.logIndex}`} className="rounded-lg bg-[#1a1a1a]/60 border border-[#3d3d3d] p-3 sm:p-4">
+                  <div className="flex flex-wrap items-center gap-2 mb-2">
+                    <Badge variant="neutral">#{idxLabel}</Badge>
+                    {decoded ? (
+                      <>
+                        <Badge variant={decoded.standard === 'ERC-721' || decoded.standard === 'ERC-1155' ? 'warning' : 'brand'}>
+                          {decoded.name}
+                        </Badge>
+                        {decoded.standard && (
+                          <span className="text-xs text-gray-500 font-mono">{decoded.standard}</span>
+                        )}
+                      </>
+                    ) : (
+                      <Badge variant="neutral">Raw</Badge>
+                    )}
+                    <Link
+                      href={`/address/${logEntry.address}`}
+                      className="text-[#ffa729] hover:text-[#ffb84d] transition-colors break-all text-xs font-mono"
+                    >
+                      {logEntry.address}
+                    </Link>
+                  </div>
+                  {decoded ? (
+                    <>
+                      <p className="text-xs text-gray-500 font-mono mb-2">{decoded.signature}</p>
+                      <div className="space-y-1">
+                        {decoded.args.map((arg) => (
+                          <div key={arg.label} className="text-xs flex flex-wrap items-start gap-2">
+                            <span className="text-gray-400 font-mono min-w-[80px]">{arg.label}:</span>
+                            {arg.type === 'address' && arg.value ? (
+                              <Link
+                                href={`/address/${arg.value}`}
+                                className="text-gray-200 hover:text-[#ffa729] transition-colors break-all font-mono"
+                              >
+                                {arg.value}
+                              </Link>
+                            ) : arg.type === 'bool' ? (
+                              <Badge variant={arg.value === 'true' ? 'success' : 'error'}>{arg.value}</Badge>
+                            ) : arg.type === 'uint256' ? (
+                              <span className="text-gray-200 font-mono break-all">
+                                {(() => { try { return BigInt(arg.value || '0').toLocaleString('en-US'); } catch { return arg.value || ''; } })()}
+                              </span>
+                            ) : arg.type === 'uint256[]' ? (
+                              <span className="text-gray-200 font-mono break-all">
+                                {arg.values && arg.values.length > 0
+                                  ? arg.values.map((v) => {
+                                      try { return BigInt(v).toLocaleString('en-US'); } catch { return v; }
+                                    }).join(', ')
+                                  : '[]'}
+                              </span>
+                            ) : (
+                              <span className="text-gray-200 font-mono break-all">{arg.value}</span>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    </>
+                  ) : (
+                    <div className="text-xs space-y-1">
+                      <div>
+                        <span className="text-gray-400 font-mono">topics:</span>
+                        <div className="ml-2 mt-1 space-y-0.5">
+                          {logEntry.topics.map((t, ti) => (
+                            <div key={ti} className="text-gray-200 font-mono break-all">[{ti}] {t}</div>
+                          ))}
+                        </div>
+                      </div>
+                      {logEntry.data && logEntry.data !== '0x' && (
+                        <div>
+                          <span className="text-gray-400 font-mono">data:</span>
+                          <p className="ml-2 mt-1 text-gray-200 font-mono break-all">{logEntry.data}</p>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Input Data Card. Decoded preview from decodeTokenTransferInput
+          when the calldata matches a known token-call selector; raw
+          calldata always shown so users can copy it into any decoder. */}
+      {transaction.input && transaction.input !== '0x' && (() => {
+        const decodedInput = decodeTokenTransferInput(transaction.input);
+        return (
+          <div className="rounded-xl bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f] border border-[#3d3d3d] shadow-xl overflow-hidden mb-6">
+            <div className="px-4 sm:px-6 py-4 border-b border-[#3d3d3d]">
+              <div className="flex items-center gap-2">
+                <h2 className="text-[15px] font-semibold text-[#ffa729]">Input Data</h2>
+                {decodedInput && (
+                  <Badge variant={decodedInput.standard === 'ERC-20' ? 'brand' : 'warning'}>
+                    {decodedInput.methodName}
+                  </Badge>
+                )}
+              </div>
+            </div>
+            <div className="p-4 sm:p-6">
+              {decodedInput && (
+                <p className="text-xs text-gray-500 font-mono mb-2">
+                  {decodedInput.standard} · {decodedInput.methodName}
+                </p>
+              )}
+              <p className="font-mono text-gray-300 break-all text-xs leading-relaxed">{transaction.input}</p>
+            </div>
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/ExplorerFrontend/app/types/transaction.ts
+++ b/ExplorerFrontend/app/types/transaction.ts
@@ -127,6 +127,22 @@ export interface TransactionDetails {
     tokenStandard?: TokenStandard | string;
   };
   tokenTransfers?: TokenTransferInfo[];
+  /** Raw calldata for the tx, "0x..." prefixed. Empty / "0x" for plain transfers. */
+  input?: string;
+  /** Receipt logs in emission order. Populated best-effort; absent when the RPC fetch fails. */
+  logs?: TxLog[];
+}
+
+/**
+ * One receipt log entry on a confirmed tx. Mirrors the subset returned by
+ * the backend's /tx/:hash route, which itself mirrors qrl_getTransactionReceipt.logs[].
+ */
+export interface TxLog {
+  address: string;
+  topics: string[];
+  data: string;
+  logIndex: string;
+  removed?: boolean;
 }
 
 /**

--- a/backendAPI/db/transaction.go
+++ b/backendAPI/db/transaction.go
@@ -427,6 +427,7 @@ func ReturnSingleTransfer(query string) (models.Transfer, error) {
 					Signature:      tx.Signature,
 					Pk:             tx.PublicKey,
 					Size:           ensureHexPrefix(block.Result.Size),
+					Input:          tx.Data,
 				}
 				return result, nil
 			}

--- a/backendAPI/models/transfer.go
+++ b/backendAPI/models/transfer.go
@@ -16,6 +16,11 @@ type Transfer struct {
 	Signature      string             `bson:"signature"`
 	Pk             string             `bson:"pk"`
 	Size           string             `bson:"size"`
+	// Input is the transaction's calldata (the tx's `data` field on the
+	// block). Populated by ReturnSingleTransfer from the blocks collection.
+	// Empty for plain QRL transfers, "0x" + selector + ABI args for contract
+	// calls. Drives the Input Data card + Event Logs panel on the tx page.
+	Input string `bson:"input,omitempty" json:"Input,omitempty"`
 }
 
 type TransactionsVolume struct {

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -4,6 +4,8 @@ import (
 	"backendAPI/cache"
 	"backendAPI/db"
 	"backendAPI/models"
+	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"math/big"
@@ -15,6 +17,47 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo"
 )
+
+// receiptLog mirrors the subset of qrl_getTransactionReceipt.logs[] the tx
+// page actually consumes. address + topics + data + logIndex is enough for
+// the frontend's Event Logs panel to decode all token-flavoured signatures
+// (Transfer / TransferSingle / TransferBatch / Approval / ApprovalForAll)
+// and render a raw fallback for everything else. Everything else on the
+// receipt (block hash, tx index, etc.) is already known to the page.
+type receiptLog struct {
+	Address  string   `json:"address"`
+	Topics   []string `json:"topics"`
+	Data     string   `json:"data"`
+	LogIndex string   `json:"logIndex"`
+	Removed  bool     `json:"removed"`
+}
+
+// fetchReceiptLogs pulls a tx's receipt over JSON-RPC and returns the
+// logs slice. Best-effort: if the node is unreachable or the receipt
+// hasn't been indexed yet, returns an empty slice without an error so
+// the tx page still renders. Errors are logged at the call site.
+func fetchReceiptLogs(ctx context.Context, txHash string) []receiptLog {
+	raw, rpcErr, transportErr := db.NodeRPC(ctx, "qrl_getTransactionReceipt", []interface{}{txHash})
+	if transportErr != nil {
+		log.Printf("receipt fetch %s: %v", txHash, transportErr)
+		return nil
+	}
+	if rpcErr != nil {
+		log.Printf("receipt fetch %s: rpc error: %s", txHash, rpcErr.Error())
+		return nil
+	}
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var receipt struct {
+		Logs []receiptLog `json:"logs"`
+	}
+	if err := json.Unmarshal(raw, &receipt); err != nil {
+		log.Printf("receipt decode %s: %v", txHash, err)
+		return nil
+	}
+	return receipt.Logs
+}
 
 // routeCache absorbs concurrent traffic on read endpoints with a small TTL
 // (5–30 s depending on freshness needs). Singleflight inside the cache
@@ -419,9 +462,20 @@ func UserRoute(router *gin.Engine) {
 			log.Printf("Error checking for token transfers tx %s: %v", value, err)
 		}
 
+		// Receipt logs power the Event Logs panel on the tx page. Best-effort
+		// RPC fetch with a 6s budget, mined txs always have a receipt but if
+		// the node is briefly unreachable we'd rather serve the page without
+		// logs than 500.
+		logCtx, cancelLogs := context.WithTimeout(c.Request.Context(), 6*time.Second)
+		defer cancelLogs()
+		logs := fetchReceiptLogs(logCtx, value)
+
 		response := gin.H{
 			"response":    query,
 			"latestBlock": latestBlockNum,
+		}
+		if len(logs) > 0 {
+			response["logs"] = logs
 		}
 
 		if contractCreated != nil {


### PR DESCRIPTION
## Summary

Follow-up to PR #102. Non-Transfer contract calls (setters, approvals, governance, anything custom) used to render as a blank card on the tx page because `/tx/:hash` returned neither the receipt's logs nor the tx's calldata. This PR surfaces both.

Reported case: [`0xbba929bd1...`](https://zondscan.com/tx/0xbba929bd10026e8f3374171cce754c3614f9291199fd3cfd46f2321e1dabee1d) (M3M owner calling a setter on the Matka3Mother ERC-721 to register the Matka1 collection) currently renders nothing useful. After this PR the page will show the calldata + the single event the receipt emits.

## Backend
- `models.Transfer`: add `Input` (tx calldata, populated from block `tx.Data` by `ReturnSingleTransfer`).
- `/tx/:hash`: fetch the receipt over JSON-RPC and include `logs[]` in the response. Best-effort with a 6s budget; the tx page still renders if the RPC fetch fails.

## Frontend
- `types.TransactionDetails`: add `input` + `logs[]`. New `TxLog` mirrors the `qrl_getTransactionReceipt.logs[]` subset the page consumes.
- `helpers.decodeEventLog`: decode the five well-known token signatures inline. `Transfer` / `Approval` branch on `topics.length` to tag ERC-20 (3 topics, value in data) vs ERC-721 (4 topics, tokenId in topic[3], empty data). `TransferSingle` / `TransferBatch` / `ApprovalForAll` cover the rest. Returns `null` for unknown signatures so the view can render a raw fallback.
- `transaction-view.tsx`: render Event Logs panel (per-log decoded card with address link, signature, labelled args; raw topics+data fallback for unknown sigs) and Input Data card (raw calldata plus an optional decoded-method chip via `decodeTokenTransferInput`).

## Test plan

- [x] `go build ./...` + `go vet ./...` clean (backendAPI)
- [x] `npx tsc --noEmit` clean (ExplorerFrontend)
- [x] `npx next build` succeeds
- [x] `npm run lint` introduces no new errors or warnings on the edited files
- [ ] Manual smoke on prod after deploy:
  - Open `0xbba929bd1...` and confirm the Event Logs panel shows the single log (unknown signature, raw fallback) and Input Data card shows the calldata.
  - Open an ERC-1155 mint tx and confirm `TransferSingle` / `TransferBatch` decode with operator/from/to/id/value.
  - Open an ERC-20 transfer tx and confirm `Transfer` decodes with from/to/value.
  - Open a plain QRL transfer and confirm neither panel renders (input == "0x", logs empty).