### PR TITLE
fix: render tx Amount/PaidFees from exact wei integers, not float64

### DIFF
--- a/QRL2MongoDB/db/transactions.go
+++ b/QRL2MongoDB/db/transactions.go
@@ -411,20 +411,24 @@ func processTransactionData(tx *models.Transaction, blockTimestamp string, to st
 
 	feesBig := new(big.Int).Mul(gasPriceBig, gasUsedBig)
 
+	// Ensure fees are never zero for successful transactions. Apply the
+	// minimal-fee floor to the wei integer (0.000001 QRL = 1e12 wei) so the
+	// exact paidFeesWei string and the legacy paidFees float stay consistent.
+	if feesBig.Sign() == 0 && statusTx == "0x1" {
+		configs.Logger.Warn("Calculated fees is zero for a successful transaction, using minimal fee",
+			zap.String("txHash", txHash))
+		feesBig = big.NewInt(1_000_000_000_000)
+	}
+
+	// Legacy float fields, kept for backward-compatible numeric queries (e.g.
+	// amount $gt 0). The exact, drift-free value travels alongside them as the
+	// amountWei / paidFeesWei base-10 integer strings (value and feesBig).
 	divisor = new(big.Float).SetFloat64(float64(configs.QUANTA))
 	feesFloat := new(big.Float).SetInt(feesBig)
 	feesResult := new(big.Float).Quo(feesFloat, divisor)
 	fees, _ := feesResult.Float64()
 
-	// Ensure fees are never zero for successful transactions
-	if fees == 0 && statusTx == "0x1" {
-		configs.Logger.Warn("Calculated fees is zero for a successful transaction, using minimal fee",
-			zap.String("txHash", txHash))
-		// Set a minimal fee value rather than zero
-		fees = 0.000001
-	}
-
-	TransactionByAddressCollection(blockTimestamp, txType, from, to, txHash, valueFloat64, fees, blockNumber)
+	TransactionByAddressCollection(blockTimestamp, txType, from, to, txHash, valueFloat64, fees, blockNumber, value.String(), feesBig.String())
 	TransferCollection(blockNumber, blockTimestamp, from, to, txHash, pk, signature, nonce, valueFloat64, data, contractAddress, statusTx, size, fees)
 }
 
@@ -518,7 +522,11 @@ func InternalTransactionByAddressCollection(transactionType string, callType str
 	return result, nil
 }
 
