### PR TITLE
fix(address): tab badge total + sensible default tab + lift token-transfers cap

### DIFF
--- a/ExplorerFrontend/app/components/TanStackTable.tsx
+++ b/ExplorerFrontend/app/components/TanStackTable.tsx
@@ -150,12 +150,13 @@ export default function TanStackTable({ transactions, internalt, tokenTransferAd
   const [mounted, setMounted] = useState(false);
   const [windowWidth, setWindowWidth] = useState(0);
   const [globalFilter, setGlobalFilter] = useState("");
-  // Default to the first tab with data. Falling back to "transactions"
+  // Default to the first tab with rows. Falling back to "transactions"
   // would show an empty table for contract-call-only addresses (no native
   // txs but plenty of internal calls / token transfers). Token transfers
-  // aren't fetched yet at this point, so we can only pick between native
-  // and internal here, with a deferred switch to "tokenTransfers" below
-  // once the lazy fetch confirms there's something there.
+  // are lazy-fetched, so the only signal we have here is "is the page
+  // wired to fetch them" (tokenTransferAddress is set), not "are there
+  // any". If the fetch later returns zero rows the tab still shows the
+  // empty-state message, which is fine.
   const initialActiveTab: TabKey =
     transactions.length > 0
       ? "transactions"
@@ -173,6 +174,31 @@ export default function TanStackTable({ transactions, internalt, tokenTransferAd
   const [tokenTransfersLoaded, setTokenTransfersLoaded] = useState(false);
   const [tokenTransfersLoading, setTokenTransfersLoading] = useState(false);
   const [tokenTransfersError, setTokenTransfersError] = useState<string | null>(null);
+
+  // When the addressee changes mid-mount (Next.js client-side route from
+  // /address/A to /address/B reuses this component), wipe the lazy-fetched
+  // token-transfer state so the new address triggers a fresh fetch instead
+  // of rendering the previous holder's rows. Same goes for the active tab
+  // and the search filter — both should reset to the new address's default.
+  useEffect(() => {
+    setTokenTransfers([]);
+    setTokenTransfersTotal(0);
+    setTokenTransfersLoaded(false);
+    setTokenTransfersLoading(false);
+    setTokenTransfersError(null);
+    const nextDefault: TabKey =
+      transactions.length > 0
+        ? "transactions"
+        : internalt.length > 0
+          ? "internal"
+          : tokenTransferAddress
+            ? "tokenTransfers"
+            : "transactions";
+    setActiveTab(nextDefault);
+    setGlobalFilter("");
+    // Length-based deps keep the effect stable across renders that pass new
+    // array identities for the same address.
+  }, [tokenTransferAddress, transactions.length, internalt.length]);
 
   useEffect(() => {
     setMounted(true);

--- a/ExplorerFrontend/app/components/TanStackTable.tsx
+++ b/ExplorerFrontend/app/components/TanStackTable.tsx
@@ -150,8 +150,26 @@ export default function TanStackTable({ transactions, internalt, tokenTransferAd
   const [mounted, setMounted] = useState(false);
   const [windowWidth, setWindowWidth] = useState(0);
   const [globalFilter, setGlobalFilter] = useState("");
-  const [activeTab, setActiveTab] = useState<TabKey>("transactions");
+  // Default to the first tab with data. Falling back to "transactions"
+  // would show an empty table for contract-call-only addresses (no native
+  // txs but plenty of internal calls / token transfers). Token transfers
+  // aren't fetched yet at this point, so we can only pick between native
+  // and internal here, with a deferred switch to "tokenTransfers" below
+  // once the lazy fetch confirms there's something there.
+  const initialActiveTab: TabKey =
+    transactions.length > 0
+      ? "transactions"
+      : internalt.length > 0
+        ? "internal"
+        : tokenTransferAddress
+          ? "tokenTransfers"
+          : "transactions";
+  const [activeTab, setActiveTab] = useState<TabKey>(initialActiveTab);
   const [tokenTransfers, setTokenTransfers] = useState<TokenTransferRow[]>([]);
+  // Server-reported unbounded count for the tab badge. tokenTransfers.length
+  // only reflects what was paginated into memory (capped at 250), which would
+  // misleadingly stop growing for very active addresses.
+  const [tokenTransfersTotal, setTokenTransfersTotal] = useState(0);
   const [tokenTransfersLoaded, setTokenTransfersLoaded] = useState(false);
   const [tokenTransfersLoading, setTokenTransfersLoading] = useState(false);
   const [tokenTransfersError, setTokenTransfersError] = useState<string | null>(null);
@@ -190,7 +208,9 @@ export default function TanStackTable({ transactions, internalt, tokenTransferAd
         );
         if (cancelled) return;
         const rows: TokenTransferRow[] = Array.isArray(res.data?.transfers) ? res.data.transfers : [];
+        const total = typeof res.data?.total === "number" ? res.data.total : rows.length;
         setTokenTransfers(rows);
+        setTokenTransfersTotal(total);
         setTokenTransfersLoaded(true);
       } catch (err) {
         if (cancelled) return;
@@ -811,7 +831,7 @@ export default function TanStackTable({ transactions, internalt, tokenTransferAd
               >
                 Token Transfers
                 {tokenTransfersLoaded && (
-                  <span className="ml-1 text-xs opacity-75">({tokenTransfers.length})</span>
+                  <span className="ml-1 text-xs opacity-75">({tokenTransfersTotal})</span>
                 )}
               </button>
             )}

--- a/backendAPI/db/token.go
+++ b/backendAPI/db/token.go
@@ -508,8 +508,15 @@ func GetTokenTransfersByAddress(address string, page, limit int) ([]models.Token
 	if limit < 1 {
 		limit = 25
 	}
-	if limit > 50 {
-		limit = 50
+	// 250 matches the frontend's bulk fetch (TanStackTable lazy-loads the
+	// full holder history once so the in-table search/pagination work
+	// without per-page round-trips). A lower ceiling here silently
+	// truncated active addresses, and the "(N)" tab badge then under-
+	// reported their real activity. The `total` returned in the response
+	// is still the unbounded CountDocuments, so the tab can render the
+	// true number regardless of what was paginated in.
+	if limit > 250 {
+		limit = 250
 	}
 
 	canonical := normalizeAddress(address)


### PR DESCRIPTION
## Why

Gemini review on #111 flagged three correctness gaps that only bite higher-volume addresses than the Q6153 test fixture used to verify the PR. The fixture has 24 token transfers so the symptoms were invisible during merge testing. Addressing all three in one follow-up.

## What

**1. \`GetTokenTransfersByAddress\` cap lifted 50 → 250** (\`backendAPI/db/token.go\`)
The frontend's \`TanStackTable\` lazy-fetches \`limit=250\` once so the in-table search runs across the full holder history without per-page round-trips. The backend was capping at 50, silently truncating any active address. Raised the cap to 250 to match. \`CountDocuments\` still returns the unbounded total.

**2. Tab badge uses server \`total\`, not \`tokenTransfers.length\`** (\`TanStackTable.tsx\`)
Previously the \"(N)\" badge surfaced the length of what was paginated in. For an address with 1k transfers it would freeze at the cap. Added a \`tokenTransfersTotal\` state, set from \`res.data.total\`, and rendered that instead.

**3. Default \`activeTab\` picks the first tab with data** (\`TanStackTable.tsx\`)
Hardcoded default of \`\"transactions\"\` opened a contract-call-only address (zero native, all internal + token transfers) on an empty table. Now picks: native if any, else internal, else token transfers (when a \`tokenTransferAddress\` prop is provided). Token transfers are lazy-fetched so we can't peek at their count without an eager round-trip; that's an acceptable tradeoff vs the empty-by-default state.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`npm run lint\` — 24 pre-existing warnings, 0 errors, 0 new
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` succeeds
- [ ] Verify in browser on dev/prod after merge: Q6153 still shows \"(24)\" on the token transfers tab, and the holdings/holders tables paginate correctly; a contract-call-only address opens on its non-empty tab.

Addresses Gemini comments r3298710xxx on #111.