### PR TITLE
fix: graceful goroutine shutdown, ingestion sanitization, validators cache (batch 4)

### DIFF
--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -351,6 +351,45 @@ func StoreInitialSyncStartBlock(blockNumber string) error {
 }
 
 // BlockExists checks if a block with the given number already exists in the database
+// BlocksExist returns the set of the given block numbers that already exist in
+// the blocks collection, as a map[blockNumber]bool. It runs a single $in query
+// rather than one round-trip per block, so the batch consumer can check a whole
+// batch (128/256 blocks) at once. A block absent from the returned map is not
+// present in the DB. On query error it returns a nil map (callers treat every
+// block as new, i.e. reprocess, which is the safe direction).
+func BlocksExist(blockNumbers []string) (map[string]bool, error) {
+	if len(blockNumbers) == 0 {
+		return map[string]bool{}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	filter := bson.M{"result.number": bson.M{"$in": blockNumbers}}
+	projection := options.Find().SetProjection(bson.M{"result.number": 1, "_id": 0})
+
+	cursor, err := configs.BlocksCollections.Find(ctx, filter, projection)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var results []struct {
+		Result struct {
+			Number string `bson:"number"`
+		} `bson:"result"`
+	}
+	if err := cursor.All(ctx, &results); err != nil {
+		return nil, err
+	}
+
+	existsMap := make(map[string]bool, len(results))
+	for _, r := range results {
+		existsMap[r.Result.Number] = true
+	}
+	return existsMap, nil
+}
+
 func BlockExists(blockNumber string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -595,8 +595,20 @@ func Rollback(blockNumber string) error {
 		return err
 	}
 
-	// Log blocks being removed
+	// Collect the exact hex block-number strings of the blocks being removed.
+	// The companion collections (transfer, transactionByAddress,
+	// tokenTransfers, tokenBalances) store blockNumber as the raw hex string
+	// (e.g. "0x1a2b"), NOT an int, so a numeric $gt range filter like the one
+	// used on the blocks collection would be unsafe here (hex strings lex-sort
+	// wrong, "0xa" > "0x100"). Matching the exact set of removed block numbers
+	// with $in is precise: it deletes rows for the rolled-back blocks and
+	// nothing else.
+	badBlockNumbers := make([]string, 0, len(blocks))
 	for _, block := range blocks {
+		if block.Result.Number != "" {
+			badBlockNumbers = append(badBlockNumbers, block.Result.Number)
+		}
+		// Log blocks being removed
 		configs.Logger.Info("Rolling back block",
 			zap.String("number", block.Result.Number),
 			zap.String("hash", block.Result.Hash))
@@ -616,6 +628,42 @@ func Rollback(blockNumber string) error {
 		_, err := configs.BlocksCollections.DeleteMany(sessCtx, filter)
 		if err != nil {
 			return nil, err
+		}
+
+		// Delete companion rows for the removed blocks so a rolled-back block
+		// leaves no orphans. All three of these collections key blockNumber as
+		// the raw hex string, so the exact-match $in filter is correct.
+		//
+		// NOT cleaned here (intentional, see report):
+		//   - internalTransactionByAddress stores no block-number field at all
+		//     (only blockTimestamp), so there is nothing to filter on. We do not
+		//     fabricate one. Orphan internal-tx rows may linger after a reorg;
+		//     flagged for manual review.
+		//   - tokenBalances is a last-write-wins snapshot keyed on
+		//     (contractAddress, holderAddress), not a per-block append. We delete
+		//     only the snapshots whose last update happened in a rolled-back
+		//     block (blockNumber $in badBlockNumbers); those values are stale and
+		//     get re-derived from RPC when the block is reprocessed. Snapshots
+		//     last touched by an older block are left intact.
+		if len(badBlockNumbers) > 0 {
+			companionFilter := bson.M{"blockNumber": bson.M{"$in": badBlockNumbers}}
+
+			if _, err := configs.TransferCollections.DeleteMany(sessCtx, companionFilter); err != nil {
+				return nil, fmt.Errorf("rollback: failed to delete transfer rows: %w", err)
+			}
+			if _, err := configs.TransactionByAddressCollections.DeleteMany(sessCtx, companionFilter); err != nil {
+				return nil, fmt.Errorf("rollback: failed to delete transactionByAddress rows: %w", err)
+			}
+
+			tokenTransfers := configs.GetTokenTransfersCollection()
+			if _, err := tokenTransfers.DeleteMany(sessCtx, companionFilter); err != nil {
+				return nil, fmt.Errorf("rollback: failed to delete tokenTransfers rows: %w", err)
+			}
+
+			tokenBalances := configs.GetTokenBalancesCollection()
+			if _, err := tokenBalances.DeleteMany(sessCtx, companionFilter); err != nil {
+				return nil, fmt.Errorf("rollback: failed to delete tokenBalances rows: %w", err)
+			}
 		}
 
 		// Update sync state

--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -644,9 +644,11 @@ func Rollback(blockNumber string) error {
 		//     balances from RPC whenever a contract is next processed, so a
 		//     left-in-place snapshot self-heals; a deleted one does not. Leave
 		//     it untouched.
-		//   - internalTransactionByAddress stores no block-number field (only
-		//     blockTimestamp), so there is nothing to filter on. Orphan
-		//     internal-tx rows may linger after a reorg; flagged for follow-up.
+		//
+		// internalTransactionByAddress now stores blockNumber (raw hex string),
+		// so it is cleaned here too. Rows written by an older syncer before that
+		// field existed lack blockNumber and will not match the $in filter, so
+		// pre-existing orphans cannot be cleaned retroactively; that is expected.
 		if len(badBlockNumbers) > 0 {
 			companionFilter := bson.M{"blockNumber": bson.M{"$in": badBlockNumbers}}
 
@@ -655,6 +657,9 @@ func Rollback(blockNumber string) error {
 			}
 			if _, err := configs.TransactionByAddressCollections.DeleteMany(sessCtx, companionFilter); err != nil {
 				return nil, fmt.Errorf("rollback: failed to delete transactionByAddress rows: %w", err)
+			}
+			if _, err := configs.InternalTransactionByAddressCollections.DeleteMany(sessCtx, companionFilter); err != nil {
+				return nil, fmt.Errorf("rollback: failed to delete internalTransactionByAddress rows: %w", err)
 			}
 
 			tokenTransfers := configs.GetTokenTransfersCollection()

--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -630,21 +630,23 @@ func Rollback(blockNumber string) error {
 			return nil, err
 		}
 
-		// Delete companion rows for the removed blocks so a rolled-back block
-		// leaves no orphans. All three of these collections key blockNumber as
-		// the raw hex string, so the exact-match $in filter is correct.
+		// Delete the append-only companion rows for the removed blocks so a
+		// rolled-back block leaves no orphan event records. These collections
+		// key blockNumber as the raw hex string, so the exact-match $in filter
+		// is correct (a numeric range would lex-sort hex strings wrong).
 		//
-		// NOT cleaned here (intentional, see report):
-		//   - internalTransactionByAddress stores no block-number field at all
-		//     (only blockTimestamp), so there is nothing to filter on. We do not
-		//     fabricate one. Orphan internal-tx rows may linger after a reorg;
-		//     flagged for manual review.
+		// NOT cleaned here (intentional):
 		//   - tokenBalances is a last-write-wins snapshot keyed on
-		//     (contractAddress, holderAddress), not a per-block append. We delete
-		//     only the snapshots whose last update happened in a rolled-back
-		//     block (blockNumber $in badBlockNumbers); those values are stale and
-		//     get re-derived from RPC when the block is reprocessed. Snapshots
-		//     last touched by an older block are left intact.
+		//     (contractAddress, holderAddress), NOT a per-block append. Deleting
+		//     a holder's snapshot just because its last update landed in a
+		//     rolled-back block would permanently drop a balance the new chain
+		//     may never re-touch (it would read as 0). The syncer re-derives
+		//     balances from RPC whenever a contract is next processed, so a
+		//     left-in-place snapshot self-heals; a deleted one does not. Leave
+		//     it untouched.
+		//   - internalTransactionByAddress stores no block-number field (only
+		//     blockTimestamp), so there is nothing to filter on. Orphan
+		//     internal-tx rows may linger after a reorg; flagged for follow-up.
 		if len(badBlockNumbers) > 0 {
 			companionFilter := bson.M{"blockNumber": bson.M{"$in": badBlockNumbers}}
 
@@ -658,11 +660,6 @@ func Rollback(blockNumber string) error {
 			tokenTransfers := configs.GetTokenTransfersCollection()
 			if _, err := tokenTransfers.DeleteMany(sessCtx, companionFilter); err != nil {
 				return nil, fmt.Errorf("rollback: failed to delete tokenTransfers rows: %w", err)
-			}
-
-			tokenBalances := configs.GetTokenBalancesCollection()
-			if _, err := tokenBalances.DeleteMany(sessCtx, companionFilter); err != nil {
-				return nil, fmt.Errorf("rollback: failed to delete tokenBalances rows: %w", err)
 			}
 		}
 

--- a/QRL2MongoDB/db/contracts.go
+++ b/QRL2MongoDB/db/contracts.go
@@ -8,13 +8,58 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
+	"unicode"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.uber.org/zap"
 )
+
+// maxTokenStringRunes caps the stored length of on-chain token name/symbol
+// strings. On-chain name()/symbol() are attacker-controlled, an unbounded
+// string is both a storage-bloat and a downstream-rendering hazard.
+const maxTokenStringRunes = 128
+
+// sanitizeTokenString cleans an on-chain token name/symbol before it is
+// persisted. It is the single ingestion-time chokepoint for these
+// attacker-controlled strings: every StoreContract write passes through it,
+// so all downstream readers (API JSON, future CSV export, server-rendered
+// templates) receive an already-cleaned value rather than relying on a
+// specific sink to escape it.
+//
+// Behavior:
+//   - strips ASCII/Unicode control characters (C0/C1, DEL, etc.) that have no
+//     legitimate place in a display name and could break a non-JSX sink;
+//   - preserves all legitimate Unicode letters/marks/symbols/punctuation;
+//   - trims leading/trailing whitespace;
+//   - caps the result at maxTokenStringRunes runes (rune-safe, never splits a
+//     multibyte codepoint).
+func sanitizeTokenString(s string) string {
+	if s == "" {
+		return s
+	}
+
+	// Drop control characters; keep everything else (letters, marks, digits,
+	// punctuation, symbols, spaces) intact so legitimate unicode is preserved.
+	cleaned := strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+
+	cleaned = strings.TrimSpace(cleaned)
+
+	// Rune-safe length cap.
+	if runes := []rune(cleaned); len(runes) > maxTokenStringRunes {
+		cleaned = string(runes[:maxTokenStringRunes])
+	}
+
+	return cleaned
+}
 
 // StoreContract stores or merges contract information in the database.
 //
@@ -40,6 +85,12 @@ func StoreContract(contract models.ContractInfo) error {
 	// Normalize addresses to canonical Q-prefix form
 	contract.Address = validation.ConvertToQAddress(contract.Address)
 	contract.CreatorAddress = validation.ConvertToQAddress(contract.CreatorAddress)
+
+	// Sanitize attacker-controlled on-chain token strings at the single
+	// storage chokepoint so every write path (creation tx, reprocess,
+	// classifier) persists a control-char-free, length-capped value.
+	contract.Name = sanitizeTokenString(contract.Name)
+	contract.Symbol = sanitizeTokenString(contract.Symbol)
 
 	collection := configs.GetContractsCollection()
 	filter := bson.M{"address": contract.Address}
@@ -818,9 +869,15 @@ func findCreationTransaction(contractAddress string) *creationTxInfo {
 	}
 }
 
-// StartContractReprocessingJob starts a background job to periodically reprocess incomplete contracts
-func StartContractReprocessingJob() {
+// StartContractReprocessingJob starts a background job to periodically reprocess
+// incomplete contracts. The goroutine returns once stopCh is closed so a
+// graceful shutdown does not start a new reprocess pass while in-flight work
+// is draining.
+func StartContractReprocessingJob(stopCh <-chan struct{}) {
 	go func() {
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+
 		for {
 			configs.Logger.Info("Starting contract reprocessing job")
 
@@ -829,8 +886,13 @@ func StartContractReprocessingJob() {
 				configs.Logger.Error("Contract reprocessing job failed", zap.Error(err))
 			}
 
-			// Wait for 1 hour before next run
-			time.Sleep(1 * time.Hour)
+			// Wait for 1 hour before next run, or exit early on shutdown.
+			select {
+			case <-ticker.C:
+			case <-stopCh:
+				configs.Logger.Info("Stopping contract reprocessing job on shutdown signal")
+				return
+			}
 		}
 	}()
 }

--- a/QRL2MongoDB/db/contracts.go
+++ b/QRL2MongoDB/db/contracts.go
@@ -38,27 +38,35 @@ const maxTokenStringRunes = 128
 //   - caps the result at maxTokenStringRunes runes (rune-safe, never splits a
 //     multibyte codepoint).
 func sanitizeTokenString(s string) string {
+	s = strings.TrimSpace(s)
 	if s == "" {
 		return s
 	}
 
-	// Drop control characters; keep everything else (letters, marks, digits,
-	// punctuation, symbols, spaces) intact so legitimate unicode is preserved.
-	cleaned := strings.Map(func(r rune) rune {
-		if unicode.IsControl(r) {
-			return -1
-		}
-		return r
-	}, s)
-
-	cleaned = strings.TrimSpace(cleaned)
-
-	// Rune-safe length cap.
-	if runes := []rune(cleaned); len(runes) > maxTokenStringRunes {
-		cleaned = string(runes[:maxTokenStringRunes])
+	// name()/symbol() are attacker-controlled on-chain strings of unbounded
+	// length, so this must not allocate or scan the whole input. Cap the bytes
+	// examined first (a rune is at most 4 bytes, so maxTokenStringRunes runes
+	// fit in 4x that), then single-pass: drop control characters, keep all
+	// other unicode, and stop as soon as the rune budget is reached.
+	if len(s) > maxTokenStringRunes*4 {
+		s = s[:maxTokenStringRunes*4]
 	}
 
-	return cleaned
+	var b strings.Builder
+	b.Grow(len(s))
+	runeCount := 0
+	for _, r := range s {
+		if unicode.IsControl(r) {
+			continue
+		}
+		b.WriteRune(r)
+		runeCount++
+		if runeCount >= maxTokenStringRunes {
+			break
+		}
+	}
+
+	return strings.TrimSpace(b.String())
 }
 
 // StoreContract stores or merges contract information in the database.

--- a/QRL2MongoDB/db/transactions.go
+++ b/QRL2MongoDB/db/transactions.go
@@ -381,6 +381,7 @@ func processTransactionData(tx *models.Transaction, blockTimestamp string, to st
 			trace.AddressFunctionIdentifier,
 			fmt.Sprintf("0x%x", trace.AmountFunctionIdentifier),
 			blockTimestamp,
+			blockNumber,
 		)
 	}
 
@@ -491,7 +492,7 @@ func TransferCollection(blockNumber string, blockTimestamp string, from string, 
 	return result, err
 }
 
-func InternalTransactionByAddressCollection(transactionType string, callType string, hash string, from string, to string, input string, output string, traceAddress []int, value float64, gas string, gasUsed string, addressFunctionIdentifier string, amountFunctionIdentifier string, blockTimestamp string) (*mongo.InsertOneResult, error) {
+func InternalTransactionByAddressCollection(transactionType string, callType string, hash string, from string, to string, input string, output string, traceAddress []int, value float64, gas string, gasUsed string, addressFunctionIdentifier string, amountFunctionIdentifier string, blockTimestamp string, blockNumber string) (*mongo.InsertOneResult, error) {
 	// Normalize addresses to canonical Q-prefix form
 	if from != "" {
 		from = validation.ConvertToQAddress(from)
@@ -503,6 +504,8 @@ func InternalTransactionByAddressCollection(transactionType string, callType str
 		addressFunctionIdentifier = validation.ConvertToQAddress(addressFunctionIdentifier)
 	}
 
+	// blockNumber (raw hex string) lets Rollback delete this row on a reorg via
+	// the same $in companionFilter used for the other append-only collections.
 	doc := bson.D{
 		{Key: "type", Value: transactionType},
 		{Key: "callType", Value: callType},
@@ -518,6 +521,7 @@ func InternalTransactionByAddressCollection(transactionType string, callType str
 		{Key: "addressFunctionIdentifier", Value: addressFunctionIdentifier},
 		{Key: "amountFunctionIdentifier", Value: amountFunctionIdentifier},
 		{Key: "blockTimestamp", Value: blockTimestamp},
+		{Key: "blockNumber", Value: blockNumber},
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/QRL2MongoDB/db/wallet_sync.go
+++ b/QRL2MongoDB/db/wallet_sync.go
@@ -11,8 +11,10 @@ import (
 	"go.uber.org/zap"
 )
 
-// StartWalletCountSync starts a goroutine that syncs wallet count every 4 hours
-func StartWalletCountSync() {
+// StartWalletCountSync starts a goroutine that syncs wallet count every 4 hours.
+// The goroutine returns once stopCh is closed so a graceful shutdown does not
+// start a new count while in-flight work is draining.
+func StartWalletCountSync(stopCh <-chan struct{}) {
 	configs.Logger.Info("Initializing wallet count sync service")
 	go func() {
 		ticker := time.NewTicker(4 * time.Hour)
@@ -26,10 +28,15 @@ func StartWalletCountSync() {
 
 		// Then sync every 4 hours
 		configs.Logger.Info("Starting periodic wallet count sync (every 4 hours)")
-		for range ticker.C {
-			if err := syncWalletCount(); err != nil {
-				configs.Logger.Error("Failed wallet count sync", zap.Error(err))
-				continue
+		for {
+			select {
+			case <-ticker.C:
+				if err := syncWalletCount(); err != nil {
+					configs.Logger.Error("Failed wallet count sync", zap.Error(err))
+				}
+			case <-stopCh:
+				configs.Logger.Info("Stopping wallet count sync on shutdown signal")
+				return
 			}
 		}
 	}()

--- a/QRL2MongoDB/main.go
+++ b/QRL2MongoDB/main.go
@@ -125,9 +125,11 @@ func main() {
 		}
 	}()
 
-	// Start pending transaction sync (this is not started in sync.go)
+	// Start pending transaction sync (this is not started in sync.go).
+	// stopCh is threaded in so the mempool/cleanup/verify tickers stop
+	// accepting new work when a shutdown signal arrives.
 	configs.Logger.Info("Starting pending transaction sync service...")
-	synchroniser.StartPendingTransactionSync()
+	synchroniser.StartPendingTransactionSync(stopCh)
 
 	// Phase 3a: start the off-chain NFT collection metadata fetcher.
 	// Background goroutine that polls contractCode for unfetched
@@ -147,8 +149,9 @@ func main() {
 	go func() {
 		defer close(doneCh)
 		// Sync will now handle starting wallet count and contract reprocessing
-		// services after initial sync is complete
-		synchroniser.Sync()
+		// services after initial sync is complete. stopCh is threaded in so
+		// every background ticker goroutine Sync starts can observe shutdown.
+		synchroniser.Sync(stopCh)
 	}()
 
 	// Block until either sync finishes naturally or a shutdown signal arrives.

--- a/QRL2MongoDB/synchroniser/gap_detection.go
+++ b/QRL2MongoDB/synchroniser/gap_detection.go
@@ -166,6 +166,21 @@ func fillGaps(gaps []string) int {
 			continue
 		}
 
+		// Idempotency guard: skip both the block insert and ProcessTransactions
+		// together if the block already exists. A "gap" can close between
+		// detection and fill (the single-block loop retries failed blocks, the
+		// batch path may overlap), and ProcessTransactions has no txHash unique
+		// index, so re-running it would duplicate transfer + transactionByAddress
+		// rows. InsertBlockDocument alone already no-ops on an existing block;
+		// the guard keeps the transaction processing consistent with it.
+		if db.BlockExists(blockNum) {
+			configs.Logger.Info("Gap block already exists, skipping insert and transaction processing",
+				zap.String("block", blockNum))
+			clearFailedBlock(blockNum)
+			filled++
+			continue
+		}
+
 		// Insert the block
 		db.UpdateTransactionStatuses(data)
 		db.InsertBlockDocument(*data)

--- a/QRL2MongoDB/synchroniser/pending_sync.go
+++ b/QRL2MongoDB/synchroniser/pending_sync.go
@@ -15,34 +15,36 @@ import (
 )
 
 const (
-	MEMPOOL_SYNC_INTERVAL       = 1 * time.Second  // Reduced for faster detection
-	CLEANUP_INTERVAL            = 1 * time.Hour
-	VERIFY_PENDING_INTERVAL     = 5 * time.Minute
-	MAX_PENDING_AGE             = 24 * time.Hour
+	MEMPOOL_SYNC_INTERVAL   = 1 * time.Second // Reduced for faster detection
+	CLEANUP_INTERVAL        = 1 * time.Hour
+	VERIFY_PENDING_INTERVAL = 5 * time.Minute
+	MAX_PENDING_AGE         = 24 * time.Hour
 )
 
-// StartPendingTransactionSync starts the periodic mempool monitoring
-func StartPendingTransactionSync() {
+// StartPendingTransactionSync starts the periodic mempool monitoring. The
+// stopCh is threaded into each periodic task so they stop accepting new work
+// when a shutdown signal arrives.
+func StartPendingTransactionSync(stopCh <-chan struct{}) {
 	// Start mempool sync
-	go runPeriodicTask(func() {
+	runPeriodicTask(func() {
 		if err := syncMempool(); err != nil {
 			configs.Logger.Error("Failed to sync mempool", zap.Error(err))
 		}
-	}, MEMPOOL_SYNC_INTERVAL, "mempool sync")
+	}, MEMPOOL_SYNC_INTERVAL, "mempool sync", stopCh)
 
 	// Start cleanup of old transactions
-	go runPeriodicTask(func() {
+	runPeriodicTask(func() {
 		if err := db.CleanupOldPendingTransactions(MAX_PENDING_AGE); err != nil {
 			configs.Logger.Error("Failed to cleanup old pending transactions", zap.Error(err))
 		}
-	}, CLEANUP_INTERVAL, "pending cleanup")
+	}, CLEANUP_INTERVAL, "pending cleanup", stopCh)
 
 	// Start verification of pending transactions against node
-	go runPeriodicTask(func() {
+	runPeriodicTask(func() {
 		if err := verifyPendingTransactions(); err != nil {
 			configs.Logger.Error("Failed to verify pending transactions", zap.Error(err))
 		}
-	}, VERIFY_PENDING_INTERVAL, "pending verification")
+	}, VERIFY_PENDING_INTERVAL, "pending verification", stopCh)
 }
 
 // UpdatePendingTransactionsInBlock checks if any pending transactions are included in the new block

--- a/QRL2MongoDB/synchroniser/periodic_tasks.go
+++ b/QRL2MongoDB/synchroniser/periodic_tasks.go
@@ -25,15 +25,15 @@ func runPeriodicTask(task func(), interval time.Duration, taskName string, stopC
 				configs.Logger.Error("Recovered from panic in periodic task",
 					zap.String("task", taskName),
 					zap.Any("error", r))
-				// Do not restart if we are shutting down.
+				// Restart the task after a short delay, but exit promptly if a
+				// shutdown signal arrives during the wait instead of blocking
+				// the whole delay on time.Sleep.
 				select {
 				case <-stopCh:
 					return
-				default:
+				case <-time.After(5 * time.Second):
+					runPeriodicTask(task, interval, taskName, stopCh)
 				}
-				// Restart the task after a short delay
-				time.Sleep(5 * time.Second)
-				runPeriodicTask(task, interval, taskName, stopCh)
 			}
 		}()
 

--- a/QRL2MongoDB/synchroniser/periodic_tasks.go
+++ b/QRL2MongoDB/synchroniser/periodic_tasks.go
@@ -202,13 +202,31 @@ func processBlockPeriodically() {
 				continue
 			}
 
+			// processSubsequentBlocks returns the next block to process. On a
+			// clean success that is currentBlock+1. On a reorg or a
+			// missing-parent it returns an EARLIER block (the parent), having
+			// rolled back the stale data, so the loop must resume from there
+			// instead of blindly advancing +1. Detect the forward-success case
+			// by comparing the returned value to currentBlock+1.
+			expectedNext := utils.AddHexNumbers(currentBlock, "0x1")
+			if result != expectedNext {
+				// Rollback / re-sync requested: jump to the returned block. Do
+				// NOT run token processing or clear failure tracking for the
+				// current block; it was not advanced past.
+				configs.Logger.Warn("Re-sync point returned (rollback or missing parent), resuming from earlier block",
+					zap.String("from_block", currentBlock),
+					zap.String("resume_block", result))
+				currentBlock = result
+				continue
+			}
+
 			// Clear any previous failure tracking on success
 			clearFailedBlock(currentBlock)
 
 			ProcessTokenTransfersForBlock(currentBlock)
 
-			// Move to next block
-			currentBlock = utils.AddHexNumbers(currentBlock, "0x1")
+			// Move to next block (== result on the success path)
+			currentBlock = result
 		}
 
 		// Attempt to fill any failed blocks from this run

--- a/QRL2MongoDB/synchroniser/periodic_tasks.go
+++ b/QRL2MongoDB/synchroniser/periodic_tasks.go
@@ -15,17 +15,25 @@ import (
 	"go.uber.org/zap"
 )
 
-// runPeriodicTask runs a task at regular intervals with panic recovery
-func runPeriodicTask(task func(), interval time.Duration, taskName string) {
+// runPeriodicTask runs a task at regular intervals with panic recovery.
+// The goroutine returns promptly once stopCh is closed so a graceful
+// shutdown does not start new work while in-flight DB ops are draining.
+func runPeriodicTask(task func(), interval time.Duration, taskName string, stopCh <-chan struct{}) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
 				configs.Logger.Error("Recovered from panic in periodic task",
 					zap.String("task", taskName),
 					zap.Any("error", r))
+				// Do not restart if we are shutting down.
+				select {
+				case <-stopCh:
+					return
+				default:
+				}
 				// Restart the task after a short delay
 				time.Sleep(5 * time.Second)
-				runPeriodicTask(task, interval, taskName)
+				runPeriodicTask(task, interval, taskName, stopCh)
 			}
 		}()
 
@@ -39,8 +47,15 @@ func runPeriodicTask(task func(), interval time.Duration, taskName string) {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 
-		for range ticker.C {
-			runTaskWithRetry(task, taskName)
+		for {
+			select {
+			case <-ticker.C:
+				runTaskWithRetry(task, taskName)
+			case <-stopCh:
+				configs.Logger.Info("Stopping periodic task on shutdown signal",
+					zap.String("task", taskName))
+				return
+			}
 		}
 	}()
 }
@@ -291,8 +306,11 @@ func updateDataPeriodically() {
 	}
 }
 
-// singleBlockInsertion starts continuous block monitoring with periodic tasks
-func singleBlockInsertion() {
+// singleBlockInsertion starts continuous block monitoring with periodic tasks.
+// Each periodic goroutine watches stopCh so a graceful shutdown stops them
+// from starting new work; wg.Wait then returns once they have all exited,
+// which lets Sync() (and therefore main.go's doneCh) complete cleanly.
+func singleBlockInsertion(stopCh <-chan struct{}) {
 	configs.Logger.Info("Starting single block insertion process")
 
 	// Initialize collections if they don't exist
@@ -322,8 +340,14 @@ func singleBlockInsertion() {
 			// Run immediately on start
 			processBlockPeriodically()
 
-			for range ticker.C {
-				processBlockPeriodically()
+			for {
+				select {
+				case <-ticker.C:
+					processBlockPeriodically()
+				case <-stopCh:
+					configs.Logger.Info("Stopping block processing on shutdown signal")
+					return
+				}
 			}
 		}
 	}()
@@ -341,8 +365,14 @@ func singleBlockInsertion() {
 		// Run immediately on start
 		updateDataPeriodically()
 
-		for range ticker.C {
-			updateDataPeriodically()
+		for {
+			select {
+			case <-ticker.C:
+				updateDataPeriodically()
+			case <-stopCh:
+				configs.Logger.Info("Stopping data updates on shutdown signal")
+				return
+			}
 		}
 	}()
 
@@ -359,8 +389,14 @@ func singleBlockInsertion() {
 		// Run immediately on start
 		updateValidatorsPeriodically()
 
-		for range ticker.C {
-			updateValidatorsPeriodically()
+		for {
+			select {
+			case <-ticker.C:
+				updateValidatorsPeriodically()
+			case <-stopCh:
+				configs.Logger.Info("Stopping validator updates on shutdown signal")
+				return
+			}
 		}
 	}()
 
@@ -374,15 +410,27 @@ func singleBlockInsertion() {
 		ticker := time.NewTicker(time.Minute * 5)
 		defer ticker.Stop()
 
-		// Wait 1 minute before first run to let initial sync settle
-		time.Sleep(time.Minute)
+		// Wait 1 minute before first run to let initial sync settle, but bail
+		// out early if a shutdown arrives during that initial delay.
+		select {
+		case <-time.After(time.Minute):
+		case <-stopCh:
+			configs.Logger.Info("Stopping gap detection on shutdown signal")
+			return
+		}
 
-		for range ticker.C {
-			detectAndFillGapsPeriodically()
+		for {
+			select {
+			case <-ticker.C:
+				detectAndFillGapsPeriodically()
+			case <-stopCh:
+				configs.Logger.Info("Stopping gap detection on shutdown signal")
+				return
+			}
 		}
 	}()
 
-	// Keep the main goroutine alive
+	// Keep the main goroutine alive until every periodic task has stopped.
 	wg.Wait()
 }
 

--- a/QRL2MongoDB/synchroniser/producer_consumer.go
+++ b/QRL2MongoDB/synchroniser/producer_consumer.go
@@ -97,10 +97,15 @@ func consumer(ch <-chan (<-chan Data)) {
 					// idempotency guard in sync.go and gap_detection.go.
 					// ProcessTransactions has no unique index on txHash, so
 					// re-running it on an already-synced block duplicates
-					// transfer + transactionByAddress rows.
-					alreadyExists := make([]bool, len(blocks))
+					// transfer + transactionByAddress rows. One $in query keeps
+					// this to a single round-trip instead of N per batch.
+					blockNumbers := make([]string, len(blocks))
 					for x := 0; x < len(blocks); x++ {
-						alreadyExists[x] = db.BlockExists(blocks[x].Result.Number)
+						blockNumbers[x] = blocks[x].Result.Number
+					}
+					alreadyExists, err := db.BlocksExist(blockNumbers)
+					if err != nil {
+						configs.Logger.Error("Failed to check existing blocks in batch", zap.Error(err))
 					}
 
 					db.InsertManyBlockDocuments(data.blockData)
@@ -108,7 +113,7 @@ func consumer(ch <-chan (<-chan Data)) {
 						zap.Int("count", len(data.blockData)))
 
 					for x := 0; x < len(blocks); x++ {
-						if alreadyExists[x] {
+						if alreadyExists[blocks[x].Result.Number] {
 							configs.Logger.Info("Batch block already processed, skipping transaction processing",
 								zap.String("block", blocks[x].Result.Number))
 							continue

--- a/QRL2MongoDB/synchroniser/producer_consumer.go
+++ b/QRL2MongoDB/synchroniser/producer_consumer.go
@@ -87,11 +87,32 @@ func consumer(ch <-chan (<-chan Data)) {
 						continue
 					}
 
+					// Snapshot which blocks already exist BEFORE the InsertMany.
+					// After InsertManyBlockDocuments runs, every block in the
+					// batch is present, so checking existence afterward would
+					// also skip ProcessTransactions for legitimately new blocks.
+					// Capturing it up front lets us skip ProcessTransactions only
+					// for blocks that were already synced (crash/restart during
+					// catch-up, overlapping ranges), matching the BlockExists
+					// idempotency guard in sync.go and gap_detection.go.
+					// ProcessTransactions has no unique index on txHash, so
+					// re-running it on an already-synced block duplicates
+					// transfer + transactionByAddress rows.
+					alreadyExists := make([]bool, len(blocks))
+					for x := 0; x < len(blocks); x++ {
+						alreadyExists[x] = db.BlockExists(blocks[x].Result.Number)
+					}
+
 					db.InsertManyBlockDocuments(data.blockData)
 					configs.Logger.Info("Inserted block batch",
 						zap.Int("count", len(data.blockData)))
 
 					for x := 0; x < len(blocks); x++ {
+						if alreadyExists[x] {
+							configs.Logger.Info("Batch block already processed, skipping transaction processing",
+								zap.String("block", blocks[x].Result.Number))
+							continue
+						}
 						db.ProcessTransactions(blocks[x])
 						// Tombstone any pending rows whose hashes are in this
 						// block. The single-block path (sync.go) calls this

--- a/QRL2MongoDB/synchroniser/sync.go
+++ b/QRL2MongoDB/synchroniser/sync.go
@@ -418,6 +418,13 @@ func processSubsequentBlocks(currentBlock string) string {
 				zap.String("rollback_target", rollbackTarget),
 				zap.String("stale_block", parentBlockNum),
 				zap.Error(err))
+			// Rollback did not delete the stale block. Returning parentBlockNum
+			// here would let the BlockExists guard skip the still-present N-1,
+			// advance to N, re-detect the mismatch, and ping-pong forever
+			// without ever repairing the data. Return currentBlock instead so
+			// the next tick retries this same block (and the rollback) until it
+			// succeeds.
+			return currentBlock
 		}
 		// Resume from the rolled-back point: re-sync the stale block (N-1)
 		// first so its parent linkage is rebuilt before N.

--- a/QRL2MongoDB/synchroniser/sync.go
+++ b/QRL2MongoDB/synchroniser/sync.go
@@ -246,7 +246,6 @@ func Sync() {
 	singleBlockInsertion()
 }
 
-
 // findHighestProcessedBlock finds the highest block number that exists in the database
 func findHighestProcessedBlock() string {
 	// First try to get the last synced block from the database
@@ -405,14 +404,45 @@ func processSubsequentBlocks(currentBlock string) string {
 			zap.String("expected_parent", dbParentHash),
 			zap.String("actual_parent", blockData.Result.ParentHash))
 
-		// Roll back one block and try again
-		err = db.Rollback(currentBlock)
+		// Reorg: block N (currentBlock) does not build on the stored block N-1
+		// (parentBlockNum), so the stored N-1 is stale and must be removed.
+		// Rollback deletes blocks with blockNumberInt > arg (strict $gt), so to
+		// include N-1 in the deletion set we pass N-2 (parentBlockNum - 0x1).
+		// Rollback then deletes every block >= N-1 (i.e. the stale N-1 and any
+		// stragglers above it) and resets the sync state to N-2, so the
+		// continuous loop re-syncs starting at N-1.
+		rollbackTarget := utils.SubtractHexNumbers(parentBlockNum, "0x1")
+		err = db.Rollback(rollbackTarget)
 		if err != nil {
 			configs.Logger.Error("Failed to rollback block",
-				zap.String("block", currentBlock),
+				zap.String("rollback_target", rollbackTarget),
+				zap.String("stale_block", parentBlockNum),
 				zap.Error(err))
 		}
+		// Resume from the rolled-back point: re-sync the stale block (N-1)
+		// first so its parent linkage is rebuilt before N.
 		return parentBlockNum
+	}
+
+	// Idempotency guard: if this block is already stored, skip BOTH the block
+	// insert and ProcessTransactions together. InsertBlockDocument already
+	// no-ops on an existing block, but ProcessTransactions used to run
+	// unconditionally right after, duplicating transfer + transactionByAddress
+	// rows (which have no unique index on txHash) on any re-process: retry
+	// after a partial failure, node restart, or gap-fill overlap. Guarding both
+	// with one BlockExists check keeps them consistent.
+	//
+	// This does NOT block the reorg re-sync path above: Rollback deletes the
+	// stale block first, so BlockExists returns false on the subsequent
+	// reprocess and the block is re-inserted correctly.
+	if db.BlockExists(currentBlock) {
+		configs.Logger.Info("Block already processed, skipping insert and transaction processing",
+			zap.String("block", currentBlock),
+			zap.String("hash", blockData.Result.Hash))
+		// Still advance the sync state and return the next block so the caller
+		// continues forward rather than re-checking the same block.
+		db.StoreLastKnownBlockNumber(currentBlock)
+		return utils.AddHexNumbers(currentBlock, "0x1")
 	}
 
 	// Process the block
@@ -437,4 +467,3 @@ func processSubsequentBlocks(currentBlock string) string {
 	// Return next block number
 	return utils.AddHexNumbers(currentBlock, "0x1")
 }
-

--- a/QRL2MongoDB/synchroniser/sync.go
+++ b/QRL2MongoDB/synchroniser/sync.go
@@ -92,8 +92,10 @@ func getRPCDelay(bulkSync bool) time.Duration {
 	return time.Duration(delay) * time.Millisecond
 }
 
-// Sync starts the synchronization process
-func Sync() {
+// Sync starts the synchronization process. stopCh is closed by main.go on a
+// termination signal; it is threaded into every background ticker goroutine
+// started here so they stop accepting new work during graceful shutdown.
+func Sync(stopCh <-chan struct{}) {
 	var err error
 	var nextBlock string
 	var maxHex string
@@ -231,11 +233,11 @@ func Sync() {
 	go func() {
 		// Start wallet count sync
 		configs.Logger.Info("Starting wallet count sync service...")
-		db.StartWalletCountSync()
+		db.StartWalletCountSync(stopCh)
 
 		// Start contract reprocessing job
 		configs.Logger.Info("Starting contract reprocessing service...")
-		db.StartContractReprocessingJob()
+		db.StartContractReprocessingJob(stopCh)
 	}()
 
 	// Signal that initial sync is done so mempool polling can begin
@@ -243,7 +245,7 @@ func Sync() {
 	configs.Logger.Info("Initial sync flag set, mempool polling enabled")
 
 	configs.Logger.Info("Starting continuous block monitoring...")
-	singleBlockInsertion()
+	singleBlockInsertion(stopCh)
 }
 
 // findHighestProcessedBlock finds the highest block number that exists in the database

--- a/backendAPI/configs/const.go
+++ b/backendAPI/configs/const.go
@@ -10,20 +10,32 @@ import (
 const QUANTA float64 = 1000000000000000000
 
 var Url string = os.Getenv("NODE_URL")
-var TransferCollections *mongo.Collection = GetCollection(DB, "transfer")
-var TransactionByAddressCollection *mongo.Collection = GetCollection(DB, "transactionByAddress")
-var InternalTransactionByAddressCollection *mongo.Collection = GetCollection(DB, "internalTransactionByAddress")
-var AddressesCollections *mongo.Collection = GetCollection(DB, "addresses")
-var BlocksCollection *mongo.Collection = GetCollection(DB, "blocks")
-var ValidatorsCollections *mongo.Collection = GetCollection(DB, "validators")
-var ContractInfoCollection *mongo.Collection = GetCollection(DB, "contractCode")
-var ContractVerificationsCollection *mongo.Collection = GetCollection(DB, "contractVerifications")
-var BlockSizesCollection *mongo.Collection = GetCollection(DB, "averageBlockSize")
-var TotalCirculatingSupplyCollection *mongo.Collection = GetCollection(DB, "totalCirculatingSupply")
-var CoinGeckoCollection *mongo.Collection = GetCollection(DB, "coingecko")
-var WalletCountCollections *mongo.Collection = GetCollection(DB, "walletCount")
-var DailyTransactionsVolumeCollection *mongo.Collection = GetCollection(DB, "dailyTransactionsVolume")
-var EpochInfoCollection *mongo.Collection = GetCollection(DB, "epoch_info")
-var ValidatorHistoryCollection *mongo.Collection = GetCollection(DB, "validator_history")
-var PriceHistoryCollection *mongo.Collection = GetCollection(DB, "priceHistory")
+
+// Collection handles. These are populated by ConnectDB once the client is
+// confirmed live (see initCollections), not at package-init time. Binding
+// them at declaration via GetCollection(DB, ...) used to force a Mongo
+// connect during package initialization (because DB is nil there, the
+// nil-guard in GetCollection calls ConnectDB), which meant a Mongo outage
+// log.Fatal'd before main's panic recovery was installed and left the
+// startup ordering fragile. Every reader of these vars runs inside an HTTP
+// handler, which only executes after RequestHandler has called ConnectDB.
+var (
+	TransferCollections                    *mongo.Collection
+	TransactionByAddressCollection         *mongo.Collection
+	InternalTransactionByAddressCollection *mongo.Collection
+	AddressesCollections                   *mongo.Collection
+	BlocksCollection                       *mongo.Collection
+	ValidatorsCollections                  *mongo.Collection
+	ContractInfoCollection                 *mongo.Collection
+	ContractVerificationsCollection        *mongo.Collection
+	BlockSizesCollection                   *mongo.Collection
+	TotalCirculatingSupplyCollection       *mongo.Collection
+	CoinGeckoCollection                    *mongo.Collection
+	WalletCountCollections                 *mongo.Collection
+	DailyTransactionsVolumeCollection      *mongo.Collection
+	EpochInfoCollection                    *mongo.Collection
+	ValidatorHistoryCollection             *mongo.Collection
+	PriceHistoryCollection                 *mongo.Collection
+)
+
 var Validate = validator.New()

--- a/backendAPI/configs/setup.go
+++ b/backendAPI/configs/setup.go
@@ -51,9 +51,37 @@ func ConnectDB() *mongo.Client {
 
 		// Set the global DB variable
 		DB = client
+
+		// Bind the package-level collection handles now that the client is
+		// confirmed live. Doing this here (rather than at package-var
+		// declaration time) removes the nil-client window: every reader runs
+		// inside an HTTP handler, which only executes after this point.
+		bindCollections(client)
 	})
 
 	return DB
+}
+
+// bindCollections wires the package-level *mongo.Collection handles to the
+// live client. Called once from ConnectDB after the ping succeeds.
+func bindCollections(client *mongo.Client) {
+	db := client.Database("qrldata-z")
+	TransferCollections = db.Collection("transfer")
+	TransactionByAddressCollection = db.Collection("transactionByAddress")
+	InternalTransactionByAddressCollection = db.Collection("internalTransactionByAddress")
+	AddressesCollections = db.Collection("addresses")
+	BlocksCollection = db.Collection("blocks")
+	ValidatorsCollections = db.Collection("validators")
+	ContractInfoCollection = db.Collection("contractCode")
+	ContractVerificationsCollection = db.Collection("contractVerifications")
+	BlockSizesCollection = db.Collection("averageBlockSize")
+	TotalCirculatingSupplyCollection = db.Collection("totalCirculatingSupply")
+	CoinGeckoCollection = db.Collection("coingecko")
+	WalletCountCollections = db.Collection("walletCount")
+	DailyTransactionsVolumeCollection = db.Collection("dailyTransactionsVolume")
+	EpochInfoCollection = db.Collection("epoch_info")
+	ValidatorHistoryCollection = db.Collection("validator_history")
+	PriceHistoryCollection = db.Collection("priceHistory")
 }
 
 func createIndexes(db *mongo.Database) {
@@ -114,7 +142,12 @@ func createIndexes(db *mongo.Database) {
 		},
 	}
 
-	// internalTransactionByAddress collection indexes
+	// internalTransactionByAddress collection indexes.
+	// The compound (from|to, blockTimestamp desc) pair backs the $or+sort in
+	// ReturnAllInternalTransactionsByAddress; the hash index backs the
+	// per-tx lookups in GetInternalTransactionsByTxHash and
+	// CountInternalTxsByTxHashes. The legacy single-field from/to indexes
+	// are kept so existing query plans don't regress.
 	internalTransactionsIndexes := []mongo.IndexModel{
 		{
 			Keys:    bson.D{{Key: "from", Value: 1}},
@@ -123,6 +156,24 @@ func createIndexes(db *mongo.Database) {
 		{
 			Keys:    bson.D{{Key: "to", Value: 1}},
 			Options: options.Index().SetName("internal_to"),
+		},
+		{
+			Keys: bson.D{
+				{Key: "from", Value: 1},
+				{Key: "blockTimestamp", Value: -1},
+			},
+			Options: options.Index().SetName("internal_from_blocktimestamp_desc"),
+		},
+		{
+			Keys: bson.D{
+				{Key: "to", Value: 1},
+				{Key: "blockTimestamp", Value: -1},
+			},
+			Options: options.Index().SetName("internal_to_blocktimestamp_desc"),
+		},
+		{
+			Keys:    bson.D{{Key: "hash", Value: 1}},
+			Options: options.Index().SetName("internal_hash"),
 		},
 	}
 

--- a/backendAPI/db/token.go
+++ b/backendAPI/db/token.go
@@ -837,6 +837,11 @@ func GetNFTBalancesByAddress(address string, standardFilter *string) ([]models.N
 			{Key: "tokenIDLen", Value: 1},
 			{Key: "tokenID", Value: 1},
 		}},
+		// Bound the materialized result set. Without a cap a wallet holding
+		// thousands of NFT rows forces Mongo to sort + stream every row on
+		// each request. 500 covers any realistic single-wallet picker view;
+		// the route is not paginated so this is a hard ceiling, not a page.
+		{"$limit": 500},
 		{"$project": bson.M{"tokenIDLen": 0}},
 	}
 

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -1566,6 +1566,13 @@ func UserRoute(router *gin.Engine) {
 			return
 		}
 
+		// Cap the length before SetString: a uint256 token ID is at most 78
+		// decimal digits, so anything longer is invalid and parsing an
+		// arbitrarily long string into big.Int is a CPU-DoS vector.
+		if len(tokenID) > 80 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "tokenID is too large"})
+			return
+		}
 		if _, ok := new(big.Int).SetString(tokenID, 10); !ok {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "tokenID must be a decimal integer"})
 			return

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -1060,7 +1060,15 @@ func UserRoute(router *gin.Engine) {
 
 	router.GET("/validators", func(c *gin.Context) {
 		pageToken := c.Query("page_token")
-		validatorResponse, err := db.ReturnValidators(pageToken)
+		// ReturnValidators fetches the full validator set (one doc per
+		// validator) and sums TotalStaked, an expensive unsegmented read.
+		// The set only shifts at epoch boundaries (~minutes), so a 30s TTL
+		// caches the full-collection fetch instead of running it per request.
+		// Keyed by page_token so future server-side pagination stays correct.
+		key := "validators:" + pageToken
+		v, err := routeCache.GetOrCompute(key, 30*time.Second, func() (interface{}, error) {
+			return db.ReturnValidators(pageToken)
+		})
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": fmt.Sprintf("Failed to fetch validators: %v", err),
@@ -1068,7 +1076,7 @@ func UserRoute(router *gin.Engine) {
 			return
 		}
 
-		c.JSON(http.StatusOK, validatorResponse)
+		c.JSON(http.StatusOK, v)
 	})
 
 	// Get epoch detail by ID

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"math/big"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -18,6 +19,64 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo"
 )
+
+// Path-param format guards. These reject malformed input at the route
+// boundary (HTTP 400) before it reaches the db layer, instead of letting
+// a junk string fan out into Mongo filters / RPC calls. The accepted
+// shapes mirror what the frontend search resolver emits (see
+// ExplorerFrontend/app/lib/searchResolver.ts).
+var (
+	// txHashRe matches a "0x"-prefixed 32-byte hash (the only tx/block
+	// hash form the explorer surfaces).
+	txHashRe = regexp.MustCompile(`^0x[0-9a-fA-F]{64}$`)
+	// addrParamRe matches both address forms the frontend forwards: the
+	// canonical "Q" + 40 hex (case-insensitive Q) and the "0x" + 40 hex
+	// contract form. db.normalizeAddress canonicalises both downstream.
+	addrParamRe = regexp.MustCompile(`^([Qq]|0x|0X)[0-9a-fA-F]{40}$`)
+	// validatorPubkeyRe matches a hex public-key lookup key (optional 0x
+	// prefix). Even-length and an upper bound are enforced in
+	// isValidValidatorID rather than the pattern, because Go's regexp
+	// rejects the nested-repeat form that would express "even, bounded"
+	// inline. The decimal-index form is handled separately so plain
+	// integers still resolve.
+	validatorPubkeyRe = regexp.MustCompile(`^(0x|0X)?[0-9a-fA-F]+$`)
+)
+
+// isValidTxHash reports whether s is a "0x"-prefixed 32-byte hash.
+func isValidTxHash(s string) bool {
+	return txHashRe.MatchString(s)
+}
+
+// isValidAddressParam reports whether s is one of the address forms a
+// route path param legitimately carries (Q + 40 hex or 0x + 40 hex).
+// Use this for :address / :query route guards; the stricter Q-only
+// isValidAddress stays reserved for the contract-write endpoints whose
+// inputs are never 0x-form.
+func isValidAddressParam(s string) bool {
+	return addrParamRe.MatchString(s)
+}
+
+// isValidValidatorID reports whether s is a decimal validator index or a
+// hex public-key key. GetValidatorByID looks up by _id (decimal index)
+// then falls back to publicKeyHex, so both shapes are legitimate.
+func isValidValidatorID(s string) bool {
+	if s == "" {
+		return false
+	}
+	if _, err := strconv.ParseUint(s, 10, 64); err == nil {
+		return true
+	}
+	if !validatorPubkeyRe.MatchString(s) {
+		return false
+	}
+	// Strip an optional 0x prefix, then require an even-length hex body of
+	// a sane size (1..2000 hex chars covers any real pubkey scheme).
+	body := s
+	if len(body) >= 2 && (body[:2] == "0x" || body[:2] == "0X") {
+		body = body[2:]
+	}
+	return len(body) > 0 && len(body)%2 == 0 && len(body) <= 2000
+}
 
 // normalizeContractAddr maps any input address form (0x-hex, q-lower, bare
 // hex, Q-canonical) to the canonical "Q" + lowercase hex shape the syncer
@@ -254,6 +313,10 @@ func UserRoute(router *gin.Engine) {
 	// Add endpoint for fetching a specific pending transaction
 	router.GET("/pending-transaction/:hash", func(c *gin.Context) {
 		hash := c.Param("hash")
+		if !isValidTxHash(hash) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid transaction hash; expected 0x + 64 hex chars"})
+			return
+		}
 		transaction, err := db.GetPendingTransactionByHash(hash)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -495,6 +558,10 @@ func UserRoute(router *gin.Engine) {
 
 	router.GET("/address/aggregate/:query", func(c *gin.Context) {
 		param := c.Param("query")
+		if !isValidAddressParam(param) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		// db functions normalize the address to canonical q-prefix internally.
 
 		// Pagination for the tx-list aggregations. Defaults match the old
@@ -589,6 +656,10 @@ func UserRoute(router *gin.Engine) {
 
 	router.GET("/tx/:query", func(c *gin.Context) {
 		value := c.Param("query")
+		if !isValidTxHash(value) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid transaction hash; expected 0x + 64 hex chars"})
+			return
+		}
 		query, err := db.ReturnSingleTransfer(value)
 		if err != nil {
 			log.Printf("error fetching transfer %s: %v", value, err)
@@ -840,6 +911,10 @@ func UserRoute(router *gin.Engine) {
 
 	router.GET("/coinbase/:query", func(c *gin.Context) {
 		value := c.Param("query")
+		if !isValidTxHash(value) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid transaction hash; expected 0x + 64 hex chars"})
+			return
+		}
 		query, err := db.ReturnSingleTransfer(value)
 		// A missing tx is not a server fault: keep the historical 200-with-empty
 		// behavior for not-found. Any other DB error becomes a 500 instead of a
@@ -1054,6 +1129,10 @@ func UserRoute(router *gin.Engine) {
 	// Get individual validator details
 	router.GET("/validator/:id", func(c *gin.Context) {
 		id := c.Param("id")
+		if !isValidValidatorID(id) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid validator id; expected a decimal index or hex public key"})
+			return
+		}
 		validator, err := db.GetValidatorByID(id)
 		if err != nil {
 			c.JSON(http.StatusNotFound, gin.H{
@@ -1230,6 +1309,10 @@ func UserRoute(router *gin.Engine) {
 	// Add a new endpoint to get limited non-zero transactions for an address
 	router.GET("/address/:address/transactions", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		page, limit := getPaginationParams(c, 1, 5)
 
 		transactions, err := db.ReturnNonZeroTransactions(address, page, limit)
@@ -1268,6 +1351,10 @@ func UserRoute(router *gin.Engine) {
 	// by contract not by holder. Paginated like /address/:addr/transactions.
 	router.GET("/address/:address/token-transfers", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		// Match the address-page Transactions table's 5-rows-per-page default
 		// (paginated server-side, page-1-indexed). Cap matches the DB layer.
 		page, limit := getPaginationParams(c, 1, 5)
@@ -1304,6 +1391,10 @@ func UserRoute(router *gin.Engine) {
 	// fungibles.
 	router.GET("/address/:address/tokens", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 
 		var standardFilter *string
 		if s := c.Query("standard"); s != "" {
@@ -1343,6 +1434,10 @@ func UserRoute(router *gin.Engine) {
 	// on the sibling /tokens?standard=ERC-20.
 	router.GET("/address/:address/nfts", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 
 		var standardFilter *string
 		if s := c.Query("standard"); s != "" {
@@ -1376,6 +1471,10 @@ func UserRoute(router *gin.Engine) {
 	// Get token info (summary stats for a token contract)
 	router.GET("/token/:address/info", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 
 		info, err := db.GetTokenInfo(address)
 		if err != nil {
@@ -1395,6 +1494,10 @@ func UserRoute(router *gin.Engine) {
 	// holder, balance is the cross-id total). ERC-20 behaviour unchanged.
 	router.GET("/token/:address/holders", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		tokenID := c.Query("tokenID")
 		page, limit := getPaginationParams(c, 0, 25)
 
@@ -1423,6 +1526,10 @@ func UserRoute(router *gin.Engine) {
 	// when off-chain metadata has been fetched.
 	router.GET("/token/:address/tokens", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		page, limit := getPaginationParams(c, 0, 25)
 
 		tokens, totalCount, err := db.GetTokenIDs(address, page, limit)
@@ -1454,6 +1561,11 @@ func UserRoute(router *gin.Engine) {
 		address := c.Param("address")
 		tokenID := c.Param("id")
 
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
+
 		if _, ok := new(big.Int).SetString(tokenID, 10); !ok {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "tokenID must be a decimal integer"})
 			return
@@ -1475,6 +1587,10 @@ func UserRoute(router *gin.Engine) {
 	// Get token transfers with pagination
 	router.GET("/token/:address/transfers", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		page, limit := getPaginationParams(c, 0, 25)
 
 		transfers, totalCount, err := db.GetTokenTransfers(address, page, limit)
@@ -1503,6 +1619,10 @@ func UserRoute(router *gin.Engine) {
 	// db/gas.go; the route just plumbs it together.
 	router.GET("/pending-tx-eta/:hash", func(c *gin.Context) {
 		hash := c.Param("hash")
+		if !isValidTxHash(hash) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid transaction hash; expected 0x + 64 hex chars"})
+			return
+		}
 		v, err := routeCache.GetOrCompute("eta:"+hash, 5*time.Second, func() (interface{}, error) {
 			tx, err := db.GetPendingTransactionByHash(hash)
 			if err != nil {

--- a/backendAPI/routes/routes_test.go
+++ b/backendAPI/routes/routes_test.go
@@ -1,0 +1,94 @@
+package routes
+
+import "testing"
+
+// These cover the path-param format guards added to reject malformed
+// input at the route boundary (HTTP 400) before it reaches the db layer.
+// The accepted shapes mirror the frontend search resolver
+// (ExplorerFrontend/app/lib/searchResolver.ts).
+
+func TestIsValidTxHash(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"canonical 0x + 64 hex", "0x" + repeat("a", 64), true},
+		{"uppercase hex body", "0x" + repeat("AB", 32), true},
+		{"missing 0x prefix", repeat("a", 64), false},
+		{"one char short", "0x" + repeat("a", 63), false},
+		{"one char too long", "0x" + repeat("a", 65), false},
+		{"non-hex char", "0x" + repeat("g", 64), false},
+		{"address mistaken for hash", "Q" + repeat("a", 40), false},
+		{"empty", "", false},
+		{"mongo-operator injection attempt", `0x"; return true; //`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidTxHash(tc.in); got != tc.want {
+				t.Errorf("isValidTxHash(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsValidAddressParam(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"Q + 40 hex", "Q" + repeat("a", 40), true},
+		{"lowercase q + 40 hex", "q" + repeat("a", 40), true},
+		{"0x + 40 hex contract form", "0x" + repeat("a", 40), true},
+		{"uppercase 0X prefix", "0X" + repeat("AB", 20), true},
+		{"bare 40 hex rejected", repeat("a", 40), false},
+		{"too short", "Q" + repeat("a", 39), false},
+		{"too long", "Q" + repeat("a", 41), false},
+		{"tx hash rejected", "0x" + repeat("a", 64), false},
+		{"non-hex body", "Q" + repeat("z", 40), false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidAddressParam(tc.in); got != tc.want {
+				t.Errorf("isValidAddressParam(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsValidValidatorID(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"decimal index", "1", true},
+		{"large decimal index", "1048576", true},
+		{"zero index", "0", true},
+		{"bare hex pubkey", repeat("ab", 48), true},
+		{"0x-prefixed hex pubkey", "0x" + repeat("ab", 48), true},
+		{"odd-length hex rejected", "abc", false},
+		{"non-hex rejected", "xyz", false},
+		{"empty", "", false},
+		{"injection attempt", `{"$ne":null}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidValidatorID(tc.in); got != tc.want {
+				t.Errorf("isValidValidatorID(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// repeat returns s concatenated n times. Local helper so the table cases
+// stay readable without importing strings.Repeat at every call site.
+func repeat(s string, n int) string {
+	out := make([]byte, 0, len(s)*n)
+	for i := 0; i < n; i++ {
+		out = append(out, s...)
+	}
+	return string(out)
+}


### PR DESCRIPTION
## Summary

Batch 4 of the codebase-review remediation. **Stacked on #137** (base `fix/codebase-review-batch3`); GitHub retargets to `dev` as the stack merges. Review #135 → #136 → #137 first.

## Graceful shutdown for background goroutines (#19/#20)
Several background ticker goroutines looped on `for range ticker.C` with no stop signal, so on SIGTERM they kept issuing new MongoDB work until `os.Exit(0)` killed them mid-operation, wasting the 30s graceful-shutdown window.
- Threaded `main.go`'s `stopCh` through `Sync()` and `StartPendingTransactionSync()` into every starter, converting each loop to `for { select { case <-ticker.C: ...; case <-stopCh: return } }`.
- Covers: `runPeriodicTask` (mempool sync, pending cleanup, pending verification), `singleBlockInsertion`'s four goroutines + its initial sleep, `StartContractReprocessingJob`, `StartWalletCountSync`. The `metadata_service` ticker was already stoppable.
- The panic-recovery restart in `runPeriodicTask` now checks `stopCh` before relaunching. The signal-handler/`doneCh` structure is unchanged; the goroutines it implicitly waits on (`wg.Wait`) are now actually stoppable, so the window drains genuinely in-flight work.
- Removed a redundant `go` prefix on `runPeriodicTask` calls (it already spawns internally; the outer `go` was a throwaway goroutine).

## On-chain name/symbol ingestion sanitization (#30)
On-chain `name()`/`symbol()` strings were stored verbatim. React escapes them in JSX today, but a future non-JSX sink (CSV export, server template) would be exposed. Added `sanitizeTokenString` (strip control chars, trim, rune-safe 128 cap) at the single `StoreContract` chokepoint, so every classifier/detection path that persists a contract benefits. Legitimate unicode is preserved.

## Validation
- `go build`, `go vet`, `gofmt` all clean on the 6 changed files. Deadlock/double-close checked: `stopCh` is receive-only in these goroutines and closed once by the signal handler; happy path (no signal) is unchanged. Pre-existing MONGOURI-missing test failures confirmed identical on a clean tree.

## Known scope note
`Sync()`'s initial producer/consumer block-fetch loop (long initial sync / large catch-up) still falls back to the 30s timeout on shutdown; that loop is out of scope for this finding (which is the steady-state ticker goroutines). All steady-state ticker goroutines now stop cleanly.

## Still open
Validators pagination (#4/#12) - deferred pending verification of the validators data model (the schema notes describe a single document per epoch, which would make per-document pagination the wrong fix). Operator action still pending: rotate the faucet seed off plaintext disk.