-func TransactionByAddressCollection(timeStamp string, txType string, from string, to string, hash string, amount float64, paidFees float64, blockNumber string) (*mongo.InsertOneResult, error) {
+// TransactionByAddressCollection persists a per-address transaction row.
+// amount/paidFees are the legacy float64 columns (kept for backward-compatible
+// numeric queries); amountWei/paidFeesWei are the exact base-10 wei integer
+// strings the API uses to render QRL without float64 precision drift.
+func TransactionByAddressCollection(timeStamp string, txType string, from string, to string, hash string, amount float64, paidFees float64, blockNumber string, amountWei string, paidFeesWei string) (*mongo.InsertOneResult, error) {
 	// Normalize addresses to canonical Q-prefix form
 	from = validation.ConvertToQAddress(from)
 	if to != "" {
@@ -532,7 +540,9 @@ func TransactionByAddressCollection(timeStamp string, txType string, from string
 		{Key: "txHash", Value: hash},
 		{Key: "timeStamp", Value: timeStamp},
 		{Key: "amount", Value: amount},
+		{Key: "amountWei", Value: amountWei},
 		{Key: "paidFees", Value: paidFees},
+		{Key: "paidFeesWei", Value: paidFeesWei},
 		{Key: "blockNumber", Value: blockNumber},
 	}
 

--- a/backendAPI/db/transaction.go
+++ b/backendAPI/db/transaction.go
@@ -18,7 +18,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-
 func ReturnLatestTransactions() ([]models.TransactionByAddress, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	var transactions []models.TransactionByAddress
@@ -33,7 +32,9 @@ func ReturnLatestTransactions() ([]models.TransactionByAddress, error) {
 		{Key: "txHash", Value: 1},
 		{Key: "timeStamp", Value: 1},
 		{Key: "amount", Value: 1},
+		{Key: "amountWei", Value: 1},
 		{Key: "paidFees", Value: 1},
+		{Key: "paidFeesWei", Value: 1},
 		{Key: "blockNumber", Value: 1},
 	}
 
@@ -169,12 +170,14 @@ func ReturnAllTransactionsByAddress(address string, page, limit int) ([]models.T
 	projection := primitive.D{
 		{Key: "timeStamp", Value: 1},
 		{Key: "amount", Value: 1},
+		{Key: "amountWei", Value: 1},
 		{Key: "inOut", Value: 1},
 		{Key: "txHash", Value: 1},
 		{Key: "txType", Value: 1},
 		{Key: "from", Value: 1},
 		{Key: "to", Value: 1},
 		{Key: "paidFees", Value: 1},
+		{Key: "paidFeesWei", Value: 1},
 		{Key: "blockNumber", Value: 1},
 	}
 
@@ -238,7 +241,9 @@ func ReturnTransactionsNetwork(page, limit int) ([]models.TransactionByAddress, 
 		{Key: "txHash", Value: 1},
 		{Key: "timeStamp", Value: 1},
 		{Key: "amount", Value: 1},
+		{Key: "amountWei", Value: 1},
 		{Key: "paidFees", Value: 1},
+		{Key: "paidFeesWei", Value: 1},
 		{Key: "blockNumber", Value: 1},
 	}
 
@@ -283,6 +288,7 @@ func ReturnTransactions(address string, page, limit int) ([]models.TransactionBy
 		{Key: "txHash", Value: 1},
 		{Key: "timeStamp", Value: 1},
 		{Key: "amount", Value: 1},
+		{Key: "amountWei", Value: 1},
 	}
 
 	opts := options.Find().
@@ -595,6 +601,7 @@ func ReturnNonZeroTransactions(address string, page, limit int) ([]models.Transa
 		{Key: "txHash", Value: 1},
 		{Key: "timeStamp", Value: 1},
 		{Key: "amount", Value: 1},
+		{Key: "amountWei", Value: 1},
 		{Key: "from", Value: 1},
 		{Key: "to", Value: 1},
 		{Key: "blockNumber", Value: 1},

--- a/backendAPI/models/transactionbyaddress.go
+++ b/backendAPI/models/transactionbyaddress.go
@@ -33,8 +33,9 @@ type TransactionByAddress struct {
 
 // weiPerQuanta is 10^18: one QRL expressed in wei. Kept as a big.Int so the
 // wei -> QRL conversion stays in exact integer/rational arithmetic and never
-// touches a float64.
-var weiPerQuanta = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+// touches a float64. 10^18 fits in an int64 (max ~9.22e18), so a literal is
+// cheaper and clearer than computing it with Exp at init.
+var weiPerQuanta = big.NewInt(1_000_000_000_000_000_000)
 
 // quantaFromWei converts a raw wei amount, given as a base-10 integer string,
 // into an exact QRL decimal string with 18 fractional digits. Because the

--- a/backendAPI/models/transactionbyaddress.go
+++ b/backendAPI/models/transactionbyaddress.go
@@ -2,7 +2,7 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
+	"math/big"
 	"strconv"
 	"strings"
 
@@ -10,22 +10,65 @@ import (
 )
 
 type TransactionByAddress struct {
-	ID          primitive.ObjectID `bson:"_id,omitempty"`
-	InOut       int                `bson:"inOut" json:"InOut"`
-	TxType      string             `bson:"txType" json:"TxType"`
-	Address     string             `json:"Address" bson:"Address"`
-	From        string             `bson:"from" json:"From"`
-	To          string             `bson:"to" json:"To"`
-	TxHash      string             `bson:"txHash" json:"TxHash"`
-	TimeStamp   string             `bson:"timeStamp" json:"TimeStamp"`
-	Amount      float64            `bson:"amount" json:"-"`
-	PaidFees    float64            `bson:"paidFees" json:"-"`
-	BlockNumber string             `bson:"blockNumber" json:"BlockNumber"`
+	ID        primitive.ObjectID `bson:"_id,omitempty"`
+	InOut     int                `bson:"inOut" json:"InOut"`
+	TxType    string             `bson:"txType" json:"TxType"`
+	Address   string             `json:"Address" bson:"Address"`
+	From      string             `bson:"from" json:"From"`
+	To        string             `bson:"to" json:"To"`
+	TxHash    string             `bson:"txHash" json:"TxHash"`
+	TimeStamp string             `bson:"timeStamp" json:"TimeStamp"`
+	Amount    float64            `bson:"amount" json:"-"`
+	PaidFees  float64            `bson:"paidFees" json:"-"`
+	// AmountWei / PaidFeesWei carry the exact value as a base-10 wei integer
+	// string (e.g. "3300000000000000000"). The syncer writes these so the API
+	// can render QRL without ever routing the value through a float64, which
+	// can't represent 3.3 and used to leak as "3.299999999999999822". Older
+	// documents predate these fields; MarshalJSON falls back to the float
+	// columns above when they are empty.
+	AmountWei   string `bson:"amountWei" json:"-"`
+	PaidFeesWei string `bson:"paidFeesWei" json:"-"`
+	BlockNumber string `bson:"blockNumber" json:"BlockNumber"`
 }
 
+// weiPerQuanta is 10^18: one QRL expressed in wei. Kept as a big.Int so the
+// wei -> QRL conversion stays in exact integer/rational arithmetic and never
+// touches a float64.
+var weiPerQuanta = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+
+// quantaFromWei converts a raw wei amount, given as a base-10 integer string,
+// into an exact QRL decimal string with 18 fractional digits. Because the
+// math is done with big.Int/big.Rat, 3300000000000000000 wei renders as
+// "3.300000000000000000" — never "3.2999999999999998xx" — and arbitrarily
+// large values keep every digit. Returns ("", false) when s is not a valid
+// integer (including the empty string) so callers can fall back.
+func quantaFromWei(s string) (string, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", false
+	}
+	wei, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		return "", false
+	}
+	// SetFrac models wei/10^18 as an exact rational; FloatString(18) renders
+	// it at exactly 18 dp with no rounding (10^18 has 18 digits).
+	return new(big.Rat).SetFrac(wei, weiPerQuanta).FloatString(18), true
+}
+
+// formatFloat is the legacy fallback for documents written before the exact
+// wei fields existed. The stored float64 already lost precision at sync time,
+// but FormatFloat with prec -1 emits the shortest decimal that round-trips to
+// it ("3.3", not "3.299999999999999822"), and re-rendering that through
+// big.Rat yields the same fixed-18-dp shape as the exact path. Best-effort:
+// spot-on for typical amounts, still float-bounded for very large legacy
+// values, which only an upstream re-sync (populating amountWei) can fully fix.
 func formatFloat(f float64) string {
-	// %.18f shows all 18 decimal places for Planck (10^-18 QRL)
-	return fmt.Sprintf("%.18f", f)
+	shortest := strconv.FormatFloat(f, 'f', -1, 64)
+	if r, ok := new(big.Rat).SetString(shortest); ok {
+		return r.FloatString(18)
+	}
+	return shortest
 }
 
 func formatBlockNumber(blockNum string) string {
@@ -42,9 +85,22 @@ func formatBlockNumber(blockNum string) string {
 	return blockNum
 }
 
-// MarshalJSON implements custom JSON marshaling
+// MarshalJSON implements custom JSON marshaling. Amount and PaidFees are
+// emitted as exact QRL decimal strings, preferring the raw-wei integer fields
+// and falling back to the legacy float columns for documents that predate
+// them.
 func (t TransactionByAddress) MarshalJSON() ([]byte, error) {
 	type Alias TransactionByAddress
+
+	amount, ok := quantaFromWei(t.AmountWei)
+	if !ok {
+		amount = formatFloat(t.Amount)
+	}
+	paidFees, ok := quantaFromWei(t.PaidFeesWei)
+	if !ok {
+		paidFees = formatFloat(t.PaidFees)
+	}
+
 	return json.Marshal(struct {
 		Alias
 		Amount      string `json:"Amount"`
@@ -52,8 +108,8 @@ func (t TransactionByAddress) MarshalJSON() ([]byte, error) {
 		BlockNumber string `json:"BlockNumber"`
 	}{
 		Alias:       Alias(t),
-		Amount:      formatFloat(t.Amount),
-		PaidFees:    formatFloat(t.PaidFees),
+		Amount:      amount,
+		PaidFees:    paidFees,
 		BlockNumber: formatBlockNumber(t.BlockNumber),
 	})
 }

--- a/backendAPI/models/transactionbyaddress_test.go
+++ b/backendAPI/models/transactionbyaddress_test.go
@@ -1,0 +1,106 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestQuantaFromWei locks in exact base-10 wei -> QRL conversion. The whole
+// point of carrying wei as an integer string is that none of these go through
+// a float64, so 3.3 stays 3.3 and 24-digit values keep every digit.
+func TestQuantaFromWei(t *testing.T) {
+	cases := []struct {
+		name string
+		wei  string
+		want string
+		ok   bool
+	}{
+		// The headline bug: 3.3 QRL must be exact, never 3.2999999999999998xx.
+		{"3.3 QRL", "3300000000000000000", "3.300000000000000000", true},
+		{"0.1 QRL", "100000000000000000", "0.100000000000000000", true},
+		{"0.33 QRL", "330000000000000000", "0.330000000000000000", true},
+		{"6.18 QRL", "6180000000000000000", "6.180000000000000000", true},
+		// 1 gwei = 1e9 wei = 1e-9 QRL: smallest-unit precision survives.
+		{"1 gwei", "1000000000", "0.000000001000000000", true},
+		// Large value (1000+ QRL) round-trips losslessly.
+		{"1000 QRL", "1000000000000000000000", "1000.000000000000000000", true},
+		// 24-digit wei: every digit preserved (well past float64's ~15-16
+		// significant-digit ceiling).
+		{"huge mixed", "123456789012345678901234", "123456.789012345678901234", true},
+		{"one wei", "1", "0.000000000000000001", true},
+		{"zero", "0", "0.000000000000000000", true},
+		{"leading/trailing space tolerated", " 3300000000000000000 ", "3.300000000000000000", true},
+		{"empty not ok", "", "", false},
+		{"decimal input rejected", "3.3", "", false},
+		{"hex input rejected", "0xabc", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := quantaFromWei(tc.wei)
+			if ok != tc.ok {
+				t.Fatalf("quantaFromWei(%q) ok = %v, want %v", tc.wei, ok, tc.ok)
+			}
+			if got != tc.want {
+				t.Errorf("quantaFromWei(%q) = %q, want %q", tc.wei, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMarshalJSONPrefersWei verifies the response uses the exact wei fields
+// when present, regardless of the lossy float column sitting next to them.
+func TestMarshalJSONPrefersWei(t *testing.T) {
+	tx := TransactionByAddress{
+		Amount:      3.3,                   // float64 3.3 is really 3.2999999999999998
+		AmountWei:   "3300000000000000000", // exact
+		PaidFees:    0.000001,
+		PaidFeesWei: "1000000000000", // 0.000001 QRL
+		BlockNumber: "0x10",
+	}
+	got := marshalToStrings(t, tx)
+	if got["Amount"] != "3.300000000000000000" {
+		t.Errorf("Amount = %q, want 3.300000000000000000", got["Amount"])
+	}
+	if got["PaidFees"] != "0.000001000000000000" {
+		t.Errorf("PaidFees = %q, want 0.000001000000000000", got["PaidFees"])
+	}
+	if got["BlockNumber"] != "16" {
+		t.Errorf("BlockNumber = %q, want 16", got["BlockNumber"])
+	}
+}
+
+// TestMarshalJSONFallbackCleansLegacyFloat covers documents written before the
+// wei fields existed: the float fallback must still strip the IEEE-754 noise
+// that produced the reported "3.29999..." display for typical amounts.
+func TestMarshalJSONFallbackCleansLegacyFloat(t *testing.T) {
+	tx := TransactionByAddress{Amount: 3.3, PaidFees: 6.18}
+	got := marshalToStrings(t, tx)
+	if got["Amount"] != "3.300000000000000000" {
+		t.Errorf("Amount = %q, want 3.300000000000000000", got["Amount"])
+	}
+	if got["PaidFees"] != "6.180000000000000000" {
+		t.Errorf("PaidFees = %q, want 6.180000000000000000", got["PaidFees"])
+	}
+}
+
+// marshalToStrings marshals tx and returns the subset of top-level JSON fields
+// whose values are strings (Amount/PaidFees/BlockNumber/etc.).
+func marshalToStrings(t *testing.T, tx TransactionByAddress) map[string]string {
+	t.Helper()
+	b, err := json.Marshal(tx)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	out := make(map[string]string)
+	for k, v := range raw {
+		var s string
+		if err := json.Unmarshal(v, &s); err == nil {
+			out[k] = s
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

The address-transactions API returned QRL amounts with floating-point drift — a 3.3 QRL transfer came back as `"3.299999999999999822"`. This keeps the wei value as a big integer end-to-end and converts to QRL with exact base-10 arithmetic, so amounts are now exact at the source.

This powers `GET /address/:addr/transactions`, which the QRL wallet's `/tx-history` proxy returns verbatim, so the wallet was displaying the bad values.

## The bug

Live response for `Q79b662ce3d663643df4454a8ba3f532c0de6887f`:

```
"Amount":"3.299999999999999822"    <- should be "3.3"
"Amount":"6.179999999999999716"    <- should be "6.18"
"Amount":"0.330000000000000016"    <- should be "0.33"
```

The trailing-garbage pattern is the fingerprint of IEEE-754 double division, not an exact base-10/BigInt conversion.

## Root cause

The precision loss was baked in **upstream at sync time**, not in the API formatter. In `QRL2MongoDB/db/transactions.go`, `processTransactionData` divided wei by `1e18` using `big.Float` and then called `.Float64()`, storing the lossy `float64` in MongoDB's `transactionByAddress.amount` / `paidFees`:

```go
value := new(big.Int)
value.SetString(tx.Value[2:], 16)
divisor := new(big.Float).SetFloat64(float64(configs.QUANTA)) // 1e18
bigIntAsFloat := new(big.Float).SetInt(value)
resultBigFloat := new(big.Float).Quo(bigIntAsFloat, divisor)
valueFloat64, _ := resultBigFloat.Float64()   // <-- lossy: 3.3 -> 3.2999999999999998
```

The backend then read that `float64` and printed it with `fmt.Sprintf("%.18f", f)`, which faithfully renders the double's true value (`3.299999999999999822`). `float64` simply can't represent `3.3`.

## The fix — keep wei as a big integer end-to-end

**1. Syncer (`QRL2MongoDB/db/transactions.go`)**
Write the raw transfer/fee wei as base-10 integer strings into two new fields, `amountWei` and `paidFeesWei`, alongside the legacy `float64` columns (kept so the existing `amount > 0` numeric query in `ReturnNonZeroTransactions` still works). The minimal-fee floor for zero-fee successful txs now applies to the wei integer (`0.000001 QRL = 1e12 wei`) so the exact and legacy representations stay consistent.

**2. Backend model (`backendAPI/models/transactionbyaddress.go`)**
`MarshalJSON` converts `amountWei` / `paidFeesWei` via `big.Int` / `big.Rat` (`FloatString(18)`) — never touching a `float64`:

```go
new(big.Rat).SetFrac(wei, weiPerQuanta).FloatString(18)
// 3300000000000000000 wei -> "3.300000000000000000"
```

For documents that predate the wei fields it falls back to the float column, but now via shortest-round-trip formatting (`strconv.FormatFloat(f, 'f', -1, 64)`), which strips the trailing IEEE-754 garbage for typical values even before a re-sync.

**3. Backend queries (`backendAPI/db/transaction.go`)**
Project `amountWei` / `paidFeesWei` in every handler that returns `TransactionByAddress` (`ReturnLatestTransactions`, `ReturnAllTransactionsByAddress`, `ReturnTransactionsNetwork`, `ReturnTransactions`, `ReturnNonZeroTransactions`).

The response shape is **unchanged** — `Amount` and `PaidFees` remain string fields. The wallet frontend already parses them as strings via `BigNumber`.

## Affected handlers — a note on the two address-transaction queries

Both read the `transactionByAddress` collection but serve different routes:

| | `ReturnNonZeroTransactions` | `ReturnAllTransactionsByAddress` |
|---|---|---|
| Route | `GET /address/:addr/transactions` (wallet / bug report) | `GET /address/aggregate/:addr` (frontend address page) |
| Filter | `from/to == addr` **AND `amount > 0`** (skips 0-value txs) | `from/to == addr` (all txs, incl. 0-value) |
| `paidFees` projected | No (so `PaidFees` was always `0`) | Yes |
| Pagination | applies skip/limit only when `limit != 0`; no clamp | clamps `page >= 1`, `limit` to `[1, 50]` |

The reported bug is on `Amount` via `ReturnNonZeroTransactions`. The exact-wei `Amount` fix is applied to both; the `PaidFees` exact-wei fix lands on the handlers that actually return fees.

## Verification

`go test ./models/` passes (`backendAPI/db` tests need a live Mongo connection at import time and are unrelated). New unit tests cover the conversion and both marshal paths:

- Exact, lossless conversion for **0.1, 0.33, 3.3, 6.18, 1 gwei (1e-9 QRL), 1000+ QRL, a 24-digit wei value, 1 wei, and 0**.
- `MarshalJSON` prefers the wei field when present.
- The legacy float fallback now renders `3.3` as `"3.300000000000000000"`, not `"3.29999…"`.

A tx with value exactly `3300000000000000000` wei now yields `Amount == "3.300000000000000000"`.

## Operational note

The code is exact for any row carrying `amountWei`. Existing historical rows only have the lossy `float64` until the syncer rewrites them, so **very large legacy amounts need a re-sync/backfill** to become exact. For typical amounts the improved float fallback removes the visible drift immediately.

https://claude.ai/code/session_01JgRyFgsbYvFKTAEJJMy137

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgRyFgsbYvFKTAEJJMy137)_