### PR TITLE
fix: show full address on mobile address page

### DIFF
--- a/ExplorerFrontend/app/address/[query]/address-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-view.tsx
@@ -23,7 +23,7 @@ interface AddressViewProps {
 // display the complete address rather than a truncated form.
 const AddressDisplay = ({ address }: { address: string }): JSX.Element => {
     return (
-        <div className="text-sm lg:text-base font-mono text-gray-300 break-all lg:break-normal">
+        <div className="text-sm lg:text-base font-mono text-gray-300 break-all">
             {address}
         </div>
     );

--- a/ExplorerFrontend/app/address/[query]/address-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-view.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState, useEffect } from 'react';
 import CopyButton from "../../components/CopyButton";
 import QRCodeButton from "../../components/QRCodeButton";
 import ContractTabs from "../../components/ContractTabs";
@@ -19,24 +18,13 @@ interface AddressViewProps {
     addressSegment: string;
 }
 
+// Show the full address on every screen size. The container wraps
+// long values (`break-all`) so even on a narrow phone there's room to
+// display the complete address rather than a truncated form.
 const AddressDisplay = ({ address }: { address: string }): JSX.Element => {
-    const [isMobile, setIsMobile] = useState(false);
-
-    useEffect(() => {
-        const checkScreenSize = (): void => {
-            setIsMobile(window.innerWidth < 768);
-        };
-        
-        checkScreenSize();
-        window.addEventListener('resize', checkScreenSize);
-        return () => window.removeEventListener('resize', checkScreenSize);
-    }, []);
-
-    const displayAddress = isMobile ? `${address.slice(0, 8)}...${address.slice(-6)}` : address;
-
     return (
         <div className="text-sm lg:text-base font-mono text-gray-300 break-all lg:break-normal">
-            {displayAddress}
+            {address}
         </div>
     );
 };


### PR DESCRIPTION
## Summary

On the address page, the address header was truncated to a shortened form (e.g. `Q79b662c...e6887f`) on mobile via a viewport-width check, even though there's plenty of room to wrap and show the full value.

This shows the **complete address on all screen sizes**. The container already has `break-all`, so on a narrow phone the address simply wraps onto multiple lines instead of being cut off.

## Changes

- `ExplorerFrontend/app/address/[query]/address-view.tsx`
  - Removed the `isMobile` slice logic in `AddressDisplay` so the full address renders on every screen size.
  - Dropped the now-unused `useState`/`useEffect` mobile-detection and the `resize` listener.

This also applies to the contract **Creator Address**, which uses the same component, so it now shows in full too. The breadcrumb is intentionally left truncated since it's a compact nav element.

## Testing

- `tsc --noEmit` passes with no errors in the changed file.

https://claude.ai/code/session_01XjXANEqyFZ6uc9xuKDJ8Pz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjXANEqyFZ6uc9xuKDJ8Pz)_