### PR TITLE
fix(scripts): prebuild reset --hard so dirty package-lock doesn't block checkout

### DIFF
--- a/ExplorerFrontend/scripts/build-dapp-example.sh
+++ b/ExplorerFrontend/scripts/build-dapp-example.sh
@@ -38,7 +38,14 @@ else
   else
     # FETCH_HEAD works for both branches and tags; origin/$REF would not resolve for tags.
     git -C "$CACHE_DIR" fetch --depth 1 origin "$REF"
-    git -C "$CACHE_DIR" checkout --detach FETCH_HEAD
+    # `reset --hard` instead of `checkout --detach`: the prior run's
+    # `npm install` inside CACHE_DIR + CACHE_DIR/example bumps the
+    # tracked package-lock.json files, which would make a plain
+    # checkout abort ("local changes would be overwritten"). reset
+    # discards those tracked-file mods and moves HEAD in one step;
+    # untracked files (node_modules/) are preserved so we keep the
+    # install cache between runs.
+    git -C "$CACHE_DIR" reset --hard FETCH_HEAD
   fi
 fi
 


### PR DESCRIPTION
## Summary

The dapp-example prebuild hook (`ExplorerFrontend/scripts/build-dapp-example.sh`) clones `myqrlwallet-connect` into `.dapp-example-cache/` once and on subsequent runs does:

```
git fetch --depth 1 origin "\$REF"
git checkout --detach FETCH_HEAD
```

Each build then `npm install`s in both the cache and `cache/example/`, which bumps the tracked `package-lock.json` files. Next build, the checkout aborts because there are tracked-file mods to clobber:

\`\`\`
remote: ...
From https://github.com/DigitalGuards/myqrlwallet-connect
 * branch            dev        -> FETCH_HEAD
error: Your local changes to the following files would be overwritten by checkout:
        example/package-lock.json
Please commit your changes or stash them before you switch branches.
Aborting
[!] Failed to build frontend
\`\`\`

This breaks any frontend rebuild that doesn't start from a clean cache. Just hit it on the user's deploy.

## Fix

Replace the two-line `fetch` + `checkout --detach FETCH_HEAD` with a single `git reset --hard FETCH_HEAD`. Same end state (HEAD at the fetched ref, working tree matches), but discards tracked-file drift instead of refusing it. Untracked files (`node_modules/`) are preserved so the install cache between runs stays intact and prebuild stays fast.

## Test plan

- [x] `bash -n` syntax check on the script.
- [ ] After deploy: trigger a frontend rebuild on `ops@46.224.165.196` (where the failure happened) and confirm the prebuild completes through to `[dapp-example] staged at ...`.
- [ ] Confirm `public/dapp-example/index.html` exists post-build.