### PR TITLE
feat(faucet): surface in footer + sitemap, floor the sending spinner

### DIFF
--- a/ExplorerFrontend/app/components/Footer.tsx
+++ b/ExplorerFrontend/app/components/Footer.tsx
@@ -31,6 +31,7 @@ export default function Footer(): JSX.Element {
           <div>
             <h3 className="text-sm font-semibold text-accent uppercase mb-4">Tools</h3>
             <ul className="space-y-2 text-sm">
+              <li><Link href="/faucet" className="hover:text-accent transition">Testnet Faucet</Link></li>
               <li><Link href="/checker" className="hover:text-accent transition">Balance Checker</Link></li>
               <li><Link href="/converter" className="hover:text-accent transition">Quanta ↔ Shor</Link></li>
             </ul>

--- a/ExplorerFrontend/app/faucet/faucet-client.tsx
+++ b/ExplorerFrontend/app/faucet/faucet-client.tsx
@@ -37,6 +37,11 @@ declare global {
 
 const SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
 
+// A claim resolves the moment the node accepts the broadcast (the tx is then
+// pending on-chain), which can be well under 100ms. Floor the visible
+// "Sending..." state so the action registers instead of flashing past.
+const MIN_SENDING_MS = 700;
+
 export default function FaucetClient(): JSX.Element {
   const [address, setAddress] = useState<string>('');
   const [status, setStatus] = useState<FaucetStatus | null>(null);
@@ -140,6 +145,7 @@ export default function FaucetClient(): JSX.Element {
       return;
     }
 
+    const startedAt = performance.now();
     try {
       const res = await fetch('/faucet/claim', {
         method: 'POST',
@@ -150,6 +156,13 @@ export default function FaucetClient(): JSX.Element {
         }),
       });
       const data = await res.json();
+
+      // Keep the spinner up for a perceptible beat even when the node accepts
+      // the broadcast near-instantly, so the claim doesn't feel like a no-op.
+      const elapsed = performance.now() - startedAt;
+      if (elapsed < MIN_SENDING_MS) {
+        await new Promise(resolve => setTimeout(resolve, MIN_SENDING_MS - elapsed));
+      }
 
       if (!res.ok) {
         if (res.status === 429 && data.retryAfterSeconds) {
@@ -164,7 +177,7 @@ export default function FaucetClient(): JSX.Element {
       setError('Network error. Please try again.');
     } finally {
       setIsLoading(false);
-      // One token per challenge — reset so the next claim gets a fresh one.
+      // One token per challenge: reset so the next claim gets a fresh one.
       if (widgetIdRef.current && window.turnstile) {
         window.turnstile.reset(widgetIdRef.current);
         tokenRef.current = '';

--- a/ExplorerFrontend/app/sitemap.ts
+++ b/ExplorerFrontend/app/sitemap.ts
@@ -36,6 +36,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     entry('/epochs/1', 'hourly', 0.7),
     entry('/gas', 'hourly', 0.7),
     entry('/richlist', 'daily', 0.6),
+    entry('/faucet', 'monthly', 0.6),
     entry('/converter', 'yearly', 0.5),
     entry('/api-explorer', 'monthly', 0.5),
     entry('/verify-contract', 'monthly', 0.5),


### PR DESCRIPTION
Follow-up polish after the faucet went live, from prod testing feedback.

## Changes
- **Footer**: add `Testnet Faucet` to the Tools column. It was only in the sidebar, so the footer felt like it was missing it.
- **Sitemap**: add `/faucet` to `sitemap.ts` (it's a real landing page with its own SEO metadata + canonical, so crawlers should index it).
- **Sending feedback**: floor the visible "Sending..." spinner to 700ms. The claim resolves the instant the node accepts the broadcast (returns on `transactionHash`, before mining), often <100ms, so the spinner flashed past imperceptibly. The broadcast is real; the tx is just pending confirmation.
- Drop a stray em dash in a comment.

## Validation
- lint: 0 errors (24 pre-existing warnings)
- build: OK
- tests: 114/114 pass