### PR TITLE
feat(verify): support multiple Hyperion compiler builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ backendAPI/main.exe
 backendAPI/.env.production
 backendAPI/.env.development
 backendAPI/verification/runner/node_modules
+# Host-specific compiler manifest (HYPC_COMPILERS); commit compilers.example.json instead
+backendAPI/verification/runner/compilers.json
 *.exe
 .DS_Store
 npm-debug.log*

--- a/ExplorerFrontend/app/api-explorer/api-explorer-client.tsx
+++ b/ExplorerFrontend/app/api-explorer/api-explorer-client.tsx
@@ -254,14 +254,14 @@ const endpointGroups: EndpointGroup[] = [
       {
         method: 'GET',
         path: '/contract/compiler-info',
-        description: 'Returns the language and pinned Hyperion build id the verifier is willing to accept. Use this to confirm the explorer can verify against your hypc version before you POST a job. Returns 503 when the verifier is not configured on this deployment.',
+        description: 'Returns every Hyperion build the verifier can compile against: { language, buildId, default, compilers: [{ buildId, language, default }] }. The top-level buildId/language mirror the default build. Use this to pick a compilerVersion before you POST a job. Returns 503 when the verifier is not configured on this deployment.',
         example: '/contract/compiler-info',
       },
       {
         method: 'POST',
         path: '/contract/verify',
-        description: 'Enqueues a verification job for a deployed contract. The endpoint compiles the supplied source via the pinned hypc runner, compares the deployed-bytecode (Solidity-style CBOR metadata trailer stripped on both sides) and on success writes the verified source + ABI back onto the contract document. Rate-limited per IP. Max body 1 MiB. Returns { jobId, status, address } synchronously; poll /contract/verify/:jobId for the terminal state.',
-        params: 'JSON body, required: address, sourceCode, contractName. Optional: compilerVersion, optimizerEnabled, optimizerRuns, evmVersion, constructorArguments, libraries, imports, license. Example body: {"address":"Q…","sourceCode":"...","contractName":"Foo"}',
+        description: 'Enqueues a verification job for a deployed contract. The endpoint compiles the supplied source via the selected hypc build (compilerVersion; the default build is used when omitted), compares the deployed-bytecode (Solidity-style CBOR metadata trailer stripped on both sides) and on success writes the verified source + ABI back onto the contract document. An unknown compilerVersion returns 400 with the supportedBuilds list. Rate-limited per IP. Max body 1 MiB. Returns { jobId, status, address } synchronously; poll /contract/verify/:jobId for the terminal state.',
+        params: 'JSON body, required: address, sourceCode, contractName. Optional: compilerVersion (one of /contract/compiler-info buildIds; defaults to the default build), optimizerEnabled, optimizerRuns, evmVersion, constructorArguments, libraries, imports, license. Example body: {"address":"Q…","sourceCode":"...","contractName":"Foo"}',
         example: '/contract/verify',
       },
       {

--- a/ExplorerFrontend/app/verify-contract/verify-contract-client.tsx
+++ b/ExplorerFrontend/app/verify-contract/verify-contract-client.tsx
@@ -7,9 +7,17 @@ import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import config from '../../config';
 
+interface CompilerBuild {
+  buildId: string;
+  language: string;
+  default?: boolean;
+}
+
 interface CompilerInfo {
   language: string;
   buildId: string;
+  default?: string;
+  compilers?: CompilerBuild[];
 }
 
 interface VerifyEnqueueResponse {
@@ -34,9 +42,11 @@ const COMMON_LICENSES = ['MIT', 'GPL-3.0', 'Apache-2.0', 'BSD-2-Clause', 'BSD-3-
 
 /**
  * Client-side verify-contract form. Posts to /contract/verify and polls
- * /contract/verify/:jobId until terminal. Compiler-version selector is
- * intentionally absent, the backend supports exactly one pinned build
- * (read-only display).
+ * /contract/verify/:jobId until terminal. The compiler-version selector is
+ * populated from /contract/compiler-info; the user picks which configured
+ * Hyperion build to compile against (defaulting to the backend's default
+ * build). The byte-match only succeeds against the exact build the contract
+ * was deployed with, so offering the real list is what lets authors verify.
  */
 export default function VerifyContractClient(): JSX.Element {
   const searchParams = useSearchParams();
@@ -54,22 +64,38 @@ export default function VerifyContractClient(): JSX.Element {
 
   const [compilerInfo, setCompilerInfo] = useState<CompilerInfo | null>(null);
   const [compilerErr, setCompilerErr] = useState<string | null>(null);
+  const [selectedBuild, setSelectedBuild] = useState('');
 
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [job, setJob] = useState<VerificationJob | null>(null);
   const [alreadyVerified, setAlreadyVerified] = useState<string | null>(null);
 
-  // Fetch the pinned compiler build once on mount. If the backend doesn't
-  // expose it (503), surface that as a banner, submitting in that state
-  // will just 503 from the backend.
+  // Fetch the available compiler builds once on mount and preselect the
+  // backend's default. If the backend doesn't expose them (503), surface
+  // that as a banner, submitting in that state will just 503 from the
+  // backend.
   useEffect(() => {
     let cancelled = false;
     axios.get<CompilerInfo>(`${config.handlerUrl}/contract/compiler-info`)
-      .then(r => { if (!cancelled) setCompilerInfo(r.data); })
+      .then(r => {
+        if (cancelled) return;
+        setCompilerInfo(r.data);
+        setSelectedBuild(r.data.default || r.data.buildId || '');
+      })
       .catch(e => { if (!cancelled) setCompilerErr(extractAxiosError(e)); });
     return () => { cancelled = true; };
   }, []);
+
+  // Available builds, tolerant of an older single-build backend that only
+  // returns { language, buildId } (no `compilers` array).
+  const compilerBuilds: CompilerBuild[] = useMemo(() => {
+    if (!compilerInfo) return [];
+    if (compilerInfo.compilers && compilerInfo.compilers.length > 0) {
+      return compilerInfo.compilers;
+    }
+    return [{ buildId: compilerInfo.buildId, language: compilerInfo.language, default: true }];
+  }, [compilerInfo]);
 
   const isTerminal = job?.status === 'success' || job?.status === 'failed';
 
@@ -122,6 +148,7 @@ export default function VerifyContractClient(): JSX.Element {
         address: address.trim(),
         sourceCode,
         contractName: contractName.trim(),
+        compilerVersion: selectedBuild || undefined,
         optimizerEnabled,
         // Pass the raw optimizerRuns through, 0 is a legitimate
         // configuration distinct from the default, so don't fall back
@@ -152,14 +179,8 @@ export default function VerifyContractClient(): JSX.Element {
         </div>
       );
     }
-    if (!compilerInfo) return null;
-    return (
-      <div className="rounded-lg border border-border bg-card-gradient p-3 text-xs md:text-sm text-gray-300">
-        <div className="text-gray-400">Pinned compiler</div>
-        <div className="font-mono break-all">{compilerInfo.language} {compilerInfo.buildId}</div>
-      </div>
-    );
-  }, [compilerErr, compilerInfo]);
+    return null;
+  }, [compilerErr]);
 
   return (
     <div className="space-y-3 md:space-y-4">
@@ -204,6 +225,32 @@ export default function VerifyContractClient(): JSX.Element {
       )}
 
       <form onSubmit={handleSubmit} className="space-y-3 md:space-y-4">
+        {compilerBuilds.length > 0 && (
+          <Field
+            label="Compiler"
+            hint="Pick the Hyperion build your contract was compiled with — the byte-match only succeeds against that exact build."
+          >
+            {compilerBuilds.length === 1 ? (
+              <div className="form-input font-mono text-xs break-all bg-transparent">
+                {compilerBuilds[0].language} {compilerBuilds[0].buildId}
+              </div>
+            ) : (
+              <select
+                value={selectedBuild}
+                onChange={e => setSelectedBuild(e.target.value)}
+                disabled={submitting}
+                className="form-input font-mono text-xs"
+              >
+                {compilerBuilds.map(b => (
+                  <option key={b.buildId} value={b.buildId}>
+                    {b.language} {b.buildId}{b.default ? ' (default)' : ''}
+                  </option>
+                ))}
+              </select>
+            )}
+          </Field>
+        )}
+
         <Field label="Contract address (Q…)">
           <input
             required

--- a/backendAPI/routes/verification_routes.go
+++ b/backendAPI/routes/verification_routes.go
@@ -30,7 +30,7 @@ func RegisterVerificationRoutes(router *gin.Engine) {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "contract verification not configured"})
 			return
 		}
