### PR TITLE
fix(api): accurate pagination totals when EstimatedDocumentCount reads 0

### DIFF
--- a/backendAPI/db/block.go
+++ b/backendAPI/db/block.go
@@ -102,13 +102,13 @@ func ReturnLatestBlocks(page int, limit int) ([]models.Result, error) {
 }
 
 // CountBlocksNetwork returns the total number of blocks. Uses
-// EstimatedDocumentCount (metadata read) rather than CountDocuments({}),
-// which is O(rows) on the blocks collection.
+// countDocumentsResilient (fast metadata read with an exact-count fallback when
+// the metadata reads 0, which it currently does on this deployment).
 func CountBlocksNetwork() (int64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	count, err := configs.BlocksCollection.EstimatedDocumentCount(ctx)
+	count, err := countDocumentsResilient(ctx, configs.BlocksCollection)
 	if err != nil {
 		return 0, err
 	}

--- a/backendAPI/db/contract.go
+++ b/backendAPI/db/contract.go
@@ -280,14 +280,14 @@ func ReturnContractCode(address string) (models.ContractInfo, error) {
 }
 
 // CountContracts returns the total number of smart contracts. Uses
-// EstimatedDocumentCount (metadata read, ~microseconds) instead of
-// CountDocuments({}) which is O(rows) and blocked hot endpoints
-// (/overview) under any concurrency.
+// countDocumentsResilient (fast metadata read with an exact-count fallback when
+// the metadata reads 0, which it currently does on this deployment). The result
+// is cached by callers (/overview), so the fallback runs at most once per window.
 func CountContracts() (int64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	count, err := configs.ContractInfoCollection.EstimatedDocumentCount(ctx)
+	count, err := countDocumentsResilient(ctx, configs.ContractInfoCollection)
 	if err != nil {
 		return 0, err
 	}

--- a/backendAPI/db/count.go
+++ b/backendAPI/db/count.go
@@ -1,0 +1,34 @@
+package db
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// countDocumentsResilient returns an accurate document count for list-pagination
+// totals.
+//
+// EstimatedDocumentCount is a near-instant metadata read, but on this
+// deployment that metadata reads 0 for every collection: the WiredTiger
+// fast-count was reset during the June 2026 infra consolidation (a restore /
+// unclean shutdown) and never rebuilt, so a populated collection reports 0
+// until a validate() rebuilds it. A 0 total collapses every paginated view to
+// "Page X of 1" and disables Next.
+//
+// So we keep the cheap metadata read on the happy path and fall back to an
+// exact CountDocuments only when it reads 0. CountDocuments on an empty
+// collection is itself instant, and the callers that matter cache the result
+// (routeCache, ~10s), so the exact count runs at most once per window. When the
+// metadata is eventually rebuilt this transparently reverts to the fast path.
+func countDocumentsResilient(ctx context.Context, coll *mongo.Collection) (int64, error) {
+	est, err := coll.EstimatedDocumentCount(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if est > 0 {
+		return est, nil
+	}
+	return coll.CountDocuments(ctx, primitive.D{})
+}

--- a/backendAPI/db/transaction.go
+++ b/backendAPI/db/transaction.go
@@ -329,15 +329,15 @@ func ReturnTransactions(address string, page, limit int) ([]models.TransactionBy
 }
 
 // CountTransactionsNetwork returns the total transactionByAddress row count.
-// Uses EstimatedDocumentCount (metadata read) rather than CountDocuments({}),
-// which is O(rows) on a collection that grows linearly with chain activity.
+// Uses countDocumentsResilient (fast metadata read with an exact-count fallback
+// when the metadata reads 0, which it currently does on this deployment).
 // Returns int64 to match sibling count helpers and to avoid an implicit cap
 // at 2^31-1 on long-running chains.
 func CountTransactionsNetwork() (int64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	count, err := configs.GetCollection(configs.DB, "transactionByAddress").EstimatedDocumentCount(ctx)
+	count, err := countDocumentsResilient(ctx, configs.GetCollection(configs.DB, "transactionByAddress"))
 	if err != nil {
 		return 0, fmt.Errorf("failed to count transactions: %v", err)
 	}

--- a/backendAPI/db/validator.go
+++ b/backendAPI/db/validator.go
@@ -89,13 +89,13 @@ func ReturnValidators(pageToken string) (*models.ValidatorResponse, error) {
 }
 
 // CountValidators returns the total validator count. Uses
-// EstimatedDocumentCount (metadata read) rather than CountDocuments({}),
-// which is O(rows) and ran on every /overview hit.
+// countDocumentsResilient (fast metadata read with an exact-count fallback when
+// the metadata reads 0, which it currently does on this deployment).
 func CountValidators() (int64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	count, err := configs.ValidatorsCollections.EstimatedDocumentCount(ctx)
+	count, err := countDocumentsResilient(ctx, configs.ValidatorsCollections)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count validators: %v", err)
 	}
@@ -263,10 +263,10 @@ func GetEpochs(page, limit int) (*models.EpochsResponse, error) {
 	finalizedEpoch := parseEpoch(epochInfo.FinalizedEpoch)
 	justifiedEpoch := parseEpoch(epochInfo.JustifiedEpoch)
 
-	// Count total epoch records. EstimatedDocumentCount is metadata-based
-	// and accurate enough for "total pages" pagination since epoch records
-	// are append-only.
-	total, err := configs.ValidatorHistoryCollection.EstimatedDocumentCount(ctx)
+	// Count total epoch records for "total pages" pagination. Uses
+	// countDocumentsResilient: the fast metadata read collapses to 0 on this
+	// deployment, which would wrongly show a single page.
+	total, err := countDocumentsResilient(ctx, configs.ValidatorHistoryCollection)
 	if err != nil {
 		return nil, fmt.Errorf("failed to count epochs: %v", err)
 	}
@@ -453,11 +453,11 @@ func GetValidatorStats() (*models.ValidatorStatsResponse, error) {
 	}
 	currentEpoch := HexToInt(latestBlock) / 128
 
-	// Check whether the collection has any documents at all. The
-	// EstimatedDocumentCount metadata can be 0 on a brand-new collection
-	// or briefly stale during heavy writes; the == 0 guard below handles
-	// both cases the same way.
-	totalCount, err := configs.ValidatorsCollections.EstimatedDocumentCount(ctx)
+	// Check whether the collection has any documents at all. Uses
+	// countDocumentsResilient because the EstimatedDocumentCount metadata reads
+	// 0 for populated collections on this deployment, which would wrongly short
+	// circuit to an empty stats response below.
+	totalCount, err := countDocumentsResilient(ctx, configs.ValidatorsCollections)
 	if err != nil {
 		return nil, fmt.Errorf("failed to count validators: %v", err)
 	}


### PR DESCRIPTION
## Bug
`/transactions/2` shows **"Page 2 of 1"** with Next disabled, and there are clearly many more pages.

## Root cause
`EstimatedDocumentCount()` (a WiredTiger fast-count metadata read) returns **0 for every collection** on the current deployment - the fast count was reset during the June 2026 infra consolidation and never rebuilt. Verified on prod:

| collection | estimated | actual |
|---|---|---|
| transactionByAddress | 0 | 980 |
| blocks | 0 | 122,880 |
| validators | 0 | 512 |
| contractCode | 0 | 126 |

The frontend computes `totalPages = Math.max(1, ceil(total/10))`, so `total=0` collapses to **1 page**. This affects `/transactions`, `/blocks`, the validators list + stats guard, epoch history, and the `/overview` contract count.

## Fix
Add `countDocumentsResilient`: keep the fast metadata read on the happy path, fall back to an exact `CountDocuments` only when it reads 0 (instant on empty collections; cached ~10s by callers). Route the six network/overview count sites through it. Reverts to the fast path automatically if the metadata is ever rebuilt. The contracts list already used `CountDocuments` and is unchanged.

## Validation
`go build ./...` and `go vet ./db/` clean. Diff is the six call swaps + the helper, no unrelated churn.