### PR TITLE
fix(frontend): wrap overflowing creation-tx hash on contract page

### DIFF
--- a/ExplorerFrontend/app/address/[query]/address-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-view.tsx
@@ -219,8 +219,8 @@ export default function AddressView({ addressData, addressSegment }: AddressView
                                     {/* Creation Transaction */}
                                     <div>
                                         <div className="text-xs md:text-sm text-gray-400 mb-1">Creation Transaction</div>
-                                        <div className="flex items-center space-x-2">
-                                            <Link href={`/tx/${contractData.creationTransaction}`} className="text-xs md:text-sm text-accent hover:text-accent-hover">
+                                        <div className="flex items-center space-x-2 min-w-0">
+                                            <Link href={`/tx/${contractData.creationTransaction}`} className="text-xs md:text-sm text-accent hover:text-accent-hover break-all min-w-0">
                                                 {contractData.creationTransaction}
                                             </Link>
                                             <CopyButton value={contractData.creationTransaction} label="Copy hash" />


### PR DESCRIPTION
## Problem

On a contract's address page, the **Creation Transaction** hash in the Contract Information section overflowed off the right edge of the screen on mobile instead of wrapping — see the reported screenshot (the `0x…` hash runs past the viewport while the Creator Address right above it wraps fine).

## Cause

The Creator Address uses `<AddressDisplay>` (which wraps internally), but the Creation Transaction row used a raw `<Link>` with no `break-all`, inside a `flex` row without `min-w-0`, so the long hash had nothing to break on.

## Fix

Add `min-w-0` to the row and `break-all min-w-0` to the link — the same wrapping pattern already used in `token-contract-view.tsx`. One file, 2 lines.

```
ExplorerFrontend/app/address/[query]/address-view.tsx
```

## Note on verification

className-only change mirroring existing working code in the repo. Not rendered live because the contract page pulls from the backend API, which isn't available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hkd2SABBcMmuaDzPjbgrQB)_