### PR TITLE
fix(tx-page): fetch tx calldata from node so Input Data card renders

### DIFF
--- a/ExplorerFrontend/app/tx/[query]/page.tsx
+++ b/ExplorerFrontend/app/tx/[query]/page.tsx
@@ -69,7 +69,11 @@ async function getTransaction(txHash: string): Promise<TransactionDetails> {
     PaidFees: txData.PaidFees ? Number(txData.PaidFees) : undefined,
     contractCreated: data.contractCreated || undefined,
     tokenTransfers: Array.isArray(data.tokenTransfers) ? data.tokenTransfers : undefined,
-    input: txData.Input || undefined,
+    // input comes from the top-level data.input field. The backend fetches
+    // it from the node via qrl_getTransactionByHash because the syncer's
+    // Transaction struct uses the wrong JSON tag (`data` instead of `input`),
+    // leaving txData.Input empty for every historical tx.
+    input: typeof data.input === 'string' ? data.input : (txData.Input || undefined),
     logs: Array.isArray(data.logs) ? data.logs : undefined,
   };
 

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -57,6 +58,34 @@ func fetchReceiptLogs(ctx context.Context, txHash string) []receiptLog {
 		return nil
 	}
 	return receipt.Logs
+}
+
+// fetchTxInput pulls a tx's calldata from the node. The historical block
+// docs in MongoDB carry an empty `data` field because the syncer's
+// Transaction struct uses the wrong JSON tag (`data`, where the node
+// returns `input`), so we resolve it over RPC instead. Best-effort:
+// returns "" when the node is unreachable so the page still renders.
+func fetchTxInput(ctx context.Context, txHash string) string {
+	raw, rpcErr, transportErr := db.NodeRPC(ctx, "qrl_getTransactionByHash", []interface{}{txHash})
+	if transportErr != nil {
+		log.Printf("tx input fetch %s: %v", txHash, transportErr)
+		return ""
+	}
+	if rpcErr != nil {
+		log.Printf("tx input fetch %s: rpc error: %s", txHash, rpcErr.Error())
+		return ""
+	}
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var tx struct {
+		Input string `json:"input"`
+	}
+	if err := json.Unmarshal(raw, &tx); err != nil {
+		log.Printf("tx input decode %s: %v", txHash, err)
+		return ""
+	}
+	return tx.Input
 }
 
 // routeCache absorbs concurrent traffic on read endpoints with a small TTL
@@ -462,13 +491,28 @@ func UserRoute(router *gin.Engine) {
 			log.Printf("Error checking for token transfers tx %s: %v", value, err)
 		}
 
-		// Receipt logs power the Event Logs panel on the tx page. Best-effort
-		// RPC fetch with a 6s budget, mined txs always have a receipt but if
-		// the node is briefly unreachable we'd rather serve the page without
-		// logs than 500.
-		logCtx, cancelLogs := context.WithTimeout(c.Request.Context(), 6*time.Second)
-		defer cancelLogs()
-		logs := fetchReceiptLogs(logCtx, value)
+		// Receipt logs power the Event Logs panel on the tx page; tx input
+		// powers the Input Data card. Best-effort RPC fetches in parallel
+		// with a shared 6s budget so the page still renders if the node is
+		// briefly unreachable. Tx input has to come from the node because
+		// the syncer's Transaction struct uses the wrong JSON tag (`data`
+		// where the node returns `input`), leaving the persisted field
+		// empty for every historical tx.
+		rpcCtx, cancelRPC := context.WithTimeout(c.Request.Context(), 6*time.Second)
+		defer cancelRPC()
+		var logs []receiptLog
+		var txInput string
+		var rpcWG sync.WaitGroup
+		rpcWG.Add(2)
+		go func() {
+			defer rpcWG.Done()
+			logs = fetchReceiptLogs(rpcCtx, value)
+		}()
+		go func() {
+			defer rpcWG.Done()
+			txInput = fetchTxInput(rpcCtx, value)
+		}()
+		rpcWG.Wait()
 
 		response := gin.H{
 			"response":    query,
@@ -476,6 +520,9 @@ func UserRoute(router *gin.Engine) {
 		}
 		if len(logs) > 0 {
 			response["logs"] = logs
+		}
+		if txInput != "" && txInput != "0x" {
+			response["input"] = txInput
 		}
 
 		if contractCreated != nil {


### PR DESCRIPTION
## Summary

Hotfix to PR #103. The Input Data card never renders because every block doc in MongoDB has `transactions[].data: \"\"`: the syncer's `Transaction` struct uses `json:\"data\"` but the QRL Zond node returns calldata in the `input` field. The mismatched tag means the JSON decoder never sees the value and empty strings get persisted forever.

Fix the surface immediately by fetching calldata from the node alongside the existing receipt-logs fetch. Both RPCs run in parallel under the shared 6s budget via `sync.WaitGroup`, so total page latency is unchanged. Emit `input` as a top-level field on `/tx/:hash`; the frontend reads `data.input` first and falls back to `txData.Input` for forward compatibility (in case the syncer is fixed later).

The syncer JSON-tag bug stays for a follow-up: fixing it changes the stored field name from `data` to `input` (driver default lowercases the Go name), which would create a storage-format drift between old and new docs and not actually help the tx page since the RPC fallback already covers history.

## Test plan

- [x] `go build ./...` + `go vet ./...` clean
- [x] `npx tsc --noEmit` clean
- [ ] After deploy: open `0xbba929bd1...` and confirm the Input Data card renders the calldata (`0x8d1cbd9c...`).
- [ ] After deploy: open a plain QRL transfer and confirm the Input Data card stays hidden.