### PR TITLE
fix(frontend): mobile horizontal overflow on address/contract pages

### DIFF
--- a/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
@@ -98,7 +98,7 @@ const AddressDisplay = ({ address, truncate = false }: { address: string; trunca
 
     const display = truncate ? `${address.slice(0, 10)}...${address.slice(-8)}` : address;
     return (
-        <Link href={`/address/${address}`} className="text-accent hover:text-accent-hover font-mono text-xs md:text-sm">
+        <Link href={`/address/${address}`} className="text-accent hover:text-accent-hover font-mono text-xs md:text-sm break-all">
             {display}
         </Link>
     );
@@ -366,7 +366,7 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                     {symbol.charAt(0)}
                                 </div>
                             )}
-                            <div>
+                            <div className="min-w-0">
                                 <div className="flex items-center gap-2 flex-wrap">
                                     <h1 className="text-xl md:text-2xl font-bold text-white">{name}</h1>
                                     {rawSymbol && (
@@ -391,8 +391,8 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                         {metaDescription}
                                     </p>
                                 )}
-                                <div className="flex items-center gap-2 mt-1">
-                                    <span className="text-xs md:text-sm text-gray-400 font-mono">{address}</span>
+                                <div className="flex items-center gap-2 mt-1 min-w-0">
+                                    <span className="text-xs md:text-sm text-gray-400 font-mono break-all">{address}</span>
                                     <CopyButton value={address} label="Copy address" />
                                     <QRCodeButton address={address} />
                                 </div>
@@ -535,10 +535,10 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                             <div className="bg-black/20 rounded-lg p-4 space-y-3">
                                 <div className="flex flex-col md:flex-row md:items-center justify-between gap-2">
                                     <div className="text-xs md:text-sm text-gray-400">Transaction Hash</div>
-                                    <div className="flex items-center gap-2">
+                                    <div className="flex items-center gap-2 min-w-0">
                                         <Link
                                             href={`/tx/${creationTxHash}`}
-                                            className="text-accent hover:text-accent-hover font-mono text-xs md:text-sm"
+                                            className="text-accent hover:text-accent-hover font-mono text-xs md:text-sm break-all"
                                         >
                                             {creationTxHash || 'Unknown'}
                                         </Link>

--- a/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
@@ -98,7 +98,7 @@ const AddressDisplay = ({ address, truncate = false }: { address: string; trunca
 
     const display = truncate ? `${address.slice(0, 10)}...${address.slice(-8)}` : address;
     return (
-        <Link href={`/address/${address}`} className="text-accent hover:text-accent-hover font-mono text-xs md:text-sm break-all">
+        <Link href={`/address/${address}`} className={`text-accent hover:text-accent-hover font-mono text-xs md:text-sm${truncate ? '' : ' break-all'}`}>
             {display}
         </Link>
     );

--- a/ExplorerFrontend/app/layout.tsx
+++ b/ExplorerFrontend/app/layout.tsx
@@ -125,7 +125,12 @@ export default function RootLayout({ children }: RootLayoutProps): JSX.Element {
           </a>
           <div className="flex min-h-screen">
             <Sidebar />
-            <div className="flex-1 lg:ml-64 min-h-screen relative transition-all duration-300 mt-[72px] lg:mt-4 flex flex-col">
+            {/* min-w-0 is load-bearing: without it this flex item refuses to
+                shrink below its content's intrinsic width (flexbox min-width:
+                auto), so any wide table or long unbroken hash stretches the
+                whole page beyond the mobile viewport instead of scrolling
+                inside its own overflow-x-auto container. */}
+            <div className="flex-1 min-w-0 lg:ml-64 min-h-screen relative transition-all duration-300 mt-[72px] lg:mt-4 flex flex-col">
               <main id="main-content" className="flex-1 relative">
                 {children}
               </main>


### PR DESCRIPTION
## Problem

On phones, opening an address page renders the layout wider than the screen (measured 959px on a wallet address page and 665px on a token contract page, against a 390px iPhone viewport), so the browser shows the page overflowed and users must zoom out to fit it.

## Root cause

The main content wrapper in `app/layout.tsx` (`flex-1 lg:ml-64 ...`) is a flex item without `min-w-0`. Flexbox's default `min-width: auto` means a flex item refuses to shrink below its content's intrinsic width, so any wide `<table>` or long unbroken hash stretched the entire page instead of scrolling inside its own `overflow-x-auto` wrapper. The homepage measures a clean 390px because it has no such wide intrinsic content; every detail page with tables/hashes was affected.

## Fix

- `min-w-0` on the layout's main flex wrapper (one class; this alone takes the contract page from 665 to 390 and lets every `overflow-x-auto` table actually scroll internally).
- `break-all` + `min-w-0` on the token contract view's remaining unbroken monospace strings (header address, creator address, creation tx hash) so they wrap inside their cards instead of being clipped by the card's `overflow-hidden`.

## Verification

Headless Chromium (Playwright) at 390x844 iPhone profile against a production build:

| Page | scrollWidth before | after |
|---|---|---|
| /address/<wallet> | 959px | 390px |
| /address/<token contract> | 665px | 390px |
| /tx/<hash> | - | 390px |

Screenshots confirm addresses wrap cleanly, tab bar and tables keep internal horizontal scroll, nothing clipped.

Gates: lint 0 errors, 114/114 tests, build green.

## Risk

`min-w-0` on the wrapper changes shrink behavior for all pages; desktop is unaffected (the wrapper was never narrower than its content there), and a mobile sweep of home/address/contract/tx pages shows correct rendering.