### PR TITLE
ui(frontend): Etherscan-style pill tabs on address and contract pages

### DIFF
--- a/ExplorerFrontend/app/address/[query]/address-tabs.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-tabs.tsx
@@ -217,7 +217,7 @@ export default function AddressTabs({
         ariaLabel="Address activity sections"
         withPanelIds
         activeKey={activeTab}
-        onSelect={(key) => setTab(key as TabKey)}
+        onSelect={setTab}
         tabs={TAB_KEYS.map((key) => ({
           key,
           label: TAB_LABEL[key],

--- a/ExplorerFrontend/app/address/[query]/address-tabs.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-tabs.tsx
@@ -6,6 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import type { InternalTransaction, Transaction } from '@/app/types';
 import config from '../../../config';
+import TabPillBar from '../../components/TabPillBar';
 import TransactionsPanel from './panels/transactions-panel';
 import InternalPanel from './panels/internal-panel';
 import TokenTransfersPanel from './panels/token-transfers-panel';
@@ -212,37 +213,17 @@ export default function AddressTabs({
         Address activity
       </h2>
 
-      <div
-        role="tablist"
-        aria-label="Address activity sections"
-        className="flex gap-1 border-b border-[#3d3d3d] overflow-x-auto"
-      >
-        {TAB_KEYS.map((key) => {
-          const active = key === activeTab;
-          const b = badge(key);
-          return (
-            <button
-              key={key}
-              id={`tab-${key}`}
-              role="tab"
-              aria-selected={active}
-              aria-controls={`tabpanel-${key}`}
-              onClick={() => setTab(key)}
-              type="button"
-              className={`whitespace-nowrap px-3 md:px-4 py-2 text-xs md:text-sm border-b-2 -mb-px transition-colors ${
-                active
-                  ? 'border-[#ffa729] text-[#ffa729]'
-                  : 'border-transparent text-gray-400 hover:text-gray-200'
-              }`}
-            >
-              {TAB_LABEL[key]}
-              {b !== null && (
-                <span className="ml-1 text-xs opacity-75">({b})</span>
-              )}
-            </button>
-          );
-        })}
-      </div>
+      <TabPillBar
+        ariaLabel="Address activity sections"
+        withPanelIds
+        activeKey={activeTab}
+        onSelect={(key) => setTab(key as TabKey)}
+        tabs={TAB_KEYS.map((key) => ({
+          key,
+          label: TAB_LABEL[key],
+          badge: badge(key),
+        }))}
+      />
 
       <div className="overflow-hidden rounded-xl border border-[#3d3d3d]">
         {isPanelMounted('transactions') && (

--- a/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
@@ -452,7 +452,7 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                 <TabPillBar
                     ariaLabel="Token contract sections"
                     activeKey={activeTab}
-                    onSelect={(key) => setActiveTab(key as typeof activeTab)}
+                    onSelect={setActiveTab}
                     tabs={tabs.map((tab) => ({ key: tab.id, label: tab.label }))}
                 />
             </div>

--- a/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import CopyButton from "../../components/CopyButton";
 import QRCodeButton from "../../components/QRCodeButton";
 import ContractTabs from "../../components/ContractTabs";
+import TabPillBar from "../../components/TabPillBar";
 import VerifiedBadge from "../../components/VerifiedBadge";
 import type { ContractData } from "../../types/address";
 import { compactTokenIDLabel, formatAmount } from "../../lib/helpers";
@@ -447,23 +448,13 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
             </div>
 
             {/* Tabs */}
-            <div className="flex border-b border-gray-700 mb-4">
-                {tabs.map((tab) => (
-                    <button
-                        key={tab.id}
-                        onClick={() => setActiveTab(tab.id as typeof activeTab)}
-                        className={`px-4 py-3 text-sm font-medium transition-colors relative
-                            ${activeTab === tab.id
-                                ? 'text-[#ffa729]'
-                                : 'text-gray-400 hover:text-gray-300'
-                            }`}
-                    >
-                        {tab.label}
-                        {activeTab === tab.id && (
-                            <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-[#ffa729]" />
-                        )}
-                    </button>
-                ))}
+            <div className="mb-4">
+                <TabPillBar
+                    ariaLabel="Token contract sections"
+                    activeKey={activeTab}
+                    onSelect={(key) => setActiveTab(key as typeof activeTab)}
+                    tabs={tabs.map((tab) => ({ key: tab.id, label: tab.label }))}
+                />
             </div>
 
             {/* Tab Content */}

--- a/ExplorerFrontend/app/components/TabPillBar.tsx
+++ b/ExplorerFrontend/app/components/TabPillBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-export interface TabPill {
-  key: string;
+export interface TabPill<T extends string = string> {
+  key: T;
   label: string;
   /** Optional count rendered as "(badge)" after the label. */
   badge?: string | null;
@@ -17,17 +17,20 @@ export interface TabPill {
  *
  * When `withPanelIds` is set, buttons emit the tab-<key> / tabpanel-<key>
  * id pairing the address page's tabpanels reference via aria-labelledby.
+ *
+ * Generic over the tab key union so callers' onSelect handlers take their
+ * own key type directly, no `as` assertions at the call sites.
  */
-export default function TabPillBar({
+export default function TabPillBar<T extends string>({
   tabs,
   activeKey,
   onSelect,
   ariaLabel,
   withPanelIds = false,
 }: {
-  tabs: TabPill[];
-  activeKey: string;
-  onSelect: (key: string) => void;
+  tabs: TabPill<T>[];
+  activeKey: T;
+  onSelect: (key: T) => void;
   ariaLabel: string;
   withPanelIds?: boolean;
 }): JSX.Element {
@@ -35,7 +38,7 @@ export default function TabPillBar({
     <div
       role="tablist"
       aria-label={ariaLabel}
-      className="flex gap-2 overflow-x-auto scrollbar-none -mx-1 px-1 py-1"
+      className="flex gap-2 overflow-x-auto hide-scrollbar -mx-1 px-1 py-1"
     >
       {tabs.map((tab) => {
         const active = tab.key === activeKey;

--- a/ExplorerFrontend/app/components/TabPillBar.tsx
+++ b/ExplorerFrontend/app/components/TabPillBar.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+export interface TabPill {
+  key: string;
+  label: string;
+  /** Optional count rendered as "(badge)" after the label. */
+  badge?: string | null;
+}
+
+/**
+ * Etherscan-style pill tab bar, shared by the address and token contract
+ * pages. Replaces the old underline tabs: an underline indicator sliding
+ * over a static border-b inside an overflow-x-auto container read as
+ * "broken/draggable" on phones, while a row of filled chips makes the
+ * horizontal scroll look intentional. The scrollbar is hidden
+ * (scrollbar-none) like Etherscan's mobile tab row.
+ *
+ * When `withPanelIds` is set, buttons emit the tab-<key> / tabpanel-<key>
+ * id pairing the address page's tabpanels reference via aria-labelledby.
+ */
+export default function TabPillBar({
+  tabs,
+  activeKey,
+  onSelect,
+  ariaLabel,
+  withPanelIds = false,
+}: {
+  tabs: TabPill[];
+  activeKey: string;
+  onSelect: (key: string) => void;
+  ariaLabel: string;
+  withPanelIds?: boolean;
+}): JSX.Element {
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className="flex gap-2 overflow-x-auto scrollbar-none -mx-1 px-1 py-1"
+    >
+      {tabs.map((tab) => {
+        const active = tab.key === activeKey;
+        return (
+          <button
+            key={tab.key}
+            id={withPanelIds ? `tab-${tab.key}` : undefined}
+            role="tab"
+            aria-selected={active}
+            aria-controls={withPanelIds ? `tabpanel-${tab.key}` : undefined}
+            onClick={() => onSelect(tab.key)}
+            type="button"
+            className={`whitespace-nowrap shrink-0 rounded-lg px-3 md:px-4 py-1.5 md:py-2 text-xs md:text-sm font-medium transition-colors ${
+              active
+                ? 'bg-[#ffa729] text-black'
+                : 'bg-[#2d2d2d] text-gray-300 hover:bg-[#3d3d3d] hover:text-white'
+            }`}
+          >
+            {tab.label}
+            {tab.badge != null && (
+              <span className={`ml-1 text-xs ${active ? 'text-black/60' : 'opacity-75'}`}>
+                ({tab.badge})
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/ExplorerFrontend/app/globals.css
+++ b/ExplorerFrontend/app/globals.css
@@ -204,6 +204,16 @@
   @apply bg-gray-700 animate-pulse rounded-sm;
 }
 
+/* Hide the scrollbar entirely (pill tab rows scroll horizontally on
+   mobile; the chips themselves are the affordance, like Etherscan). */
+@utility scrollbar-none {
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 /* Custom scrollbar for dark mode */
 @utility scrollbar-dark {
   scrollbar-color: #2d2d2d #1a1a1a;

--- a/ExplorerFrontend/app/globals.css
+++ b/ExplorerFrontend/app/globals.css
@@ -204,16 +204,6 @@
   @apply bg-gray-700 animate-pulse rounded-sm;
 }
 
-/* Hide the scrollbar entirely (pill tab rows scroll horizontally on
-   mobile; the chips themselves are the affordance, like Etherscan). */
-@utility scrollbar-none {
-  scrollbar-width: none;
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
-}
-
 /* Custom scrollbar for dark mode */
 @utility scrollbar-dark {
   scrollbar-color: #2d2d2d #1a1a1a;


### PR DESCRIPTION
## Problem

On phones, the address page tab bar (Transactions / Internal Txns / Token Transfers / Tokens / NFTs) can be grabbed and dragged: it is an `overflow-x-auto` row (necessary, the tabs don't fit a phone screen), but styled as underline tabs sliding over a static `border-b` it reads as a broken, unattached element. There is also little visual separation between tabs compared to e.g. Etherscan's pill buttons.

## Change

New shared `TabPillBar` component used by both the wallet address tabs and the token contract tabs:

- Each tab is a filled chip: accent orange with black text when active, dark gray (`#2d2d2d`) otherwise, `gap-2` separation, count badges preserved.
- The row still scrolls horizontally on narrow screens (it must), but a chip row visually communicates that, the same pattern Etherscan uses. Scrollbar hidden via a new `scrollbar-none` utility in globals.css.
- No logic changes: URL-driven `?tab=` state, lazy panel mounting, ARIA tablist/tab/tabpanel semantics all unchanged. The contract page tab bar keeps its local state behavior.

## Verification

- Playwright at 390x844 (iPhone) and 1280x900 (desktop) against a production build: pages stay exactly viewport-width, tab click updates `?tab=internal`, badges render, screenshots reviewed on both form factors.
- `npm run lint` 0 errors, `npm test` 114/114, `npm run build` green.

## Risk

Pure presentational change; the two former inline tab button styles are replaced by one shared component. ARIA ids (`tab-<key>` / `tabpanel-<key>`) are emitted only for the address page (`withPanelIds`), matching the previous markup.