### PR TITLE
fix(address): guard creation-tx link when creationTransaction is absent

### DIFF
--- a/ExplorerFrontend/app/address/[query]/address-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-view.tsx
@@ -220,12 +220,18 @@ export default function AddressView({ addressData, addressSegment }: AddressView
                                     <div>
                                         <div className="text-xs md:text-sm text-gray-400 mb-1">Creation Transaction</div>
                                         <div className="flex items-center space-x-2 min-w-0">
-                                            <Link href={`/tx/${contractData.creationTransaction}`} className="text-xs md:text-sm text-accent hover:text-accent-hover break-all min-w-0">
-                                                {contractData.creationTransaction}
-                                            </Link>
-                                            <div className="shrink-0">
-                                                <CopyButton value={contractData.creationTransaction} label="Copy hash" />
-                                            </div>
+                                            {contractData.creationTransaction ? (
+                                                <>
+                                                    <Link href={`/tx/${contractData.creationTransaction}`} className="text-xs md:text-sm text-accent hover:text-accent-hover break-all min-w-0">
+                                                        {contractData.creationTransaction}
+                                                    </Link>
+                                                    <div className="shrink-0">
+                                                        <CopyButton value={contractData.creationTransaction} label="Copy hash" />
+                                                    </div>
+                                                </>
+                                            ) : (
+                                                <span className="text-xs md:text-sm text-gray-300">Unknown</span>
+                                            )}
                                         </div>
                                     </div>
 


### PR DESCRIPTION
Addresses the medium comment on #131. If `contractData.creationTransaction` is missing (genesis/precompiled/unindexed contracts), the row rendered a `/tx/undefined` link and passed `undefined` to CopyButton. Now shows `Unknown`, matching the existing Creator Address fallback pattern. Frontend lint 0 errors, build OK.