### PR TITLE
fix(syncer): remove duplicate tokenTransfers index init

### DIFF
--- a/QRL2MongoDB/configs/setup.go
+++ b/QRL2MongoDB/configs/setup.go
@@ -279,40 +279,15 @@ func initializeCollections(db *mongo.Database) {
 		Logger.Error("Failed to create processed index for pending token contracts collection", zap.Error(err))
 	}
 
-	// Initialize token transfers collection with indexes
-	tokenTransfersCollection := db.Collection("tokenTransfers")
-	_, err = tokenTransfersCollection.Indexes().CreateMany(
-		ctx,
-		[]mongo.IndexModel{
-			{
-				Keys: bson.D{
-					{Key: "contractAddress", Value: 1},
-					{Key: "blockNumber", Value: 1},
-				},
-			},
-			{
-				Keys: bson.D{
-					{Key: "from", Value: 1},
-					{Key: "blockNumber", Value: 1},
-				},
-			},
-			{
-				Keys: bson.D{
-					{Key: "to", Value: 1},
-					{Key: "blockNumber", Value: 1},
-				},
-			},
-			{
-				Keys:    bson.D{{Key: "txHash", Value: 1}},
-				Options: options.Index().SetUnique(true),
-			},
-		},
-	)
-	if err != nil {
-		Logger.Error("Failed to create indexes for token transfers collection", zap.Error(err))
-	} else {
-		Logger.Info("Token transfers collection initialized with indexes")
-	}
+	// tokenTransfers indexes are owned by db.InitializeTokenTransfersCollection
+	// (called from synchroniser.InitializeTokenCollections at startup). Creating
+	// a duplicate, auto-named set here causes IndexOptionsConflict against the
+	// named set declared in db/tokentransfers.go, which aborts the entire
+	// CreateMany in the proper init — including the (txHash, contract, logIndex,
+	// tokenID) unique that ERC-1155 TransferBatch + ERC-721 batch mint depend on
+	// to land more than one row per tx. Leaving that single source of truth in
+	// place here keeps the indexes aligned with the model that the writer code
+	// actually expects.
 
 	// Initialize CoinGecko collection with empty document
 	_, err = db.Collection("coingecko").UpdateOne(

--- a/QRL2MongoDB/db/tokentransfers.go
+++ b/QRL2MongoDB/db/tokentransfers.go
@@ -524,6 +524,75 @@ func normalizeAddress(addr string) string {
 	return addr
 }
 
+// dropLegacyConflictingIndexes scans `collection`'s indexes and drops any
+// whose key spec matches one of `targets`, regardless of the index name.
+// Used to migrate off auto-named indexes (Mongo's default `field_1_field_1`)
+// before re-creating the same key spec under a stable name. Without this
+// step Mongo rejects the second create with IndexOptionsConflict and aborts
+// the whole CreateMany batch.
+//
+// Key match is direction-aware and order-aware (the `bson.D` is a slice).
+// Pass exactly the key spec you intend to recreate.
+func dropLegacyConflictingIndexes(ctx context.Context, collection *mongo.Collection, targets []bson.D) {
+	cursor, err := collection.Indexes().List(ctx)
+	if err != nil {
+		configs.Logger.Warn("Could not list indexes for legacy cleanup; existing autoindexes may cause IndexOptionsConflict",
+			zap.Error(err))
+		return
+	}
+	defer cursor.Close(ctx)
+
+	for cursor.Next(ctx) {
+		var idx struct {
+			Name string `bson:"name"`
+			Key  bson.D `bson:"key"`
+		}
+		if decErr := cursor.Decode(&idx); decErr != nil {
+			continue
+		}
+		if idx.Name == "_id_" {
+			continue
+		}
+		for _, want := range targets {
+			if !sameKeySpec(idx.Key, want) {
+				continue
+			}
+			if _, dErr := collection.Indexes().DropOne(ctx, idx.Name); dErr != nil {
+				msg := dErr.Error()
+				if !strings.Contains(msg, "IndexNotFound") &&
+					!strings.Contains(msg, "ns does not exist") &&
+					!strings.Contains(msg, "NamespaceNotFound") {
+					configs.Logger.Warn("Could not drop legacy conflicting index",
+						zap.String("indexName", idx.Name),
+						zap.Error(dErr))
+				}
+			} else {
+				configs.Logger.Info("Dropped legacy conflicting index",
+					zap.String("indexName", idx.Name))
+			}
+			break
+		}
+	}
+}
+
+// sameKeySpec returns true when two index key specs are identical in field
+// order, name, and direction. Mongo treats `{a:1,b:1}` and `{b:1,a:1}` as
+// different indexes, so order matters for collision detection.
+func sameKeySpec(a, b bson.D) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Key != b[i].Key {
+			return false
+		}
+		if a[i].Value != b[i].Value {
+			return false
+		}
+	}
+	return true
+}
+
 // InitializeTokenTransfersCollection ensures the token transfers collection is set up with proper indexes.
 // Uses CreateMany which is a no-op for indexes that already exist, safe to call on every restart.
 func InitializeTokenTransfersCollection() error {
@@ -545,6 +614,29 @@ func InitializeTokenTransfersCollection() error {
 				zap.Error(err))
 		}
 	}
