### PR TITLE
fix(address): auto-refresh native tx feed without manual reload

### DIFF
--- a/ExplorerFrontend/app/address/[query]/address-tabs.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-tabs.tsx
@@ -2,7 +2,10 @@
 
 import { useCallback, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
 import type { InternalTransaction, Transaction } from '@/app/types';
+import config from '../../../config';
 import TransactionsPanel from './panels/transactions-panel';
 import InternalPanel from './panels/internal-panel';
 import TokenTransfersPanel from './panels/token-transfers-panel';
@@ -61,13 +64,68 @@ interface AddressTabsProps {
 
 export default function AddressTabs({
   address,
-  transactions,
-  transactionsCount,
-  internalt,
+  transactions: initialTransactions,
+  transactionsCount: initialTransactionsCount,
+  internalt: initialInternalt,
 }: AddressTabsProps): JSX.Element {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+
+  // The server rendered page 1 of the native-tx feed + counts. Seed local
+  // state from those props, then keep them live by polling the same
+  // /address/aggregate endpoint client-side, so a transaction mined after
+  // the user lands (e.g. one they just sent from the wallet) appears on its
+  // own instead of requiring a manual page refresh.
+  //
+  // Safe to seed once via the initializer: the parent (address-view) passes
+  // key={addressSegment}, so this whole component unmounts + remounts on
+  // address change and the seed re-runs with the new holder's data.
+  const [transactions, setTransactions] = useState(initialTransactions);
+  const [transactionsCount, setTransactionsCount] = useState(initialTransactionsCount);
+  const [internalt, setInternalt] = useState(initialInternalt);
+
+  // Visibility-aware polling, same TanStack Query discipline as the
+  // home/gas/validators pages (backgrounded tabs go quiet). The interval
+  // sits just above the backend's 10s aggregate cache so each poll has a
+  // chance at fresh data rather than re-reading the same cached snapshot.
+  // refetchOnMount:'always' fires one client fetch right after hydration,
+  // which bypasses the page's 10s ISR and surfaces a tx that landed between
+  // the (possibly cached) server render and the user arriving.
+  useQuery<number>({
+    queryKey: ['address-aggregate', address],
+    queryFn: async () => {
+      const res = await axios.get(
+        `${config.handlerUrl}/address/aggregate/${address}`,
+        { params: { page: 1, limit: 10 } },
+      );
+      const data = res.data ?? {};
+      if (Array.isArray(data.transactions_by_address)) {
+        // Mirror the gas-field normalization the server page applies so the
+        // CSV export and any downstream readers see the same row shape.
+        setTransactions(
+          data.transactions_by_address.map((tx: any) => ({
+            ...tx,
+            gasUsedStr:
+              tx.gasUsedStr || (tx.gasUsed ? `0x${tx.gasUsed.toString(16)}` : '0x0'),
+            gasPriceStr:
+              tx.gasPriceStr || (tx.gasPrice ? `0x${tx.gasPrice.toString(16)}` : '0x0'),
+          })),
+        );
+      }
+      if (typeof data.transactions_count === 'number') {
+        setTransactionsCount(data.transactions_count);
+      }
+      if (Array.isArray(data.internal_transactions_by_address)) {
+        setInternalt(data.internal_transactions_by_address);
+      }
+      return Date.now();
+    },
+    refetchInterval: 15000,
+    refetchIntervalInBackground: false,
+    refetchOnMount: 'always',
+    staleTime: 0,
+  });
 
   const activeTab = parseTabKey(searchParams?.get('tab') ?? null);
 


### PR DESCRIPTION
## Problem
Clicking a wallet address (from qrlwallet.com) opens the zondscan address page, but recently-mined transactions did not appear until a manual page refresh.

**Root cause:** the address page rendered transactions once server-side and had **zero client-side refresh**. Transactions flowed as a static prop (`page.tsx` -> `address-view` -> `address-tabs` -> `transactions-panel`) and never re-fetched. The 10s page ISR (`page.tsx:49`) layered on the 10s backend aggregate cache (`routes.go:497`) also made the initial paint up to ~20s stale.

## Fix
`address-tabs.tsx` now seeds tx / count / internal-tx state from the server props, then polls `/address/aggregate` client-side via TanStack Query:
- `refetchInterval: 15000` (just above the backend's 10s cache so each poll can return fresh data)
- `refetchIntervalInBackground: false` (backgrounded tabs go quiet)
- `refetchOnMount: 'always'` (one fetch right after hydration bypasses the page ISR for a fresher first paint)

Same visibility-aware TanStack Query idiom already used on home/gas/validators. Per-address reset is free: parent already remounts via `key={addressSegment}`.

## Verification
- `tsc --noEmit` clean
- `eslint` 0 errors (1 pre-existing `tx: any` warning, matches server page pattern)
- `next build` succeeds

Residual floor (intentional): backend 10s singleflight cache + syncer indexing lag mean a brand-new tx can still take ~10-15s to surface, but it now surfaces automatically instead of requiring a manual reload.