### PR TITLE
feat(tx): show "Contract Created" address in empty To field

### DIFF
--- a/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
+++ b/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
@@ -233,15 +233,53 @@ export default function TransactionView({ transaction }: TransactionViewProps): 
             </div>
           </DetailRow>
           <DetailRow label="To" mono>
-            <div className="flex items-start gap-2">
-              <Link
-                href={`/address/${transaction.to}`}
-                className="text-gray-200 hover:text-[#ffa729] transition-colors break-all"
-              >
-                {displayAddr(transaction.to)}
-              </Link>
-              <CopyButton value={transaction.to} label="Copy address" size="sm" />
-            </div>
+            {/* Contract-creation txs have an empty `to` because the tx
+                doesn't target an existing address; the new contract's
+                address comes back on the receipt. Render Etherscan-style:
+                "[Contract Created]" label + the new contract address as
+                a link, instead of an empty field. The separate "Contract
+                Created" section below still surfaces the token / standard
+                details. */}
+            {transaction.contractCreated?.address ? (
+              <div className="flex items-start gap-2 flex-wrap">
+                <span className="inline-flex items-center gap-1 text-xs text-green-400">
+                  <svg
+                    className="w-3.5 h-3.5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={2}
+                    stroke="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                  </svg>
+                  Contract Created
+                </span>
+                <Link
+                  href={`/address/${transaction.contractCreated.address}`}
+                  className="text-gray-200 hover:text-[#ffa729] transition-colors break-all"
+                >
+                  {displayAddr(transaction.contractCreated.address)}
+                </Link>
+                <CopyButton
+                  value={transaction.contractCreated.address}
+                  label="Copy contract address"
+                  size="sm"
+                />
+              </div>
+            ) : transaction.to ? (
+              <div className="flex items-start gap-2">
+                <Link
+                  href={`/address/${transaction.to}`}
+                  className="text-gray-200 hover:text-[#ffa729] transition-colors break-all"
+                >
+                  {displayAddr(transaction.to)}
+                </Link>
+                <CopyButton value={transaction.to} label="Copy address" size="sm" />
+              </div>
+            ) : (
+              <span className="text-gray-500">—</span>
+            )}
           </DetailRow>
           <DetailRow label="Value">
             <span className="font-semibold text-[#ffa729]">{formattedValue}</span>

--- a/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
+++ b/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
@@ -242,7 +242,7 @@ export default function TransactionView({ transaction }: TransactionViewProps): 
                 details. */}
             {transaction.contractCreated?.address ? (
               <div className="flex items-start gap-2 flex-wrap">
-                <span className="inline-flex items-center gap-1 text-xs text-green-400">
+                <span className="inline-flex items-center gap-1 text-xs text-green-400 font-sans">
                   <svg
                     className="w-3.5 h-3.5"
                     fill="none"


### PR DESCRIPTION
## Why

Contract-creation txs (\`to\` empty on the wire because the tx doesn't target an existing address) rendered the /tx/:hash To DetailRow as an empty Link + Copy button. Looked broken.

Example: https://zondscan.com/tx/0xa36f354fcfa61315a5c785bea3b2112732d64c67997c16241c30c0c4d529b11e — the deploy of the SimpleERC1155 test contract.

The new contract's address has been on the page all along — \`transaction.contractCreated.address\` (also rendered in the standalone "Contract Created" section below). Just wasn't surfaced in the To row.

## What

Three-way branch on the To row in /tx/:hash:

1. \`contractCreated.address\` present → green "Contract Created" label + plus icon, then the new contract address as a Link, then a CopyButton labelled "Copy contract address". Etherscan-style.
2. Plain \`to\` present → existing render, byte-identical.
3. Neither (rare — pending tx or malformed payload) → "—" placeholder instead of a broken empty link.

The standalone "Contract Created" section below the main card stays unchanged. It carries the token-standard / name / symbol details that the inline To row leaves out, so users still get the full info without clutter in the header.

## Verification

- [x] \`tsc --noEmit\` clean.
- [x] \`npm run lint\` 0 errors, 24 pre-existing warnings.
- [x] \`npm run build\` succeeds.
- [x] Local SSR on the deploy tx shows "Contract Created" label, the new contract address (Q0a54...), and the "Copy contract address" button.
- [x] Local SSR on a normal call (the SimpleERC721.batchMint tx) renders standard To unchanged.