### PR TITLE
fix(review): address medium Gemini comments on merged PRs (#128/#129/#130)

### DIFF
--- a/ExplorerFrontend/app/address/[query]/address-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-view.tsx
@@ -223,7 +223,9 @@ export default function AddressView({ addressData, addressSegment }: AddressView
                                             <Link href={`/tx/${contractData.creationTransaction}`} className="text-xs md:text-sm text-accent hover:text-accent-hover break-all min-w-0">
                                                 {contractData.creationTransaction}
                                             </Link>
-                                            <CopyButton value={contractData.creationTransaction} label="Copy hash" />
+                                            <div className="shrink-0">
+                                                <CopyButton value={contractData.creationTransaction} label="Copy hash" />
+                                            </div>
                                         </div>
                                     </div>
 

--- a/ExplorerFrontend/app/faucet/faucet-client.tsx
+++ b/ExplorerFrontend/app/faucet/faucet-client.tsx
@@ -157,13 +157,6 @@ export default function FaucetClient(): JSX.Element {
       });
       const data = await res.json();
 
-      // Keep the spinner up for a perceptible beat even when the node accepts
-      // the broadcast near-instantly, so the claim doesn't feel like a no-op.
-      const elapsed = performance.now() - startedAt;
-      if (elapsed < MIN_SENDING_MS) {
-        await new Promise(resolve => setTimeout(resolve, MIN_SENDING_MS - elapsed));
-      }
-
       if (!res.ok) {
         if (res.status === 429 && data.retryAfterSeconds) {
           setError(`${data.error} (try again in ~${formatDuration(data.retryAfterSeconds)})`);
@@ -172,6 +165,15 @@ export default function FaucetClient(): JSX.Element {
         }
         return;
       }
+
+      // Keep the spinner up for a perceptible beat even when the node accepts
+      // the broadcast near-instantly, so a successful claim doesn't feel like a
+      // no-op. Errors above skip this and surface immediately.
+      const elapsed = performance.now() - startedAt;
+      if (elapsed < MIN_SENDING_MS) {
+        await new Promise(resolve => setTimeout(resolve, MIN_SENDING_MS - elapsed));
+      }
+
       setResult(data as ClaimSuccess);
     } catch {
       setError('Network error. Please try again.');

--- a/backendAPI/db/count.go
+++ b/backendAPI/db/count.go
@@ -2,10 +2,17 @@ package db
 
 import (
 	"context"
+	"log"
+	"sync"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
+
+// fallbackLogged tracks which collections have already logged the
+// metadata-fallback warning, so we surface it once per collection per process
+// instead of on every (currently always-0) count call.
+var fallbackLogged sync.Map
 
 // countDocumentsResilient returns an accurate document count for list-pagination
 // totals.
@@ -29,6 +36,9 @@ func countDocumentsResilient(ctx context.Context, coll *mongo.Collection) (int64
 	}
 	if est > 0 {
 		return est, nil
+	}
+	if _, seen := fallbackLogged.LoadOrStore(coll.Name(), true); !seen {
+		log.Printf("[count] EstimatedDocumentCount returned 0 for %q on a query; using exact CountDocuments. The WiredTiger fast-count metadata is stale: run validate() on this collection to rebuild it and restore the fast path.", coll.Name())
 	}
 	return coll.CountDocuments(ctx, primitive.D{})
 }


### PR DESCRIPTION
Follow-up addressing the **medium** review comments left on PRs that were merged before Gemini finished. The critical/high comments on #126/#127 were all already addressed in-PR; these were the remaining mediums.

- **#129** faucet-client: the 700ms spinner floor now applies **only to successful claims**, so rate-limit (429) and validation errors surface immediately instead of waiting.
- **#130** count.go: `countDocumentsResilient` now logs a **throttled** warning (once per collection per process) when it falls back, pointing operators at `validate()` to rebuild the stale fast-count metadata. Throttled because the fallback is currently the permanent path (would otherwise spam).
- **#128** address-view: wrap the creation-tx `CopyButton` in `shrink-0` so it can't distort on very narrow viewports.

## Validation
Frontend: lint 0 errors, build OK. Backend: `gofmt` clean, `go vet` + `go build` pass.