-		c.JSON(http.StatusOK, v.Compiler.CompilerInfo())
+		c.JSON(http.StatusOK, v.Registry.Info())
 	})
 
 	// Maximum body size for a verify submission. The compiler also has
@@ -62,14 +62,19 @@ func RegisterVerificationRoutes(router *gin.Engine) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "contractName and sourceCode are required"})
 			return
 		}
-		if req.CompilerVersion != "" && req.CompilerVersion != v.Compiler.BuildID {
+		// Resolve the requested build (empty selects the registry default).
+		// Pin the request to the resolved build id so the stored payload and
+		// the async compile can't drift from what we validated here.
+		comp, ok := v.Registry.Resolve(req.CompilerVersion)
+		if !ok {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error":           "unsupported compilerVersion, see /contract/compiler-info",
-				"supportedBuild":  v.Compiler.BuildID,
 				"requestedBuild":  req.CompilerVersion,
+				"supportedBuilds": v.Registry.SupportedBuildIDs(),
 			})
 			return
 		}
+		req.CompilerVersion = comp.BuildID
 
 		// Idempotency: if the contract is already verified, return success
 		// without spawning another compile.
@@ -97,7 +102,7 @@ func RegisterVerificationRoutes(router *gin.Engine) {
 			Payload: models.VerificationJobPayload{
 				SourceCode:           req.SourceCode,
 				ContractName:         req.ContractName,
-				CompilerVersion:      v.Compiler.BuildID,
+				CompilerVersion:      comp.BuildID,
 				OptimizationEnabled:  req.OptimizerEnabled,
 				OptimizationRuns:     req.OptimizerRuns,
 				EvmVersion:           req.EvmVersion,

--- a/backendAPI/verification/compiler.go
+++ b/backendAPI/verification/compiler.go
@@ -6,27 +6,31 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"strings"
-	"sync"
 	"time"
 )
 
-// Compiler wraps the @theqrl/hypc WASM via a one-shot Node subprocess
-// (backendAPI/verification/runner/hypc-runner.js). The Go layer holds the
-// sandboxing budget, timeout, concurrency cap, stdin size cap, scratch
-// env, so the runner can stay tiny.
+// Compiler wraps ONE pinned @theqrl/hypc build behind a one-shot subprocess
+// (the WASM-via-Node runner hypc-runner.js, or the native hypc-native.sh
+// wrapper). One Compiler == one build id.
+//
+// The sandboxing budget — per-compile timeout, stdin size cap, and the
+// concurrency semaphore — is supplied by the owning Registry and SHARED
+// across every build, so the total number of in-flight runner processes is
+// bounded regardless of which build a request selects.
 type Compiler struct {
-	NodeBin    string        // path to the `node` binary
-	RunnerPath string        // absolute path to hypc-runner.js
-	BuildID    string        // pinned version string (e.g. "0.0.2+commit.3e18e55d.Emscripten.clang")
-	Timeout    time.Duration // per-compile hard deadline
-	MaxStdin   int           // bytes, reject standard-JSON inputs larger than this
+	Language   string // always "Hyperion" today; carried explicitly for the API
+	NodeBin    string // path to the interpreter (`node`, or `/bin/sh` for the native wrapper)
+	RunnerPath string // absolute path to the runner (hypc-runner.js / hypc-native.sh)
+	Bin        string // optional native hypc path, passed to the runner as HYPC_BIN
+	BuildID    string // pinned version string the runner must report
+	Default    bool   // true for the build used when the client omits compilerVersion
 
-	sem  chan struct{}
-	once sync.Once
+	Timeout  time.Duration // per-compile hard deadline (shared across builds)
+	MaxStdin int           // standard-JSON payload cap in bytes (shared across builds)
+	sem      chan struct{} // concurrency permit, SHARED across all builds
 }
 
 // ErrPayloadTooLarge is returned when the standard-JSON payload exceeds
@@ -37,58 +41,42 @@ var ErrPayloadTooLarge = errors.New("verification: standard-JSON payload exceeds
 // ErrCompileTimeout is returned when the per-call deadline fires.
 var ErrCompileTimeout = errors.New("verification: compile timed out")
 
-// NewCompiler constructs a Compiler from environment variables:
-//
-//	HYPC_NODE_BIN           path to the node binary           (default "node")
-//	HYPC_RUNNER             abs path to hypc-runner.js        (required)
-//	HYPC_BUILD_ID           pinned version string             (required)
-//	VERIFIER_MAX_CONCURRENCY in-process concurrent compiles   (default 2)
-//	VERIFIER_COMPILE_TIMEOUT per-compile hard timeout         (default 30s)
-//	VERIFIER_SOURCE_MAX_BYTES standard-JSON payload cap       (default 256KiB)
-//
-// The Compiler fails fast at startup if HYPC_RUNNER / HYPC_BUILD_ID are
-// missing or if the runner's reported version doesn't match HYPC_BUILD_ID.
-func NewCompiler() (*Compiler, error) {
-	nodeBin := envWithDefault("HYPC_NODE_BIN", "node")
-	runner := os.Getenv("HYPC_RUNNER")
-	if runner == "" {
-		return nil, errors.New("HYPC_RUNNER env var is required (abs path to hypc-runner.js)")
+// newCompiler builds a single Compiler from a spec, wires in the shared
+// limits, and gates construction on a successful version probe: the runner
+// must report exactly spec.BuildID. A probe failure / mismatch is returned
+// as an error so the Registry can skip just this build.
+func newCompiler(spec CompilerSpec, sem chan struct{}, timeout time.Duration, maxStdin int) (*Compiler, error) {
+	nodeBin := spec.NodeBin
+	if nodeBin == "" {
+		nodeBin = "node"
 	}
-	buildID := os.Getenv("HYPC_BUILD_ID")
-	if buildID == "" {
-		return nil, errors.New("HYPC_BUILD_ID env var is required (pinned hypc version string)")
+	if spec.Runner == "" {
+		return nil, errors.New("runner path is required")
 	}
-	maxConc := envInt("VERIFIER_MAX_CONCURRENCY", 2)
-	if maxConc < 1 {
-		maxConc = 1
+	if spec.BuildID == "" {
+		return nil, errors.New("buildId is required")
 	}
-	timeout := envDuration("VERIFIER_COMPILE_TIMEOUT", 30*time.Second)
-	maxStdin := envInt("VERIFIER_SOURCE_MAX_BYTES", 256*1024)
 
 	c := &Compiler{
+		Language:   "Hyperion",
 		NodeBin:    nodeBin,
-		RunnerPath: runner,
-		BuildID:    buildID,
+		RunnerPath: spec.Runner,
+		Bin:        spec.Bin,
+		BuildID:    spec.BuildID,
+		Default:    spec.Default,
 		Timeout:    timeout,
 		MaxStdin:   maxStdin,
-		sem:        make(chan struct{}, maxConc),
+		sem:        sem,
 	}
 
-	// Validate the runner can be invoked + reports the expected build.
 	got, err := c.probeVersion()
 	if err != nil {
-		return nil, fmt.Errorf("hypc-runner version probe failed: %w", err)
+		return nil, fmt.Errorf("version probe failed: %w", err)
 	}
-	if got != buildID {
-		return nil, fmt.Errorf("hypc-runner build mismatch: want %q, got %q", buildID, got)
+	if got != spec.BuildID {
+		return nil, fmt.Errorf("build mismatch: want %q, got %q", spec.BuildID, got)
 	}
-	log.Printf("verification.Compiler ready: runner=%s build=%s timeout=%s concurrency=%d", runner, buildID, timeout, maxConc)
 	return c, nil
-}
-
-// CompilerInfo returns the pinned build ID. Used by GET /contract/compiler-info.
-func (c *Compiler) CompilerInfo() CompilerInfoResponse {
-	return CompilerInfoResponse{Language: "Hyperion", BuildID: c.BuildID}
 }
 
 // Compile invokes the runner with the supplied standard-JSON input and
@@ -125,7 +113,7 @@ func (c *Compiler) Compile(ctx context.Context, input StandardJSONInput) (*Stand
 	//   HYPC_BIN , lets the native-binary runner (hypc-native.sh) pin an
 	//               absolute hypc path independent of PATH order. Ignored
 	//               by the WASM-via-Node runner.
-	cmd.Env = runnerEnv()
+	cmd.Env = c.runnerEnv()
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -151,7 +139,7 @@ func (c *Compiler) probeVersion() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, c.NodeBin, c.RunnerPath, "--version")
-	cmd.Env = runnerEnv()
+	cmd.Env = c.runnerEnv()
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -159,13 +147,19 @@ func (c *Compiler) probeVersion() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// runnerEnv builds the minimal env passed to the runner subprocess.
-// Kept in one place so the Compile and probeVersion paths can't drift
-// from each other.
-func runnerEnv() []string {
+// runnerEnv builds the minimal env passed to this build's runner subprocess.
+// Each build pins its own HYPC_BIN (so two native builds can point at
+// different hypc binaries). When a build doesn't set Bin we fall back to a
+// process-level HYPC_BIN — this preserves the pre-multi-version single-build
+// deploy where HYPC_BIN was exported once in the environment.
+func (c *Compiler) runnerEnv() []string {
 	env := []string{"PATH=" + os.Getenv("PATH")}
-	if v := os.Getenv("HYPC_BIN"); v != "" {
-		env = append(env, "HYPC_BIN="+v)
+	bin := c.Bin
+	if bin == "" {
+		bin = os.Getenv("HYPC_BIN")
+	}
+	if bin != "" {
+		env = append(env, "HYPC_BIN="+bin)
 	}
 	return env
 }

--- a/backendAPI/verification/init.go
+++ b/backendAPI/verification/init.go
@@ -18,13 +18,13 @@ var (
 // routes are live; a non-nil error logs a warning and leaves the default
 // nil, the rest of the backend remains usable.
 func Init() error {
-	c, err := NewCompiler()
+	reg, err := NewRegistry()
 	if err != nil {
 		log.Printf("WARN: contract verification disabled, %v", err)
 		return err
 	}
 	defaultMu.Lock()
-	def = &Verifier{Compiler: c}
+	def = &Verifier{Registry: reg}
 	defaultMu.Unlock()
 	return nil
 }

--- a/backendAPI/verification/registry.go
+++ b/backendAPI/verification/registry.go
@@ -1,0 +1,194 @@
+package verification
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+)
+
+// CompilerSpec is one entry in the HYPC_COMPILERS manifest. It describes how
+// to invoke a single hypc build; the runner contract is shared with the
+// legacy single-build env vars (see backendAPI/verification/runner/).
+type CompilerSpec struct {
+	BuildID string `json:"buildId"`           // required: version string the runner must report
+	NodeBin string `json:"nodeBin,omitempty"` // interpreter; default "node"
+	Runner  string `json:"runner"`            // required: abs path to hypc-runner.js / hypc-native.sh
+	Bin     string `json:"bin,omitempty"`     // optional: native hypc path → HYPC_BIN for this build
+	Default bool   `json:"default,omitempty"` // optional: the build used when a request omits compilerVersion
+}
+
+// Registry holds every configured (and probe-verified) hypc build keyed by
+// build id, plus the build to use when a request doesn't pick one. Exactly
+// one build is always the default once construction succeeds.
+type Registry struct {
+	byID  map[string]*Compiler
+	order []*Compiler // stable display/iteration order (config order)
+	def   *Compiler
+}
+
+// NewRegistry builds the compiler registry from the environment.
+//
+// Preferred (multi-build): HYPC_COMPILERS holds either an inline JSON array
+// of CompilerSpec, or a path to a file containing that array.
+//
+// Legacy (single-build, still supported): when HYPC_COMPILERS is unset, a
+// one-entry registry is synthesised from HYPC_RUNNER / HYPC_BUILD_ID /
+// HYPC_NODE_BIN / HYPC_BIN exactly as the pre-multi-version backend did, so
+// existing deploys keep working untouched.
+//
+// Shared limits — VERIFIER_MAX_CONCURRENCY / VERIFIER_COMPILE_TIMEOUT /
+// VERIFIER_SOURCE_MAX_BYTES — bound ALL builds together (one process-wide
+// compile budget) regardless of which build a request selects.
+//
+// A build whose runner can't be invoked, or reports the wrong version, is
+// skipped with a warning rather than disabling the whole feature. Only when
+// zero builds survive does NewRegistry return an error (verification then
+// boots disabled and the routes answer 503).
+func NewRegistry() (*Registry, error) {
+	specs, err := loadCompilerSpecs()
+	if err != nil {
+		return nil, err
+	}
+	if len(specs) == 0 {
+		return nil, errors.New("no hypc builds configured (set HYPC_COMPILERS, or HYPC_RUNNER+HYPC_BUILD_ID)")
+	}
+
+	maxConc := envInt("VERIFIER_MAX_CONCURRENCY", 2)
+	if maxConc < 1 {
+		maxConc = 1
+	}
+	timeout := envDuration("VERIFIER_COMPILE_TIMEOUT", 30*time.Second)
+	maxStdin := envInt("VERIFIER_SOURCE_MAX_BYTES", 256*1024)
+	sem := make(chan struct{}, maxConc)
+
+	reg := &Registry{byID: map[string]*Compiler{}}
+	for _, spec := range specs {
+		if _, dup := reg.byID[spec.BuildID]; dup {
+			log.Printf("WARN: duplicate hypc build %q in HYPC_COMPILERS, keeping the first", spec.BuildID)
+			continue
+		}
+		c, err := newCompiler(spec, sem, timeout, maxStdin)
+		if err != nil {
+			log.Printf("WARN: skipping hypc build %q (runner=%s): %v", spec.BuildID, spec.Runner, err)
+			continue
+		}
+		reg.byID[c.BuildID] = c
+		reg.order = append(reg.order, c)
+		if c.Default && reg.def == nil {
+			reg.def = c
+		}
+	}
+
+	if len(reg.order) == 0 {
+		return nil, errors.New("no usable hypc builds (every configured runner failed its version probe)")
+	}
+
+	// Guarantee exactly one default and keep the Default flags consistent
+	// with reality (an explicit default may have been the build that got
+	// skipped above).
+	if reg.def == nil {
+		reg.def = reg.order[0]
+	}
+	for _, c := range reg.order {
+		c.Default = c == reg.def
+	}
+
+	log.Printf("verification.Registry ready: %d build(s) %v, default=%s, timeout=%s concurrency=%d",
+		len(reg.order), reg.SupportedBuildIDs(), reg.def.BuildID, timeout, maxConc)
+	return reg, nil
+}
+
+// loadCompilerSpecs reads the HYPC_COMPILERS manifest (inline JSON or a file
+// path), falling back to the legacy single-build env vars when unset.
+func loadCompilerSpecs() ([]CompilerSpec, error) {
+	raw := strings.TrimSpace(os.Getenv("HYPC_COMPILERS"))
+	if raw == "" {
+		return legacyCompilerSpecs(), nil
+	}
+
+	data := []byte(raw)
+	// Anything that doesn't start with a JSON array is treated as a path.
+	if !strings.HasPrefix(raw, "[") {
+		b, err := os.ReadFile(raw)
+		if err != nil {
+			return nil, fmt.Errorf("read HYPC_COMPILERS file %q: %w", raw, err)
+		}
+		data = b
+	}
+
+	var specs []CompilerSpec
+	if err := json.Unmarshal(data, &specs); err != nil {
+		return nil, fmt.Errorf("parse HYPC_COMPILERS: %w", err)
+	}
+	for i := range specs {
+		if specs[i].Runner == "" {
+			return nil, fmt.Errorf("HYPC_COMPILERS entry %d missing required \"runner\"", i)
+		}
+		if specs[i].BuildID == "" {
+			return nil, fmt.Errorf("HYPC_COMPILERS entry %d missing required \"buildId\"", i)
+		}
+	}
+	return specs, nil
+}
+
+// legacyCompilerSpecs reproduces the single-build configuration from the
+// pre-multi-version env vars. Returns nil when neither is set so the caller
+// can report "no builds configured".
+func legacyCompilerSpecs() []CompilerSpec {
+	runner := os.Getenv("HYPC_RUNNER")
+	buildID := os.Getenv("HYPC_BUILD_ID")
+	if runner == "" || buildID == "" {
+		return nil
+	}
+	return []CompilerSpec{{
+		BuildID: buildID,
+		NodeBin: envWithDefault("HYPC_NODE_BIN", "node"),
+		Runner:  runner,
+		Bin:     os.Getenv("HYPC_BIN"),
+		Default: true,
+	}}
+}
+
+// Resolve returns the compiler for the requested build id. An empty id
+// selects the default build. The bool is false only when a non-empty id
+// matches no configured build.
+func (r *Registry) Resolve(buildID string) (*Compiler, bool) {
+	if buildID == "" {
+		return r.def, true
+	}
+	c, ok := r.byID[buildID]
+	return c, ok
+}
+
+// Default returns the build used when a submission omits compilerVersion.
+func (r *Registry) Default() *Compiler { return r.def }
+
+// Info is the body of GET /contract/compiler-info: every selectable build
+// plus which one is the default. The top-level Language/BuildID mirror the
+// default build for backwards compatibility with single-build clients.
+func (r *Registry) Info() CompilerInfoResponse {
+	builds := make([]CompilerBuild, len(r.order))
+	for i, c := range r.order {
+		builds[i] = CompilerBuild{BuildID: c.BuildID, Language: c.Language, Default: c.Default}
+	}
+	return CompilerInfoResponse{
+		Language:  r.def.Language,
+		BuildID:   r.def.BuildID,
+		Default:   r.def.BuildID,
+		Compilers: builds,
+	}
+}
+
+// SupportedBuildIDs returns every configured build id in display order.
+// Used to populate the 400 response when a client requests an unknown build.
+func (r *Registry) SupportedBuildIDs() []string {
+	ids := make([]string, len(r.order))
+	for i, c := range r.order {
+		ids[i] = c.BuildID
+	}
+	return ids
+}

--- a/backendAPI/verification/registry_test.go
+++ b/backendAPI/verification/registry_test.go
@@ -1,0 +1,192 @@
+package verification
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// localBuildID is the build id reported by the npm @theqrl/hypc bundled in
+// verification/runner/node_modules. The integration test below probes the
+// real runner, so it only runs where that runner is installed and node is on
+// PATH; everywhere else it skips.
+const localBuildID = "0.0.2+commit.3e18e55d.Emscripten.clang"
+
+func localRunner(t *testing.T) string {
+	t.Helper()
+	abs, err := filepath.Abs(filepath.Join("runner", "hypc-runner.js"))
+	if err != nil {
+		t.Fatalf("abs runner path: %v", err)
+	}
+	return abs
+}
+
+// clearVerifierEnv blanks every env var loadCompilerSpecs consults so each
+// case starts from a known state (t.Setenv restores originals on cleanup).
+func clearVerifierEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{"HYPC_COMPILERS", "HYPC_RUNNER", "HYPC_BUILD_ID", "HYPC_NODE_BIN", "HYPC_BIN"} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestLoadCompilerSpecs_InlineArray(t *testing.T) {
+	clearVerifierEnv(t)
+	t.Setenv("HYPC_COMPILERS", `  [
+		{"buildId":"a","runner":"/x/a.js","default":true},
+		{"buildId":"b","runner":"/x/b.sh","nodeBin":"/bin/sh","bin":"/usr/bin/hypc-b"}
+	]`)
+
+	specs, err := loadCompilerSpecs()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("want 2 specs, got %d", len(specs))
+	}
+	if specs[0].BuildID != "a" || !specs[0].Default {
+		t.Errorf("spec[0] = %+v", specs[0])
+	}
+	if specs[1].NodeBin != "/bin/sh" || specs[1].Bin != "/usr/bin/hypc-b" {
+		t.Errorf("spec[1] = %+v", specs[1])
+	}
+}
+
+func TestLoadCompilerSpecs_FilePath(t *testing.T) {
+	clearVerifierEnv(t)
+	path := filepath.Join(t.TempDir(), "compilers.json")
+	if err := os.WriteFile(path, []byte(`[{"buildId":"x","runner":"/r.js"}]`), 0o600); err != nil {
+		t.Fatalf("write temp manifest: %v", err)
+	}
+	t.Setenv("HYPC_COMPILERS", path)
+
+	specs, err := loadCompilerSpecs()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(specs) != 1 || specs[0].BuildID != "x" || specs[0].Runner != "/r.js" {
+		t.Fatalf("unexpected specs: %+v", specs)
+	}
+}
+
+func TestLoadCompilerSpecs_LegacyEnv(t *testing.T) {
+	clearVerifierEnv(t)
+	t.Setenv("HYPC_RUNNER", "/legacy/runner.sh")
+	t.Setenv("HYPC_BUILD_ID", "legacy-1")
+	t.Setenv("HYPC_NODE_BIN", "/bin/sh")
+	t.Setenv("HYPC_BIN", "/opt/hypc")
+
+	specs, err := loadCompilerSpecs()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("want 1 legacy spec, got %d", len(specs))
+	}
+	got := specs[0]
+	if got.BuildID != "legacy-1" || got.Runner != "/legacy/runner.sh" ||
+		got.NodeBin != "/bin/sh" || got.Bin != "/opt/hypc" || !got.Default {
+		t.Fatalf("legacy spec mismatch: %+v", got)
+	}
+}
+
+func TestLoadCompilerSpecs_Unconfigured(t *testing.T) {
+	clearVerifierEnv(t)
+	specs, err := loadCompilerSpecs()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("want no specs when unconfigured, got %+v", specs)
+	}
+}
+
+func TestLoadCompilerSpecs_MissingFields(t *testing.T) {
+	cases := map[string]string{
+		"missing runner":  `[{"buildId":"a"}]`,
+		"missing buildId": `[{"runner":"/r.js"}]`,
+	}
+	for name, manifest := range cases {
+		t.Run(name, func(t *testing.T) {
+			clearVerifierEnv(t)
+			t.Setenv("HYPC_COMPILERS", manifest)
+			if _, err := loadCompilerSpecs(); err == nil {
+				t.Fatalf("expected error for %q", name)
+			}
+		})
+	}
+}
+
+// TestRegistry_Integration boots a real Registry against the bundled npm
+// hypc runner. It is the end-to-end check that the legacy/multi config paths,
+// the version probe, default selection, and Resolve/Info all behave. Skips
+// when node or the runner aren't usable so CI without hypc stays green.
+func TestRegistry_Integration(t *testing.T) {
+	runner := localRunner(t)
+	if _, err := os.Stat(runner); err != nil {
+		t.Skipf("runner not present: %v", err)
+	}
+
+	// Gate on a working probe via the legacy single-build path, which must
+	// reproduce the pre-multi-version behavior exactly.
+	clearVerifierEnv(t)
+	t.Setenv("HYPC_RUNNER", runner)
+	t.Setenv("HYPC_BUILD_ID", localBuildID)
+	reg, err := NewRegistry()
+	if err != nil {
+		t.Skipf("hypc runner not usable in this environment: %v", err)
+	}
+
+	if got := reg.SupportedBuildIDs(); len(got) != 1 || got[0] != localBuildID {
+		t.Fatalf("legacy registry builds = %v", got)
+	}
+	if reg.Default().BuildID != localBuildID {
+		t.Fatalf("legacy default = %q", reg.Default().BuildID)
+	}
+	// Empty selects default; exact id resolves; unknown id is rejected.
+	if c, ok := reg.Resolve(""); !ok || c.BuildID != localBuildID {
+		t.Fatalf("Resolve(\"\") = %v ok=%v", c, ok)
+	}
+	if _, ok := reg.Resolve("0.9.9+nope"); ok {
+		t.Fatalf("Resolve(unknown) should be false")
+	}
+	info := reg.Info()
+	if info.BuildID != localBuildID || info.Default != localBuildID || len(info.Compilers) != 1 {
+		t.Fatalf("legacy Info() = %+v", info)
+	}
+
+	t.Run("skips bad build, default falls back to survivor", func(t *testing.T) {
+		clearVerifierEnv(t)
+		// First entry is the "preferred default" but reports the wrong id, so
+		// it must be skipped; the default then falls back to the good build.
+		t.Setenv("HYPC_COMPILERS", `[
+			{"buildId":"0.0.0+bogus","runner":"`+runner+`","default":true},
+			{"buildId":"`+localBuildID+`","runner":"`+runner+`"}
+		]`)
+		reg, err := NewRegistry()
+		if err != nil {
+			t.Fatalf("NewRegistry: %v", err)
+		}
+		if got := reg.SupportedBuildIDs(); len(got) != 1 || got[0] != localBuildID {
+			t.Fatalf("expected only the good build, got %v", got)
+		}
+		if reg.Default().BuildID != localBuildID || !reg.Default().Default {
+			t.Fatalf("default should fall back to the good build, got %+v", reg.Default())
+		}
+	})
+
+	t.Run("duplicate build ids are de-duped", func(t *testing.T) {
+		clearVerifierEnv(t)
+		t.Setenv("HYPC_COMPILERS", `[
+			{"buildId":"`+localBuildID+`","runner":"`+runner+`"},
+			{"buildId":"`+localBuildID+`","runner":"`+runner+`"}
+		]`)
+		reg, err := NewRegistry()
+		if err != nil {
+			t.Fatalf("NewRegistry: %v", err)
+		}
+		if got := reg.SupportedBuildIDs(); len(got) != 1 {
+			t.Fatalf("expected dedup to 1 build, got %v", got)
+		}
+	})
+}

--- a/backendAPI/verification/runner/README.md
+++ b/backendAPI/verification/runner/README.md
@@ -32,23 +32,33 @@ The verifier supports **multiple** builds; a submission picks one via
 ### Preferred: `HYPC_COMPILERS` manifest
 
 Set `HYPC_COMPILERS` to either an inline JSON array or a path to a JSON file
-of `CompilerSpec` entries. See [`compilers.example.json`](./compilers.example.json):
+of `CompilerSpec` entries. See [`compilers.example.json`](./compilers.example.json).
 
-```jsonc
+The manifest is parsed with Go's standard `encoding/json`, so it must be
+**strict JSON — no comments, no trailing commas**:
+
+```json
 [
   {
-    "buildId": "0.2.0-develop.2026.4.13+commit.d5d1b977.Linux.g++", // required; runner MUST report this
-    "nodeBin": "/bin/sh",                                            // default "node"
-    "runner":  "/abs/path/to/hypc-native.sh",                        // required
-    "bin":     "/usr/local/bin/hypc-0.2.0",                          // optional; native hypc path (HYPC_BIN)
-    "default": true                                                  // optional; the build used when compilerVersion omitted
+    "buildId": "0.2.0-develop.2026.4.13+commit.d5d1b977.Linux.g++",
+    "nodeBin": "/bin/sh",
+    "runner": "/abs/path/to/hypc-native.sh",
+    "bin": "/usr/local/bin/hypc-0.2.0",
+    "default": true
   },
   {
     "buildId": "0.0.2+commit.3e18e55d.Emscripten.clang",
-    "runner":  "/abs/path/to/hypc-runner.js"
+    "runner": "/abs/path/to/hypc-runner.js"
   }
 ]
 ```
+
+Per-entry fields:
+- `buildId` *(required)* — the version string the runner must report from `--version`; the build is skipped if it reports anything else.
+- `runner` *(required)* — absolute path to `hypc-runner.js` (WASM) or `hypc-native.sh` (native).
+- `nodeBin` *(optional, default `"node"`)* — interpreter; use `/bin/sh` for the native wrapper.
+- `bin` *(optional)* — native hypc path, exported to the runner as `HYPC_BIN`.
+- `default` *(optional)* — the build used when a submission omits `compilerVersion`; if none is flagged, the first surviving build wins.
 
 ```bash
 # file path

--- a/backendAPI/verification/runner/README.md
+++ b/backendAPI/verification/runner/README.md
@@ -1,0 +1,83 @@
+# hypc verification runners
+
+The backend verifier (`backendAPI/verification/`) compiles submitted contract
+source with a pinned [`@theqrl/hypc`](https://www.npmjs.com/package/@theqrl/hypc)
+build and byte-matches the result against the on-chain runtime code. The
+compile itself runs in a one-shot subprocess so the Go layer keeps the
+timeout / concurrency / stdin-size budget and the runner stays tiny.
+
+## Runner wire contract
+
+Both runners speak the same contract, so the Go side can swap between them by
+config alone:
+
+| Invocation | stdin | stdout |
+| --- | --- | --- |
+| `<runner> --version` | — | a single line: the exact hypc build id (no prefix) |
+| `<runner>` | Hyperion standard-JSON | hypc standard-JSON output |
+
+- **`hypc-runner.js`** — wraps the `@theqrl/hypc` WASM via Node. Invoke with
+  `nodeBin: "node"`. This is the npm-published build (currently only `0.0.2`).
+- **`hypc-native.sh`** — wraps a natively-built `hypc` binary. Invoke with
+  `nodeBin: "/bin/sh"` and set `bin` to the absolute path of the `hypc`
+  binary (exported to the runner as `HYPC_BIN`). Use this for builds that
+  aren't on npm, e.g. a `0.2.0-develop` snapshot built from
+  [`theqrl/hyperion`](https://github.com/theqrl/hyperion).
+
+## Configuring the builds
+
+The verifier supports **multiple** builds; a submission picks one via
+`compilerVersion` (the default build is used when omitted).
+
+### Preferred: `HYPC_COMPILERS` manifest
+
+Set `HYPC_COMPILERS` to either an inline JSON array or a path to a JSON file
+of `CompilerSpec` entries. See [`compilers.example.json`](./compilers.example.json):
+
+```jsonc
+[
+  {
+    "buildId": "0.2.0-develop.2026.4.13+commit.d5d1b977.Linux.g++", // required; runner MUST report this
+    "nodeBin": "/bin/sh",                                            // default "node"
+    "runner":  "/abs/path/to/hypc-native.sh",                        // required
+    "bin":     "/usr/local/bin/hypc-0.2.0",                          // optional; native hypc path (HYPC_BIN)
+    "default": true                                                  // optional; the build used when compilerVersion omitted
+  },
+  {
+    "buildId": "0.0.2+commit.3e18e55d.Emscripten.clang",
+    "runner":  "/abs/path/to/hypc-runner.js"
+  }
+]
+```
+
+```bash
+# file path
+HYPC_COMPILERS=/home/ops/zondscan/backendAPI/verification/runner/compilers.json
+# …or inline
+HYPC_COMPILERS='[{"buildId":"0.0.2+commit.3e18e55d.Emscripten.clang","runner":"/abs/hypc-runner.js"}]'
+```
+
+Each build is probed at startup (`<runner> --version`) and must report
+exactly its `buildId`. A build that fails the probe is skipped with a warning
+(the others stay live); verification only boots disabled if **none** survive,
+in which case the `/contract/*` endpoints answer `503`.
+
+### Legacy: single-build env vars (still supported)
+
+When `HYPC_COMPILERS` is unset, a one-entry registry is synthesised from the
+original env vars, so existing single-build deploys keep working untouched:
+
+```bash
+HYPC_NODE_BIN=node                                          # default "node"
+HYPC_RUNNER=/abs/path/to/hypc-runner.js                     # required
+HYPC_BUILD_ID=0.0.2+commit.3e18e55d.Emscripten.clang        # required
+HYPC_BIN=/usr/local/bin/hypc                                # optional (native runner)
+```
+
+### Shared limits (apply to all builds)
+
+```bash
+VERIFIER_MAX_CONCURRENCY=2     # total concurrent compiles across ALL builds
+VERIFIER_COMPILE_TIMEOUT=30s   # per-compile hard deadline
+VERIFIER_SOURCE_MAX_BYTES=262144   # standard-JSON payload cap (256 KiB)
+```

--- a/backendAPI/verification/runner/compilers.example.json
+++ b/backendAPI/verification/runner/compilers.example.json
@@ -1,0 +1,14 @@
+[
+  {
+    "buildId": "0.2.0-develop.2026.4.13+commit.d5d1b977.Linux.g++",
+    "nodeBin": "/bin/sh",
+    "runner": "/home/ops/zondscan/backendAPI/verification/runner/hypc-native.sh",
+    "bin": "/usr/local/bin/hypc-0.2.0",
+    "default": true
+  },
+  {
+    "buildId": "0.0.2+commit.3e18e55d.Emscripten.clang",
+    "nodeBin": "node",
+    "runner": "/home/ops/zondscan/backendAPI/verification/runner/hypc-runner.js"
+  }
+]

--- a/backendAPI/verification/types.go
+++ b/backendAPI/verification/types.go
@@ -33,11 +33,24 @@ type VerifyEnqueueResponse struct {
 	Address string `json:"address"`
 }
 
-// CompilerInfoResponse is the body of GET /contract/compiler-info, the
-// single pinned hypc build the backend is willing to verify against.
+// CompilerInfoResponse is the body of GET /contract/compiler-info: every
+// hypc build the backend can verify against, plus which one is used when a
+// submission omits compilerVersion. The top-level Language/BuildID mirror
+// the default build so single-build clients (which only read those two
+// fields) keep working unchanged.
 type CompilerInfoResponse struct {
-	Language string `json:"language"`
+	Language  string          `json:"language"`
+	BuildID   string          `json:"buildId"`
+	Default   string          `json:"default"`
+	Compilers []CompilerBuild `json:"compilers"`
+}
+
+// CompilerBuild describes one selectable compiler build in the
+// /contract/compiler-info response.
+type CompilerBuild struct {
 	BuildID  string `json:"buildId"`
+	Language string `json:"language"`
+	Default  bool   `json:"default"`
 }
 
 // StandardJSONInput is the Hyperion standard-JSON shape we feed to the

--- a/backendAPI/verification/verifier.go
+++ b/backendAPI/verification/verifier.go
@@ -15,16 +15,21 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-// Verifier ties Compiler + on-chain code + byte match + the M1 storage
-// layer (MarkContractVerified + UpdateVerificationJob) into a single
+// Verifier ties the compiler Registry + on-chain code + byte match + the M1
+// storage layer (MarkContractVerified + UpdateVerificationJob) into a single
 // background runner. One Verifier per process.
 type Verifier struct {
-	Compiler *Compiler
+	Registry *Registry
 }
 
 // RunAsync runs the verification flow in the background and updates the
 // job document along the way. Returns immediately so the HTTP handler
 // can hand the jobId back to the client without blocking.
+//
+// req.CompilerVersion selects which configured build to compile with; an
+// empty value uses the registry default. (The routes layer already validated
+// it, so an unknown id here only happens for a direct/internal caller — we
+// fail the job rather than leave it stuck in 'pending'.)
 //
 // Status transitions:
 //
@@ -34,14 +39,19 @@ type Verifier struct {
 // The supplied ctx should typically be context.Background() so the job
 // survives the client connection being torn down mid-compile.
 func (v *Verifier) RunAsync(jobID string, req VerifyRequest) {
+	comp, ok := v.Registry.Resolve(req.CompilerVersion)
+	if !ok {
+		failJob(jobID, fmt.Sprintf("unsupported compilerVersion %q", req.CompilerVersion))
+		return
+	}
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), v.Compiler.Timeout+15*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), comp.Timeout+15*time.Second)
 		defer cancel()
-		v.run(ctx, jobID, req)
+		v.run(ctx, jobID, req, comp)
 	}()
 }
 
-func (v *Verifier) run(ctx context.Context, jobID string, req VerifyRequest) {
+func (v *Verifier) run(ctx context.Context, jobID string, req VerifyRequest, comp *Compiler) {
 	if err := db.UpdateVerificationJob(jobID, bson.M{"status": models.VerificationJobCompiling}); err != nil {
 		// Status transition failures aren't fatal, the rest of the run
 		// continues and the client will see the eventual terminal state.
@@ -51,7 +61,7 @@ func (v *Verifier) run(ctx context.Context, jobID string, req VerifyRequest) {
 
 	input := wrapStandardJSON(req)
 
-	out, err := v.Compiler.Compile(ctx, input)
+	out, err := comp.Compile(ctx, input)
 	if err != nil {
 		failJob(jobID, fmt.Sprintf("compile invocation failed: %s", err.Error()))
 		return
@@ -94,7 +104,7 @@ func (v *Verifier) run(ctx context.Context, jobID string, req VerifyRequest) {
 		SourceCode:           req.SourceCode,
 		Abi:                  string(abiBytes),
 		ContractName:         req.ContractName,
-		CompilerVersion:      v.Compiler.BuildID,
+		CompilerVersion:      comp.BuildID,
 		OptimizationEnabled:  req.OptimizerEnabled,
 		OptimizationRuns:     req.OptimizerRuns,
 		EvmVersion:           req.EvmVersion,


### PR DESCRIPTION
## Why

Contract verification was pinned to a **single** hypc build, so any contract compiled with a different build (e.g. a `0.2.0-develop` snapshot vs npm `0.0.2`) could never byte-match and verify. This was surfaced by a user whose compiler differed from the one pinned on Zondscan.

## What

Replaces the single pinned `Compiler` with a **registry** of builds the submitter can select from.

### Backend
- **`verification/registry.go` (new):** builds a `Registry` from `HYPC_COMPILERS` (inline JSON array *or* a file path) of `{buildId, nodeBin, runner, bin, default}`. Each build is probe-verified at startup; a bad build is **skipped with a warning** instead of disabling the whole feature. Exactly one default is guaranteed.
- **Shared budget:** concurrency semaphore / timeout / stdin cap bound **all** builds together (one process-wide compile budget).
- **Per-build `Bin` → `HYPC_BIN`**, falling back to the process-level `HYPC_BIN`.
- **Back-compat:** with `HYPC_COMPILERS` unset, the legacy `HYPC_RUNNER`/`HYPC_BUILD_ID`/`HYPC_NODE_BIN`/`HYPC_BIN` vars synthesize a one-entry registry, so existing deploys are unchanged.
- **`GET /contract/compiler-info`** now returns `{ language, buildId, default, compilers[] }` (top-level fields mirror the default build for back-compat).
- **`POST /contract/verify`** resolves `compilerVersion` against the registry (empty → default), `400`s with `supportedBuilds` on an unknown id, and pins the job to the resolved build id.

### Frontend
- verify-contract: read-only "pinned compiler" banner → a **build selector** (default preselected; single-build degrades to static text), sends `compilerVersion`. Tolerates an older single-build backend.
- api-explorer docs updated.

### Docs / tests
- `runner/README.md` + `compilers.example.json` document the manifest.
- `registry_test.go`: spec parsing (inline/file/legacy/errors) + a real-probe integration test (default selection, bad-build skip, dedup) that skips when node/hypc are unavailable.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./verification/...` (incl. real hypc-probe integration test) — green
- frontend `eslint` + `tsc --noEmit` — green
- 5-dimension adversarial review (back-compat, correctness, concurrency, security, frontend) — 0 confirmed findings

## Operational follow-up
No DB migration. To actually *offer* a second build, ops must add it to `HYPC_COMPILERS` **and** install that hypc binary. Until then the default stays the existing single build (legacy env path).