### PR TITLE
feat(address): token transfers tab + paginated holdings

### DIFF
--- a/ExplorerFrontend/app/address/[query]/address-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-view.tsx
@@ -267,14 +267,24 @@ export default function AddressView({ addressData, addressSegment }: AddressView
                 so there's no spacer when it's not relevant. */}
             <HoldingsDisplay address={addressSegment} />
 
-            {/* Transactions Section */}
+            {/* Transactions Section. The table itself surfaces three tabs:
+                Transactions (native), Internal Txns (sub-frame calls), and
+                Token Transfers (NFT / ERC-20 events for the holder). Token
+                transfers are lazy-loaded server-side, so an address with no
+                native txs but plenty of NFT activity still gets the tabs.
+                We only fall back to the EmptyState when there's literally no
+                activity of any kind on this address. */}
             <section aria-labelledby="address-transactions-heading" className="space-y-3 md:space-y-4">
-                <h2 id="address-transactions-heading" className="text-base md:text-lg lg:text-xl font-semibold text-accent">Transactions</h2>
+                <h2 id="address-transactions-heading" className="text-base md:text-lg lg:text-xl font-semibold text-accent">Activity</h2>
                 <div className="overflow-hidden rounded-xl border border-border">
-                    {addressData.transactions_by_address && addressData.transactions_by_address.length > 0 ? (
-                        <TanStackTable 
-                            transactions={addressData.transactions_by_address} 
+                    {(
+                        (addressData.transactions_by_address && addressData.transactions_by_address.length > 0)
+                        || (addressData.internal_transactions_by_address && addressData.internal_transactions_by_address.length > 0)
+                    ) ? (
+                        <TanStackTable
+                            transactions={addressData.transactions_by_address || []}
                             internalt={addressData.internal_transactions_by_address || []}
+                            tokenTransferAddress={addressSegment}
                         />
                     ) : (
                         <EmptyState

--- a/ExplorerFrontend/app/address/[query]/holdings-display.tsx
+++ b/ExplorerFrontend/app/address/[query]/holdings-display.tsx
@@ -1,9 +1,22 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
 import Link from 'next/link';
+import {
+  createColumnHelper,
+  flexRender,
+  useReactTable,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  type Cell,
+  type Header,
+  type HeaderGroup,
+  type Row,
+} from '@tanstack/react-table';
 import Badge from '../../components/Badge';
+import DebouncedInput from '../../components/DebouncedInput';
 import ImageWithFallback from '../../components/ImageWithFallback';
 import config from '../../../config';
 import { formatTokenAmount } from '../../lib/helpers';
@@ -20,6 +33,11 @@ import { formatTokenAmount } from '../../lib/helpers';
  * section but doesn't block the other. Network failures are silent: the
  * section stays empty rather than throwing, matching the rest of the
  * address page's resilience pattern.
+ *
+ * Pagination + search are now backed by TanStack Table, mirroring the
+ * Transactions table's UX: hard cap of 5 rows per page, first/prev/next/last
+ * controls, and a name/symbol/contract-address filter. Each section runs its
+ * own table so the search input scopes to the section the user is looking at.
  */
 
 interface TokenBalanceRow {
@@ -49,6 +67,323 @@ interface HoldingsDisplayProps {
 }
 
 const NFT_STANDARDS = new Set(['ERC-721', 'ERC-1155']);
+// Match the user-requested holdings page size. The transactions paginator
+// uses TanStack's default 10/page; the holdings list is denser per row
+// (image tile + multi-line text), so 5 keeps both sections about the same
+// vertical height as one paginated transactions page.
+const PAGE_SIZE = 5;
+
+const tokenColumnHelper = createColumnHelper<TokenBalanceRow>();
+const nftColumnHelper = createColumnHelper<NFTBalanceRow>();
+
+const renderHeader = <T,>(headerGroups: ReturnType<ReturnType<typeof useReactTable<T>>['getHeaderGroups']>): JSX.Element[] => {
+  return headerGroups.map((headerGroup: HeaderGroup<T>) => (
+    <tr key={headerGroup.id} className="border-b border-border">
+      {headerGroup.headers.map((header: Header<T, unknown>) => (
+        <th key={header.id} scope="col" className="px-4 py-3 text-left text-xs md:text-sm font-medium text-accent">
+          {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+        </th>
+      ))}
+    </tr>
+  ));
+};
+
+const renderBody = <T,>(rows: Row<T>[]): JSX.Element[] => {
+  return rows.map((row) => (
+    <tr key={row.id} className="border-b border-border hover:bg-[rgba(255,167,41,0.05)]">
+      {row.getVisibleCells().map((cell: Cell<T, unknown>) => (
+        <td key={cell.id} className="px-4 py-3 text-sm text-gray-300 align-top">
+          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </td>
+      ))}
+    </tr>
+  ));
+};
+
+interface PaginatorProps {
+  pageIndex: number;
+  pageCount: number;
+  canPrev: boolean;
+  canNext: boolean;
+  goFirst: () => void;
+  goPrev: () => void;
+  goNext: () => void;
+  goLast: () => void;
+}
+
+const Paginator = ({ pageIndex, pageCount, canPrev, canNext, goFirst, goPrev, goNext, goLast }: PaginatorProps): JSX.Element => {
+  return (
+    <div className="flex flex-col md:flex-row items-center justify-between gap-2 p-4 border-t border-border">
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          aria-label="Go to first page"
+          onClick={goFirst}
+          disabled={!canPrev}
+          className="px-3 py-1.5 text-sm text-gray-400 hover:text-white disabled:text-gray-600"
+        >
+          {"<<"}
+        </button>
+        <button
+          aria-label="Go to previous page"
+          onClick={goPrev}
+          disabled={!canPrev}
+          className="px-3 py-1.5 text-sm text-gray-400 hover:text-white disabled:text-gray-600"
+        >
+          Previous
+        </button>
+        <button
+          aria-label="Go to next page"
+          onClick={goNext}
+          disabled={!canNext}
+          className="px-3 py-1.5 text-sm text-gray-400 hover:text-white disabled:text-gray-600"
+        >
+          Next
+        </button>
+        <button
+          aria-label="Go to last page"
+          onClick={goLast}
+          disabled={!canNext}
+          className="px-3 py-1.5 text-sm text-gray-400 hover:text-white disabled:text-gray-600"
+        >
+          {">>"}
+        </button>
+      </div>
+      <div className="text-sm text-gray-400">
+        Page {pageIndex + 1} of {Math.max(1, pageCount)}
+      </div>
+    </div>
+  );
+};
+
+interface TokensSectionProps {
+  tokens: TokenBalanceRow[];
+}
+
+function TokensSection({ tokens }: TokensSectionProps): JSX.Element | null {
+  const [filter, setFilter] = useState('');
+
+  const columns = useMemo(() => [
+    tokenColumnHelper.accessor((row) => row.name || row.symbol || row.contractAddress, {
+      id: 'Token',
+      header: 'Token',
+      cell: (info) => {
+        const row = info.row.original;
+        const label = row.name || row.symbol || row.contractAddress;
+        return (
+          <div className="min-w-0">
+            <Link
+              href={`/address/${row.contractAddress}`}
+              className="text-sm text-accent hover:text-accent-hover transition-colors font-medium break-all"
+              title={row.contractAddress}
+            >
+              {label}
+            </Link>
+            {row.symbol && row.symbol !== row.name && (
+              <span className="text-gray-500 ml-2 font-mono text-xs">({row.symbol})</span>
+            )}
+          </div>
+        );
+      },
+    }),
+    tokenColumnHelper.accessor((row) => row.balance, {
+      id: 'Balance',
+      header: 'Balance',
+      cell: (info) => {
+        const row = info.row.original;
+        const formatted = formatTokenAmount(row.balance, row.decimals ?? 18);
+        return (
+          <span className="text-sm font-mono text-gray-200 break-all">
+            {formatted}
+            {row.symbol && <span className="text-gray-500 ml-2">{row.symbol}</span>}
+          </span>
+        );
+      },
+    }),
+  ], []);
+
+  const table = useReactTable({
+    data: tokens,
+    columns,
+    state: { globalFilter: filter },
+    onGlobalFilterChange: setFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageIndex: 0, pageSize: PAGE_SIZE } },
+  });
+
+  if (tokens.length === 0) return null;
+
+  return (
+    <div className="rounded-xl border border-border overflow-hidden" role="region" aria-label="Token holdings">
+      <div className="px-4 py-3 border-b border-border bg-[#1a1a1a]/40 flex flex-wrap items-center gap-2 justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-gray-200">Tokens</span>
+          <Badge variant="brand">{tokens.length} QRC-20</Badge>
+        </div>
+        <DebouncedInput
+          value={filter}
+          onChange={(v) => setFilter(String(v))}
+          className="px-3 py-1.5 text-sm bg-[#1a1a1a] border border-border rounded-lg focus:outline-none focus:border-accent text-white w-full md:w-auto"
+          placeholder="Search by name, symbol, address"
+        />
+      </div>
+      {table.getRowModel().rows.length === 0 ? (
+        <div className="p-6 text-center text-sm text-gray-400">No tokens match your search.</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table aria-label="Token holdings table" className="w-full">
+            <thead>{renderHeader(table.getHeaderGroups())}</thead>
+            <tbody>{renderBody(table.getRowModel().rows)}</tbody>
+          </table>
+        </div>
+      )}
+      <Paginator
+        pageIndex={table.getState().pagination.pageIndex}
+        pageCount={table.getPageCount()}
+        canPrev={table.getCanPreviousPage()}
+        canNext={table.getCanNextPage()}
+        goFirst={() => table.setPageIndex(0)}
+        goPrev={() => table.previousPage()}
+        goNext={() => table.nextPage()}
+        goLast={() => table.setPageIndex(table.getPageCount() - 1)}
+      />
+    </div>
+  );
+}
+
+interface NftsSectionProps {
+  nfts: NFTBalanceRow[];
+}
+
+function NftsSection({ nfts }: NftsSectionProps): JSX.Element | null {
+  const [filter, setFilter] = useState('');
+
+  const columns = useMemo(() => [
+    nftColumnHelper.accessor((row) => `${row.collectionName ?? ''} ${row.collectionSymbol ?? ''} ${row.name ?? ''} ${row.contractAddress} #${row.tokenID}`, {
+      id: 'NFT',
+      header: 'NFT',
+      cell: (info) => {
+        const row = info.row.original;
+        const tokenLabel = row.name || `#${row.tokenID}`;
+        const collectionLabel = row.collectionName || row.collectionSymbol || row.contractAddress;
+        return (
+          <div className="flex items-center gap-3 min-w-0">
+            {row.image ? (
+              // Off-chain metadata images live on arbitrary HTTP / IPFS
+              // gateways. ImageWithFallback handles broken URLs by
+              // swapping in the tokenID monogram on load failure;
+              // unoptimized inside the component skips next/image's
+              // domain-list requirement.
+              <ImageWithFallback
+                src={row.image}
+                alt=""
+                width={40}
+                height={40}
+                className="w-10 h-10 rounded-md object-cover bg-[#1a1a1a]"
+                fallback={
+                  <div className="w-10 h-10 rounded-md bg-[#1a1a1a] border border-border flex items-center justify-center text-xs font-mono text-gray-500">
+                    {(row.tokenID || '?').slice(0, 3)}
+                  </div>
+                }
+              />
+            ) : (
+              <div className="w-10 h-10 rounded-md bg-[#1a1a1a] border border-border flex items-center justify-center text-xs font-mono text-gray-500">
+                {(row.tokenID || '?').slice(0, 3)}
+              </div>
+            )}
+            <div className="min-w-0">
+              <Link
+                href={`/address/${row.contractAddress}`}
+                className="text-sm text-accent hover:text-accent-hover transition-colors font-medium break-all"
+                title={row.contractAddress}
+              >
+                {collectionLabel}
+              </Link>
+              <div className="text-xs text-gray-400 font-mono break-all">
+                {tokenLabel}
+                {row.name && row.tokenID && ` (#${row.tokenID})`}
+              </div>
+            </div>
+          </div>
+        );
+      },
+    }),
+    nftColumnHelper.accessor((row) => row.tokenStandard, {
+      id: 'Standard',
+      header: 'Standard',
+      cell: (info) => {
+        const row = info.row.original;
+        const standardBadge = row.tokenStandard === 'ERC-1155' ? 'QRC-1155' : 'QRC-721';
+        const qty = (() => {
+          try {
+            return BigInt(row.balance).toLocaleString('en-US');
+          } catch {
+            return row.balance;
+          }
+        })();
+        return (
+          <div className="flex items-center gap-2">
+            <Badge variant="warning">{standardBadge}</Badge>
+            {row.tokenStandard === 'ERC-1155' && (
+              <span className="text-sm font-mono text-gray-200">x{qty}</span>
+            )}
+          </div>
+        );
+      },
+    }),
+  ], []);
+
+  const table = useReactTable({
+    data: nfts,
+    columns,
+    state: { globalFilter: filter },
+    onGlobalFilterChange: setFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageIndex: 0, pageSize: PAGE_SIZE } },
+  });
+
+  if (nfts.length === 0) return null;
+
+  return (
+    <div className="rounded-xl border border-border overflow-hidden" role="region" aria-label="NFT holdings">
+      <div className="px-4 py-3 border-b border-border bg-[#1a1a1a]/40 flex flex-wrap items-center gap-2 justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-gray-200">NFTs</span>
+          <Badge variant="warning">{nfts.length} item{nfts.length === 1 ? '' : 's'}</Badge>
+        </div>
+        <DebouncedInput
+          value={filter}
+          onChange={(v) => setFilter(String(v))}
+          className="px-3 py-1.5 text-sm bg-[#1a1a1a] border border-border rounded-lg focus:outline-none focus:border-accent text-white w-full md:w-auto"
+          placeholder="Search by collection, tokenID, address"
+        />
+      </div>
+      {table.getRowModel().rows.length === 0 ? (
+        <div className="p-6 text-center text-sm text-gray-400">No NFTs match your search.</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table aria-label="NFT holdings table" className="w-full">
+            <thead>{renderHeader(table.getHeaderGroups())}</thead>
+            <tbody>{renderBody(table.getRowModel().rows)}</tbody>
+          </table>
+        </div>
+      )}
+      <Paginator
+        pageIndex={table.getState().pagination.pageIndex}
+        pageCount={table.getPageCount()}
+        canPrev={table.getCanPreviousPage()}
+        canNext={table.getCanNextPage()}
+        goFirst={() => table.setPageIndex(0)}
+        goPrev={() => table.previousPage()}
+        goNext={() => table.nextPage()}
+        goLast={() => table.setPageIndex(table.getPageCount() - 1)}
+      />
+    </div>
+  );
+}
 
 export default function HoldingsDisplay({ address }: HoldingsDisplayProps): JSX.Element | null {
   const [tokens, setTokens] = useState<TokenBalanceRow[]>([]);
@@ -95,111 +430,8 @@ export default function HoldingsDisplay({ address }: HoldingsDisplayProps): JSX.
   return (
     <section aria-labelledby="holdings-heading" className="space-y-4 md:space-y-6">
       <h2 id="holdings-heading" className="text-base md:text-lg lg:text-xl font-semibold text-accent">Holdings</h2>
-
-      {tokens.length > 0 && (
-        <div className="rounded-xl border border-border overflow-hidden" role="region" aria-label="Token holdings">
-          <div className="px-4 py-3 border-b border-border bg-[#1a1a1a]/40 flex items-center gap-2">
-            <span className="text-sm font-medium text-gray-200">Tokens</span>
-            <Badge variant="brand">{tokens.length} QRC-20</Badge>
-          </div>
-          <ul className="divide-y divide-border">
-            {tokens.map((t) => {
-              const formatted = formatTokenAmount(t.balance, t.decimals ?? 18);
-              const label = t.name || t.symbol || t.contractAddress;
-              return (
-                <li key={t.contractAddress} className="px-4 py-3 flex flex-wrap items-center justify-between gap-3">
-                  <Link
-                    href={`/address/${t.contractAddress}`}
-                    className="text-sm text-accent hover:text-accent-hover transition-colors font-medium"
-                  >
-                    {label}
-                    {t.symbol && t.symbol !== t.name && (
-                      <span className="text-gray-500 ml-2 font-mono text-xs">({t.symbol})</span>
-                    )}
-                  </Link>
-                  <span className="text-sm font-mono text-gray-200 break-all">
-                    {formatted}
-                    {t.symbol && <span className="text-gray-500 ml-2">{t.symbol}</span>}
-                  </span>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      )}
-
-      {nfts.length > 0 && (
-        <div className="rounded-xl border border-border overflow-hidden" role="region" aria-label="NFT holdings">
-          <div className="px-4 py-3 border-b border-border bg-[#1a1a1a]/40 flex items-center gap-2">
-            <span className="text-sm font-medium text-gray-200">NFTs</span>
-            <Badge variant="warning">{nfts.length} collection{nfts.length === 1 ? '' : 's'}</Badge>
-          </div>
-          <ul className="divide-y divide-border">
-            {nfts.map((n) => {
-              const standardBadge = n.tokenStandard === 'ERC-1155' ? 'QRC-1155' : 'QRC-721';
-              const tokenLabel = n.name || `#${n.tokenID}`;
-              const collectionLabel = n.collectionName || n.collectionSymbol || n.contractAddress;
-              const qty = (() => {
-                try {
-                  return BigInt(n.balance).toLocaleString('en-US');
-                } catch {
-                  return n.balance;
-                }
-              })();
-              return (
-                <li
-                  key={`${n.contractAddress}-${n.tokenID}`}
-                  className="px-4 py-3 flex flex-wrap items-center justify-between gap-3"
-                >
-                  <div className="flex items-center gap-3 min-w-0">
-                    {n.image ? (
-                      // Off-chain metadata images live on arbitrary HTTP / IPFS
-                      // gateways. ImageWithFallback handles broken URLs by
-                      // swapping in the tokenID monogram on load failure;
-                      // unoptimized inside the component skips next/image's
-                      // domain-list requirement.
-                      <ImageWithFallback
-                        src={n.image}
-                        alt=""
-                        width={40}
-                        height={40}
-                        className="w-10 h-10 rounded-md object-cover bg-[#1a1a1a]"
-                        fallback={
-                          <div className="w-10 h-10 rounded-md bg-[#1a1a1a] border border-border flex items-center justify-center text-xs font-mono text-gray-500">
-                            {(n.tokenID || '?').slice(0, 3)}
-                          </div>
-                        }
-                      />
-                    ) : (
-                      <div className="w-10 h-10 rounded-md bg-[#1a1a1a] border border-border flex items-center justify-center text-xs font-mono text-gray-500">
-                        {(n.tokenID || '?').slice(0, 3)}
-                      </div>
-                    )}
-                    <div className="min-w-0">
-                      <Link
-                        href={`/address/${n.contractAddress}`}
-                        className="text-sm text-accent hover:text-accent-hover transition-colors font-medium break-all"
-                      >
-                        {collectionLabel}
-                      </Link>
-                      <div className="text-xs text-gray-400 font-mono break-all">
-                        {tokenLabel}
-                        {n.name && n.tokenID && ` (#${n.tokenID})`}
-                      </div>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Badge variant="warning">{standardBadge}</Badge>
-                    {n.tokenStandard === 'ERC-1155' && (
-                      <span className="text-sm font-mono text-gray-200">x{qty}</span>
-                    )}
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      )}
+      <TokensSection tokens={tokens} />
+      <NftsSection nfts={nfts} />
     </section>
   );
 }

--- a/ExplorerFrontend/app/components/TanStackTable.tsx
+++ b/ExplorerFrontend/app/components/TanStackTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import axios from "axios";
 import {
   createColumnHelper,
   flexRender,
@@ -17,11 +18,33 @@ import type {
   Cell,
   ColumnDef
 } from "@tanstack/react-table";
-import { formatAmount, formatTimestamp, normalizeHexString, formatAddress } from "../lib/helpers";
+import { formatAmount, formatTimestamp, normalizeHexString, formatAddress, formatTokenAmount } from "../lib/helpers";
 import DebouncedInput from "./DebouncedInput";
 import { DownloadBtn, DownloadBtnInternal } from "./DownloadBtn";
 import Link from "next/link";
+import config from "../../config";
 import type { Transaction, InternalTransaction } from "@/app/types";
+
+// Token transfer rows for the new "Token Transfers" tab. Mirrors the backend's
+// models.TokenTransfer (json tags). All amount math is BigInt-safe via
+// formatTokenAmount so an NFT row's "1" renders identically to an ERC-20 row's
+// "12345600000000000000".
+interface TokenTransferRow {
+  contractAddress: string;
+  from: string;
+  to: string;
+  amount: string;
+  blockNumber: string;
+  txHash: string;
+  logIndex?: string;
+  timestamp: string;
+  tokenSymbol: string;
+  tokenDecimals: number;
+  tokenName: string;
+  transferType: string;
+  tokenStandard?: string;
+  tokenID?: string;
+}
 
 const truncateMiddle = (str: string, startChars = 8, endChars = 8): string => {
   if (str.length <= startChars + endChars) return str;
@@ -35,15 +58,25 @@ const TX_TYPE_MAP = ["Coinbase", "Attest", "Transfer", "Stake"] as const;
 // Create column helpers outside component to avoid type inference issues
 const columnHelper = createColumnHelper<Transaction & { formattedAmount: string; formattedFees: string }>();
 const internalColumnHelper = createColumnHelper<InternalTransaction & { formattedValue: string }>();
+const tokenTransferColumnHelper = createColumnHelper<TokenTransferRow & { formattedAmount: string; tsSeconds: number }>();
 
 interface TableProps {
   transactions: Transaction[];
   internalt: InternalTransaction[];
+  // Required for the lazy-loaded "Token Transfers" tab. The tab issues
+  // /address/:addr/token-transfers, paginated client-side after a single
+  // 250-row fetch so the search input filters across all rows the holder
+  // has touched without round-tripping per page. When absent the tab is
+  // hidden, callers outside the address page don't surface it.
+  tokenTransferAddress?: string;
 }
 
 type TableInstance<T> = Table<T>;
 
-const renderTableHeader = <T extends Transaction | InternalTransaction>(
+// Generic over any row shape so the Token Transfers tab can reuse the same
+// renderer without expanding the union, the heads/bodies don't read row
+// fields, they only walk the table's own header/cell descriptors.
+const renderTableHeader = <T,>(
   table: TableInstance<T>
 ): JSX.Element[] => {
   return table.getHeaderGroups().map((headerGroup: HeaderGroup<T>) => (
@@ -66,7 +99,7 @@ const renderTableHeader = <T extends Transaction | InternalTransaction>(
   ));
 };
 
-const renderTableBody = <T extends Transaction | InternalTransaction>(
+const renderTableBody = <T,>(
   table: TableInstance<T>
 ): JSX.Element[] => {
   return table.getRowModel().rows.map((row: Row<T>) => (
@@ -111,11 +144,17 @@ const calculateFees = (tx: Transaction): number => {
   }
 };
 
-export default function TanStackTable({ transactions, internalt }: TableProps): JSX.Element | null {
+type TabKey = "transactions" | "internal" | "tokenTransfers";
+
+export default function TanStackTable({ transactions, internalt, tokenTransferAddress }: TableProps): JSX.Element | null {
   const [mounted, setMounted] = useState(false);
   const [windowWidth, setWindowWidth] = useState(0);
   const [globalFilter, setGlobalFilter] = useState("");
-  const [showInternal, setShowInternal] = useState(false);
+  const [activeTab, setActiveTab] = useState<TabKey>("transactions");
+  const [tokenTransfers, setTokenTransfers] = useState<TokenTransferRow[]>([]);
+  const [tokenTransfersLoaded, setTokenTransfersLoaded] = useState(false);
+  const [tokenTransfersLoading, setTokenTransfersLoading] = useState(false);
+  const [tokenTransfersError, setTokenTransfersError] = useState<string | null>(null);
 
   useEffect(() => {
     setMounted(true);
@@ -124,6 +163,47 @@ export default function TanStackTable({ transactions, internalt }: TableProps): 
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
+
+  // Lazy-load token transfers on first visit to the tab. One server hit with
+  // a generous limit (250) is cheaper than paginating server-side, the address
+  // page already pages native txs server-side and a per-tab server round-trip
+  // every time the user clicks Next/Prev would feel sluggish vs the local
+  // pagination the Transactions tab uses on its 10-row payload. Fetch is
+  // gated on tokenTransferAddress so callers without an address can't trip
+  // a no-op fetch.
+  useEffect(() => {
+    if (!tokenTransferAddress) return;
+    if (activeTab !== "tokenTransfers") return;
+    if (tokenTransfersLoaded || tokenTransfersLoading) return;
+
+    let cancelled = false;
+    (async () => {
+      setTokenTransfersLoading(true);
+      setTokenTransfersError(null);
+      try {
+        // page-1-indexed on the wire (matches sibling /address routes); we
+        // ask for the first page at limit=250 to give the search box something
+        // useful to chew on without paging through the server.
+        const res = await axios.get(
+          `${config.handlerUrl}/address/${tokenTransferAddress}/token-transfers`,
+          { params: { page: 1, limit: 250 } }
+        );
+        if (cancelled) return;
+        const rows: TokenTransferRow[] = Array.isArray(res.data?.transfers) ? res.data.transfers : [];
+        setTokenTransfers(rows);
+        setTokenTransfersLoaded(true);
+      } catch (err) {
+        if (cancelled) return;
+        console.error("Failed to load token transfers:", err);
+        setTokenTransfersError("Failed to load token transfers");
+      } finally {
+        if (!cancelled) setTokenTransfersLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, tokenTransferAddress, tokenTransfersLoaded, tokenTransfersLoading]);
 
   // Pre-format the transaction data
   const formattedTransactions = useMemo(() => transactions.map(tx => {
@@ -287,6 +367,118 @@ export default function TanStackTable({ transactions, internalt }: TableProps): 
     }),
   ], [internalt.length, internalColumnHelper]);
 
+  // Token transfers, normalised once per fetch. tsSeconds turns the syncer's
+  // hex timestamp into the seconds-int formatTimestamp expects; falling back
+  // to 0 yields formatTimestamp's empty-string sentinel so a missing field
+  // doesn't render "NaN" or "Invalid Date".
+  const formattedTokenTransfers = useMemo(() => tokenTransfers.map((row) => {
+    const decimals = typeof row.tokenDecimals === "number" ? row.tokenDecimals : 0;
+    const formattedAmount = formatTokenAmount(row.amount, decimals);
+    let tsSeconds = 0;
+    if (row.timestamp) {
+      try {
+        tsSeconds = row.timestamp.startsWith("0x") ? parseInt(row.timestamp, 16) : parseInt(row.timestamp, 10);
+        if (Number.isNaN(tsSeconds)) tsSeconds = 0;
+      } catch {
+        tsSeconds = 0;
+      }
+    }
+    return { ...row, formattedAmount, tsSeconds };
+  }), [tokenTransfers]);
+
+  const tokenTransferColumns = useMemo(() => [
+    // Token column: name + standard badge + per-id tag for NFTs. Single
+    // cell with two lines so the table stays compact on the address page.
+    tokenTransferColumnHelper.accessor((row) => ({
+      name: row.tokenName,
+      symbol: row.tokenSymbol,
+      standard: row.tokenStandard,
+      tokenID: row.tokenID,
+      contractAddress: row.contractAddress,
+    }), {
+      id: "Token",
+      cell: (info) => {
+        const { name, symbol, standard, tokenID, contractAddress } = info.getValue();
+        const label = name || symbol || (contractAddress ? truncateMiddle(contractAddress) : "Token");
+        // Surface the QRC-X branding on the row badge (DB rows stay ERC-X)
+        // so users reading the explorer see consistent QRL-flavoured terminology.
+        const badge = standard ? standard.replace(/^ERC-/, "QRC-") : "Token";
+        return (
+          <div className="flex flex-col">
+            <Link
+              href={`/address/${contractAddress}`}
+              className="text-[#ffa729] hover:text-[#ffb954] font-medium"
+              title={contractAddress}
+            >
+              {label}
+            </Link>
+            <div className="flex items-center gap-2 text-xs text-gray-400">
+              <span className="font-mono">{badge}</span>
+              {tokenID && <span className="font-mono">#{tokenID}</span>}
+              {symbol && symbol !== name && <span className="font-mono">({symbol})</span>}
+            </div>
+          </div>
+        );
+      },
+      header: "Token",
+    }),
+    tokenTransferColumnHelper.accessor((row) => ({ from: row.from, to: row.to }), {
+      id: "Parties",
+      cell: (info) => {
+        const { from, to } = info.getValue();
+        return (
+          <div className="flex flex-col gap-1">
+            {from && (
+              <div className="flex items-center gap-1">
+                <span className="text-gray-400 text-sm">From:</span>
+                <Link href={`/address/${from}`} title={from} className="text-[#ffa729] hover:text-[#ffb954]">
+                  {truncateMiddle(from)}
+                </Link>
+              </div>
+            )}
+            {to && (
+              <div className="flex items-center gap-1">
+                <span className="text-gray-400 text-sm">To:</span>
+                <Link href={`/address/${to}`} title={to} className="text-[#ffa729] hover:text-[#ffb954]">
+                  {truncateMiddle(to)}
+                </Link>
+              </div>
+            )}
+          </div>
+        );
+      },
+      header: "From/To",
+    }),
+    tokenTransferColumnHelper.accessor("formattedAmount", {
+      cell: (info) => {
+        const row = info.row.original;
+        const symbol = row.tokenSymbol;
+        return (
+          <span className="font-mono">
+            {info.getValue()}
+            {symbol && <span className="text-gray-500 ml-2">{symbol}</span>}
+          </span>
+        );
+      },
+      header: "Amount",
+    }),
+    tokenTransferColumnHelper.accessor("txHash", {
+      cell: (info) => {
+        const fullHash = info.getValue();
+        return (
+          <Link href={`/tx/${fullHash}`} title={fullHash} className="text-[#ffa729] hover:text-[#ffb954]">
+            {truncateMiddle(fullHash)}
+          </Link>
+        );
+      },
+      header: "Transaction Hash",
+    }),
+    tokenTransferColumnHelper.accessor("tsSeconds", {
+      cell: (info) => <span>{formatTimestamp(info.getValue())}</span>,
+      header: "Timestamp",
+    }),
+  ], []);
+
   const transactionTable = useReactTable({
     data: formattedTransactions,
     // @ts-expect-error - ColumnDef types conflict with index signature in Transaction type
@@ -304,6 +496,18 @@ export default function TanStackTable({ transactions, internalt }: TableProps): 
     data: formattedInternalTransactions,
     // @ts-expect-error - ColumnDef types conflict with index signature in InternalTransaction type
     columns: internalTransactionColumns,
+    state: {
+      globalFilter,
+    },
+    onGlobalFilterChange: setGlobalFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  });
+
+  const tokenTransferTable = useReactTable({
+    data: formattedTokenTransfers,
+    columns: tokenTransferColumns as ColumnDef<TokenTransferRow & { formattedAmount: string; tsSeconds: number }>[],
     state: {
       globalFilter,
     },
@@ -451,22 +655,129 @@ export default function TanStackTable({ transactions, internalt }: TableProps): 
     );
   };
 
+  const renderTokenTransferCard = (row: Row<TokenTransferRow & { formattedAmount: string; tsSeconds: number }>): JSX.Element => {
+    const data = row.original;
+    const badge = data.tokenStandard ? data.tokenStandard.replace(/^ERC-/, "QRC-") : "Token";
+    const label = data.tokenName || data.tokenSymbol || data.contractAddress;
+    return (
+      <div key={row.id} className="p-4 border-b border-[#3d3d3d] last:border-b-0">
+        <div className="space-y-3">
+          <div className="flex justify-between items-start">
+            <div className="space-y-1">
+              <div className="text-xs text-gray-400">Token</div>
+              <Link
+                href={`/address/${data.contractAddress}`}
+                className="text-sm text-[#ffa729] hover:text-[#ffb954] break-all"
+              >
+                {label}
+              </Link>
+              <div className="text-xs text-gray-400 font-mono">
+                {badge}{data.tokenID ? ` #${data.tokenID}` : ""}
+              </div>
+            </div>
+            <div className="px-2 py-1 rounded bg-[#3d3d3d] bg-opacity-40">
+              <span className="text-xs text-[#ffa729]">{data.formattedAmount}{data.tokenSymbol ? " " + data.tokenSymbol : ""}</span>
+            </div>
+          </div>
+
+          <div>
+            <div className="text-xs text-gray-400">Transaction Hash</div>
+            <Link
+              href={`/tx/${data.txHash}`}
+              className="text-sm text-[#ffa729] hover:text-[#ffb954] break-all"
+            >
+              {data.txHash}
+            </Link>
+          </div>
+
+          <div>
+            <div className="text-xs text-gray-400">From</div>
+            {data.from && (
+              <Link href={`/address/${data.from}`} className="text-sm text-[#ffa729] hover:text-[#ffb954] break-all">
+                {truncateMiddle(data.from)}
+              </Link>
+            )}
+          </div>
+
+          <div>
+            <div className="text-xs text-gray-400">To</div>
+            {data.to && (
+              <Link href={`/address/${data.to}`} className="text-sm text-[#ffa729] hover:text-[#ffb954] break-all">
+                {truncateMiddle(data.to)}
+              </Link>
+            )}
+          </div>
+
+          <div>
+            <div className="text-xs text-gray-400">Time</div>
+            <div className="text-sm text-white">{formatTimestamp(data.tsSeconds)}</div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
   if (!mounted) {
     return null;
   }
+
+  const showTokenTab = !!tokenTransferAddress;
+  const tabId = activeTab === "transactions" ? "tab-transactions" : activeTab === "internal" ? "tab-internal" : "tab-token-transfers";
+  const tableLabel = activeTab === "transactions"
+    ? "Transaction history"
+    : activeTab === "internal"
+      ? "Internal transactions"
+      : "Token transfers";
+  const searchPlaceholder = activeTab === "tokenTransfers"
+    ? "Search token transfers..."
+    : "Search transactions...";
+
+  // Single switch keeps the table-selection ternaries below readable; without
+  // it every render branch (mobile cards, desktop table, paginator, page
+  // counter) repeats the same 3-way conditional and drifts over time.
+  const activeTable: Table<Transaction & { formattedAmount: string; formattedFees: string }>
+    | Table<InternalTransaction & { formattedValue: string }>
+    | Table<TokenTransferRow & { formattedAmount: string; tsSeconds: number }> =
+      activeTab === "internal"
+        ? internalTransactionTable
+        : activeTab === "tokenTransfers"
+          ? tokenTransferTable
+          : transactionTable;
+
+  const renderActiveCards = (): JSX.Element[] => {
+    if (activeTab === "internal") {
+      return internalTransactionTable.getRowModel().rows.map((row) => renderInternalTransactionCard(row));
+    }
+    if (activeTab === "tokenTransfers") {
+      return tokenTransferTable.getRowModel().rows.map((row) => renderTokenTransferCard(row));
+    }
+    return transactionTable.getRowModel().rows.map((row) => renderTransactionCard(row));
+  };
+
+  const renderActiveHeader = (): JSX.Element[] => {
+    if (activeTab === "internal") return renderTableHeader(internalTransactionTable);
+    if (activeTab === "tokenTransfers") return renderTableHeader(tokenTransferTable);
+    return renderTableHeader(transactionTable);
+  };
+
+  const renderActiveBody = (): JSX.Element[] => {
+    if (activeTab === "internal") return renderTableBody(internalTransactionTable);
+    if (activeTab === "tokenTransfers") return renderTableBody(tokenTransferTable);
+    return renderTableBody(transactionTable);
+  };
 
   return (
     <div className="w-full">
       <div className="p-4 border-b border-[#3d3d3d] space-y-4">
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
-          <div role="tablist" className="flex items-center space-x-4">
+          <div role="tablist" className="flex items-center flex-wrap gap-2 md:gap-4">
             <button
               id="tab-transactions"
               role="tab"
-              aria-selected={!showInternal}
-              onClick={() => setShowInternal(false)}
+              aria-selected={activeTab === "transactions"}
+              onClick={() => setActiveTab("transactions")}
               className={`px-3 py-1.5 rounded-lg text-sm transition-colors ${
-                !showInternal
+                activeTab === "transactions"
                   ? "bg-[#ffa729] text-black"
                   : "text-gray-400 hover:text-white"
               }`}
@@ -476,141 +787,113 @@ export default function TanStackTable({ transactions, internalt }: TableProps): 
             <button
               id="tab-internal"
               role="tab"
-              aria-selected={showInternal}
-              onClick={() => setShowInternal(true)}
+              aria-selected={activeTab === "internal"}
+              onClick={() => setActiveTab("internal")}
               className={`px-3 py-1.5 rounded-lg text-sm transition-colors ${
-                showInternal
+                activeTab === "internal"
                   ? "bg-[#ffa729] text-black"
                   : "text-gray-400 hover:text-white"
               }`}
             >
               Internal Txns
             </button>
+            {showTokenTab && (
+              <button
+                id="tab-token-transfers"
+                role="tab"
+                aria-selected={activeTab === "tokenTransfers"}
+                onClick={() => setActiveTab("tokenTransfers")}
+                className={`px-3 py-1.5 rounded-lg text-sm transition-colors ${
+                  activeTab === "tokenTransfers"
+                    ? "bg-[#ffa729] text-black"
+                    : "text-gray-400 hover:text-white"
+                }`}
+              >
+                Token Transfers
+                {tokenTransfersLoaded && (
+                  <span className="ml-1 text-xs opacity-75">({tokenTransfers.length})</span>
+                )}
+              </button>
+            )}
           </div>
           <div className="flex items-center space-x-4">
             <DebouncedInput
               value={globalFilter ?? ""}
               onChange={(value) => setGlobalFilter(String(value))}
               className="px-4 py-2 text-sm bg-[#1a1a1a] border border-[#3d3d3d] rounded-lg focus:outline-none focus:border-[#ffa729] text-white w-full md:w-auto"
-              placeholder="Search transactions..."
+              placeholder={searchPlaceholder}
             />
-            {showInternal ? (
+            {activeTab === "internal" ? (
               <DownloadBtnInternal data={internalt} />
-            ) : (
+            ) : activeTab === "transactions" ? (
               <DownloadBtn data={transactions} />
-            )}
+            ) : null}
           </div>
         </div>
       </div>
 
-      <div role="tabpanel" aria-labelledby={showInternal ? "tab-internal" : "tab-transactions"} className="overflow-x-auto">
-        {windowWidth < 768 ? (
-          <div className="overflow-hidden">
-            {showInternal
-              ? internalTransactionTable.getRowModel().rows.map((row) => renderInternalTransactionCard(row))
-              : transactionTable.getRowModel().rows.map((row) => renderTransactionCard(row))
-            }
-          </div>
-        ) : (
-          <table aria-label={showInternal ? "Internal transactions" : "Transaction history"} className="w-full">
-            <thead>
-              {showInternal
-                ? renderTableHeader(internalTransactionTable)
-                : renderTableHeader(transactionTable)
-              }
-            </thead>
-            <tbody>
-              {showInternal
-                ? renderTableBody(internalTransactionTable)
-                : renderTableBody(transactionTable)
-              }
-            </tbody>
-          </table>
+      <div role="tabpanel" aria-labelledby={tabId} className="overflow-x-auto">
+        {activeTab === "tokenTransfers" && tokenTransfersLoading && (
+          <div className="p-8 text-center text-gray-400">Loading token transfers...</div>
+        )}
+        {activeTab === "tokenTransfers" && !tokenTransfersLoading && tokenTransfersError && (
+          <div className="p-8 text-center text-red-400">{tokenTransfersError}</div>
+        )}
+        {activeTab === "tokenTransfers" && !tokenTransfersLoading && !tokenTransfersError && tokenTransfersLoaded && tokenTransfers.length === 0 && (
+          <div className="p-8 text-center text-gray-400">No token transfers for this address.</div>
+        )}
+        {(activeTab !== "tokenTransfers" || (tokenTransfersLoaded && tokenTransfers.length > 0)) && (
+          windowWidth < 768 ? (
+            <div className="overflow-hidden">
+              {renderActiveCards()}
+            </div>
+          ) : (
+            <table aria-label={tableLabel} className="w-full">
+              <thead>{renderActiveHeader()}</thead>
+              <tbody>{renderActiveBody()}</tbody>
+            </table>
+          )
         )}
       </div>
 
       <div className="p-4 border-t border-[#3d3d3d]">
         <div className="flex flex-col md:flex-row items-center justify-between gap-4">
           <div className="flex flex-wrap items-center gap-2">
-            {showInternal ? (
-              <>
-                <button
-                  aria-label="Go to first page"
-                  className="px-3 py-1.5 text-sm text-gray-400 hover:text-white disabled:text-gray-600"
-                  onClick={() => internalTransactionTable.setPageIndex(0)}
-                  disabled={!internalTransactionTable.getCanPreviousPage()}
-                >
-                  {"<<"}
-                </button>
-                <button
-                  aria-label="Go to previous page"
-                  className="px-3 py-1.5 text-sm text-gray-400 hover:text-white disabled:text-gray-600"
-                  onClick={() => internalTransactionTable.previousPage()}
-                  disabled={!internalTransactionTable.getCanPreviousPage()}
-                >
-                  Previous
-                </button>
-                <button
-                  aria-label="Go to next page"
-                  className="px-3 py-1.5 text-sm text-gray-400 hover:text-white disabled:text-gray-600"
-                  onClick={() => internalTransactionTable.nextPage()}
-                  disabled={!internalTransactionTable.getCanNextPage()}
-                >
-                  Next
-                </button>
-                <button
-                  aria-label="Go to last page"
-                  className="px-3 py-1.5 text-sm text-gray-400 hover:text-white disabled:text-gray-600"
-                  onClick={() => internalTransactionTable.setPageIndex(internalTransactionTable.getPageCount() - 1)}
-                  disabled={!internalTransactionTable.getCanNextPage()}
-                >
-                  {">>"}
-                </button>
-              </>
-            ) : (
-              <>
-                <button
-                  aria-label="Go to first page"
-                  className="px-3 py-1.5 text-sm text-gray-400 hover:text-white disabled:text-gray-600"
-                  onClick={() => transactionTable.setPageIndex(0)}
-                  disabled={!transactionTable.getCanPreviousPage()}
-                >
-                  {"<<"}
-                </button>
-                <button
-                  aria-label="Go to previous page"
-                  className="px-3 py-1.5 text-sm text-gray-400 hover:text-white disabled:text-gray-600"
-                  onClick={() => transactionTable.previousPage()}
-                  disabled={!transactionTable.getCanPreviousPage()}
-                >
-                  Previous
-                </button>
-                <button
-                  aria-label="Go to next page"
-                  className="px-3 py-1.5 text-sm text-gray-400 hover:text-white disabled:text-gray-600"
-                  onClick={() => transactionTable.nextPage()}
-                  disabled={!transactionTable.getCanNextPage()}
-                >
-                  Next
-                </button>
-                <button
-                  aria-label="Go to last page"
-                  className="px-3 py-1.5 text-sm text-gray-400 hover:text-white disabled:text-gray-600"
-                  onClick={() => transactionTable.setPageIndex(transactionTable.getPageCount() - 1)}
-                  disabled={!transactionTable.getCanNextPage()}
-                >
-                  {">>"}
-                </button>
-              </>
-            )}
+            <button
+              aria-label="Go to first page"
+              className="px-3 py-1.5 text-sm text-gray-400 hover:text-white disabled:text-gray-600"
+              onClick={() => activeTable.setPageIndex(0)}
+              disabled={!activeTable.getCanPreviousPage()}
+            >
+              {"<<"}
+            </button>
+            <button
+              aria-label="Go to previous page"
+              className="px-3 py-1.5 text-sm text-gray-400 hover:text-white disabled:text-gray-600"
+              onClick={() => activeTable.previousPage()}
+              disabled={!activeTable.getCanPreviousPage()}
+            >
+              Previous
+            </button>
+            <button
+              aria-label="Go to next page"
+              className="px-3 py-1.5 text-sm text-gray-400 hover:text-white disabled:text-gray-600"
+              onClick={() => activeTable.nextPage()}
+              disabled={!activeTable.getCanNextPage()}
+            >
+              Next
+            </button>
+            <button
+              aria-label="Go to last page"
+              className="px-3 py-1.5 text-sm text-gray-400 hover:text-white disabled:text-gray-600"
+              onClick={() => activeTable.setPageIndex(activeTable.getPageCount() - 1)}
+              disabled={!activeTable.getCanNextPage()}
+            >
+              {">>"}
+            </button>
           </div>
           <div className="text-sm text-gray-400">
-            Page {showInternal
-              ? internalTransactionTable.getState().pagination.pageIndex + 1
-              : transactionTable.getState().pagination.pageIndex + 1} of{" "}
-            {showInternal
-              ? internalTransactionTable.getPageCount()
-              : transactionTable.getPageCount()}
+            Page {activeTable.getState().pagination.pageIndex + 1} of {Math.max(1, activeTable.getPageCount())}
           </div>
         </div>
       </div>

--- a/backendAPI/db/token.go
+++ b/backendAPI/db/token.go
@@ -487,6 +487,64 @@ func GetTokenTransfers(contractAddress string, page, limit int) ([]models.TokenT
 	return transfers, totalCount, nil
 }
 
+// GetTokenTransfersByAddress returns token transfer events touching the given
+// holder address (either side: from or to), with pagination. Matches the
+// shape of GetTokenTransfers so the address-page consumer can render the
+// same row schema produced by /token/:address/transfers. Sorted by
+// blockNumber desc so the most recent transfer is first.
+//
+// The address is normalised to the canonical Q-prefix lowercase form the
+// syncer writes; we don't expand to a multi-variant $in here because every
+// token transfer row is written via validation.ConvertToQAddress(), so a
+// single canonical lookup hits the from_block_idx / to_block_idx indexes
+// without forcing the planner onto a slower variant scan.
+func GetTokenTransfersByAddress(address string, page, limit int) ([]models.TokenTransfer, int64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	if page < 0 {
+		page = 0
+	}
+	if limit < 1 {
+		limit = 25
+	}
+	if limit > 50 {
+		limit = 50
+	}
+
+	canonical := normalizeAddress(address)
+	filter := bson.M{"$or": []bson.M{
+		{"from": canonical},
+		{"to": canonical},
+	}}
+	collection := configs.GetCollection(configs.DB, "tokenTransfers")
+
+	totalCount, err := collection.CountDocuments(ctx, filter)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	opts := options.Find().
+		SetSort(bson.D{{Key: "blockNumber", Value: -1}}).
+		SetSkip(int64(page * limit)).
+		SetLimit(int64(limit))
+
+	cursor, err := collection.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer cursor.Close(ctx)
+
+	var transfers []models.TokenTransfer
+	if err := cursor.All(ctx, &transfers); err != nil {
+		return nil, 0, err
+	}
+	if transfers == nil {
+		transfers = make([]models.TokenTransfer, 0)
+	}
+	return transfers, totalCount, nil
+}
+
 // GetTokenInfo returns summary information about a token
 func GetTokenInfo(contractAddress string) (*models.TokenInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -1250,6 +1250,35 @@ func UserRoute(router *gin.Engine) {
 		})
 	})
 
+	// Token / NFT transfer events touching this wallet (sender OR recipient),
+	// across every contract. Powers the "Token Transfers" tab on the address
+	// page, which previously had no data source: /address/aggregate only
+	// returns native-value transactions, and /token/:addr/transfers is keyed
+	// by contract not by holder. Paginated like /address/:addr/transactions.
+	router.GET("/address/:address/token-transfers", func(c *gin.Context) {
+		address := c.Param("address")
+		// Match the address-page Transactions table's 5-rows-per-page default
+		// (paginated server-side, page-1-indexed). Cap matches the DB layer.
+		page, limit := getPaginationParams(c, 1, 5)
+		// db helper is 0-indexed; getPaginationParams returns the 1-indexed
+		// form so the query-string contract stays consistent with siblings.
+		transfers, total, err := db.GetTokenTransfersByAddress(address, page-1, limit)
+		if err != nil {
+			log.Printf("Error fetching token transfers for %s: %v", address, err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": fmt.Sprintf("Failed to fetch token transfers: %v", err),
+			})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"address":   address,
+			"transfers": transfers,
+			"total":     total,
+			"page":      page,
+			"limit":     limit,
+		})
+	})
+
 	// Get all token balances for a wallet address.
 	//
 	// Default behaviour returns every standard the explorer indexes for


### PR DESCRIPTION
## Summary

Fixes two issues on the address page that surfaced once the NFT test fixtures landed and started moving lots of token activity through deployer addresses with little / no native QRL traffic.

### Issue 1: address page didn't show token / NFT transfers

**Root cause:** the address page is hydrated from `/address/aggregate/:addr`, which only returns native `transactions_by_address` + `internal_transactions_by_address`. There is no holder-side index of `tokenTransfers`, the existing `/token/:addr/transfers` route is keyed by *contract*. So an address that has done lots of NFT activity but few native value transfers shows an empty / sparse Transactions table.

Verified against `Q6153d37fa4da7193e6219dcbd2bbe62fa12905b1` on local mongo: `tokenTransfers.countDocuments({$or:[{from},{to}]}) = 20`, but the previous frontend never fetched them.

**Fix:**
- New `GET /address/:address/token-transfers?page=&limit=` backed by `db.GetTokenTransfersByAddress`. Sorts by blockNumber desc, paginated (matches `/token/:addr/transfers` shape).
- `TanStackTable` grows a third "Token Transfers" tab. Lazy-loads on first click (limit=250 single fetch so client-side search hits the whole holder history without per-page server round-trips). The address-page section heading is renamed Transactions to Activity to reflect the three tabs.
- The table now also renders when only internal txs exist, so a contract-call-only address still surfaces its tabs.

### Issue 2: holdings list flat + uncapped

Holdings used to render as a long flat list per section. Refactored both Tokens and NFTs into TanStack-Table-backed sections with:
- hard 5 rows per page
- first / prev / next / last controls matching the Transactions table
- per-section search input (filters by name / symbol / contract / tokenID)

## Test plan

- [x] `cd backendAPI && go build ./... && go vet ./...` clean
- [x] `cd ExplorerFrontend && npx tsc --noEmit` clean, `npm run lint` no new errors, `npm run build` clean, `npm test` 114/114 passing
- [x] Hit `GET /address/Q6153.../token-transfers?page=1&limit=5` directly + via dev proxy: `total=20`, page 2 returns next 5
- [ ] Manual browser check on `/address/Q6153d37fa4da7193e6219dcbd2bbe62fa12905b1`: open Token Transfers tab, page through 4 pages, search by NFT name, confirm rows render. Sandbox has no headless browser so the rendered DOM was verified by inspecting the SSR markup + compiled bundle, not by clicking through.
- [ ] Manual browser check that Holdings sections paginate at 5/page and the search input filters within section.

## Out of scope

- Did NOT widen the empty-state branch to consider token-only-activity addresses (still falls back to EmptyState when there are zero native + zero internal txs). The /address/aggregate response doesn't include token transfers, so detecting them upfront would require a fanout fetch on every address-page SSR. Left for a follow-up.
- Did NOT change `/address/aggregate` itself; tokenTransfers stay on the dedicated tab fetch.
- Did NOT touch `/token/:addr/transfers` (still by-contract, used by token-contract-view).