### PR TITLE
chore(contracts): replace set-state-in-effect with adjust-on-render

### DIFF
--- a/ExplorerFrontend/app/contracts/contracts-client.tsx
+++ b/ExplorerFrontend/app/contracts/contracts-client.tsx
@@ -173,11 +173,15 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
     router.replace(`/contracts?${params.toString()}`, { scroll: false });
   }, [router, searchParams]);
   // Keep state in sync when the URL changes from outside (back/forward,
-  // breadcrumb click on a different tab).
-  useEffect(() => {
-    if (urlTab !== activeTab) setActiveTabState(urlTab);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [urlTab]);
+  // breadcrumb click on a different tab). Adjusting state during render
+  // via a prev-value tracker, the React-recommended replacement for the
+  // set-state-in-effect anti-pattern. Matches the cadence used in
+  // pending-transaction-view.tsx for ETA resync.
+  const [prevUrlTab, setPrevUrlTab] = useState<TabType>(urlTab);
+  if (urlTab !== prevUrlTab) {
+    setPrevUrlTab(urlTab);
+    setActiveTabState(urlTab);
+  }
   const [searchQuery, setSearchQuery] = useState('');
   const [currentPage, setCurrentPage] = useState(0);
   const [contracts, setContracts] = useState<ContractData[]>(initialData);


### PR DESCRIPTION
## Summary

`react-hooks/set-state-in-effect` has been firing on `contracts-client.tsx:178` (the URL→activeTab sync) since that rule was added. Calling `setActiveTabState` inside a `useEffect` is the classic anti-pattern: it triggers a cascading render and is the only lint error currently on `dev`, masking real errors in PR lint runs.

Switch to the **prev-value-during-render** pattern that the codebase already uses elsewhere (see `pending-transaction-view.tsx` for ETA resync): track the previous `urlTab` in state, and when it diverges from the live prop update both `prev` and `activeTab` in the same render pass. Same observable behaviour, no effect, no cascade.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` exits 0 (previously exited 1 on this exact line)
- [ ] Manual smoke: navigate `/contracts?tab=erc721` directly, browser-back from a contract detail page, and click a tab — confirm `activeTab` follows the URL in all three flows.