+
+	// Drop legacy auto-named indexes that collide on key spec with the
+	// named ones we're about to create. configs/setup.go used to register
+	// these without SetName(), so Mongo gave them auto-generated names
+	// like "contractAddress_1_blockNumber_1" / "txHash_1". When the named
+	// versions below are later submitted via CreateMany, Mongo rejects
+	// the whole batch with IndexOptionsConflict — including the new
+	// 4-tuple unique that ERC-1155 TransferBatch + ERC-721 batch mint
+	// depend on. Same pattern as the tokenBalances migration further
+	// down: match by key spec (not name), drop everything that conflicts
+	// with what we're about to (re)create. Crucially this includes the
+	// legacy "txHash_1" unique-on-txHash, which would otherwise reject
+	// every Transfer event after the first per tx (E11000 duplicate-key).
+	// See https://github.com/DigitalGuards/zondscan/pull/110 for the
+	// incident write-up.
+	dropLegacyConflictingIndexes(ctx, collection,
+		[]bson.D{
+			{{Key: "contractAddress", Value: 1}, {Key: "blockNumber", Value: 1}},
+			{{Key: "from", Value: 1}, {Key: "blockNumber", Value: 1}},
+			{{Key: "to", Value: 1}, {Key: "blockNumber", Value: 1}},
+			{{Key: "txHash", Value: 1}},
+		},
+	)
 
 	// Create the new 4-tuple unique index BEFORE dropping the old 3-tuple
 	// version. Order matters: if creation fails (duplicate-key on legacy

--- a/QRL2MongoDB/rpc/tokenscalls.go
+++ b/QRL2MongoDB/rpc/tokenscalls.go
@@ -46,7 +46,11 @@ var (
 const (
 	TransferEventSignature       = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
 	TransferSingleEventSignature = "0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62"
-	TransferBatchEventSignature  = "0x4a39dc06d4c0dbc64b50af327f5f6b67b0c4b21be9d6c92d40b00b3e7ec1c3ef"
+	// keccak256("TransferBatch(address,address,address,uint256[],uint256[])").
+	// The earlier value (…b50af327f5f6b67…) was a typo, so qrl_getLogs filtered
+	// by it never returned TransferBatch logs and the explorer silently dropped
+	// every ERC-1155 batch mint / batch transfer.
+	TransferBatchEventSignature = "0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb"
 )
 
 // CallContractMethod makes a qrl_call to a contract method and returns the result


### PR DESCRIPTION
## Why

Batch mints + multi-Transfer txs only land their first row in zondscan. The actual on-chain receipt for tx \`0x79fcb7a6...\` (an ERC-1155 batch with 12 \`TransferSingle\` logs) shows up in the syncer log as:

\`\`\`
Found potential token transfer logs   logCount=12
Failed to store token transfer ... E11000 duplicate key error
   collection: qrldata-z.tokenTransfers index: txHash_1
Finished processing token transfers   transfersProcessed=1
\`\`\`

Tracing the legacy \`txHash_1\` unique back, \`configs/setup.go\` was creating four auto-named indexes on \`tokenTransfers\` at startup (the last one being a unique on \`txHash\` alone). Then the proper \`db.InitializeTokenTransfersCollection\` ran and tried to create the same key specs with proper names plus the new \`(txHash, contractAddress, logIndex, tokenID)\` unique. Mongo rejected the second \`CreateMany\` with \`IndexOptionsConflict: Index already exists with a different name: contractAddress_1_blockNumber_1\` and aborted the whole call — so the new 4-tuple unique never made it onto the collection, and the legacy \`txHash_1\` (unique on txHash alone) stayed in place rejecting every Transfer event after the first in a tx.

## What

Remove the duplicate index init from \`configs/setup.go\`. \`db/tokentransfers.go\` is the single source of truth for those indexes and already covers every key spec the removed block was creating, plus the 4-tuple unique + the \`(contractAddress, tokenID, blockNumber)\` per-NFT secondary.

## Risk

- Zero schema change on its own. Drops a redundant write at startup; nothing reads from the old auto-named index names.
- Operational follow-up (done on prod separately): drop the four legacy auto-named indexes (\`txHash_1\`, \`contractAddress_1_blockNumber_1\`, \`from_1_blockNumber_1\`, \`to_1_blockNumber_1\`) so the new \`InitializeTokenTransfersCollection\` can create its named versions clean on next restart.
- Existing rows are untouched. ERC-1155 \`TransferBatch\` rows that previously got dropped need a separate replay pass (delete partial rows for the affected txns + re-run \`ProcessBlockTokenTransfers\` for those blocks). Tracked as follow-up.

## Test plan

- [x] \`go build ./QRL2MongoDB/...\` clean.
- [ ] On prod (\`ops@46.224.165.196\`): \`pm2 stop synchroniser\`, drop the four auto-named indexes, \`git pull\`, rebuild, \`pm2 start synchroniser\`. New startup creates the named indexes including the 4-tuple unique. Verify via \`db.tokenTransfers.getIndexes()\`.
- [ ] Deploy a test ERC-1155 / ERC-721 batch-mint NFT on v2 testnet, watch the syncer ingest all token IDs from a single tx, confirm explorer + wallet show every minted token.