### PR TITLE
fix: medium-severity bugs, security hardening, indexes (batch 5)

### DIFF
--- a/ExplorerFrontend/app/contracts/loading.tsx
+++ b/ExplorerFrontend/app/contracts/loading.tsx
@@ -1,0 +1,28 @@
+/**
+ * Route-level skeleton for /contracts. The page is server-rendered and
+ * awaits the /contracts fetch, so without a fallback the page is briefly
+ * blank between click and data.
+ *
+ * Shape mirrors ContractsClient: header + tab strip stub and a stack of
+ * contract row placeholders.
+ */
+export default function Loading(): JSX.Element {
+  return (
+    <div role="status" aria-label="Loading contracts" className="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8">
+      <div className="mb-6">
+        <h1 className="text-xl sm:text-2xl font-bold text-[#ffa729] mb-2">Smart Contracts</h1>
+        <div className="flex gap-2">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="h-9 w-28 bg-[#2d2d2d] rounded-lg animate-pulse" />
+          ))}
+        </div>
+      </div>
+
+      <div className="p-4 space-y-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="h-16 bg-gray-700/30 rounded animate-pulse" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ExplorerFrontend/app/epochs/loading.tsx
+++ b/ExplorerFrontend/app/epochs/loading.tsx
@@ -1,0 +1,48 @@
+/**
+ * Route-level skeleton for /epochs/<page>. The page is server-rendered
+ * and awaits the beacon-chain epochs fetch (force-dynamic), so without a
+ * fallback the page is briefly blank between click and data.
+ *
+ * Shape mirrors EpochsClient: header + search bar stub + the six-column
+ * epochs table so the transition reads as "the data is filling in".
+ */
+export default function Loading(): JSX.Element {
+  return (
+    <div role="status" aria-label="Loading epochs" className="p-4 sm:p-8 max-w-6xl mx-auto">
+      <h1 className="text-xl sm:text-2xl font-bold mb-4 text-[#ffa729]">Epochs</h1>
+
+      <div className="mb-6">
+        <div className="h-11 w-full bg-[#1e1e1e] border border-[#2a2a2a] rounded-lg animate-pulse" />
+      </div>
+
+      <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden mb-6">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[#2a2a2a]">
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Epoch</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Time</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Status</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden sm:table-cell">Validators</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden sm:table-cell">Active</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden md:table-cell">Total Staked</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from({ length: 15 }).map((_, i) => (
+                <tr key={i} className="border-b border-[#2a2a2a] last:border-b-0">
+                  <td className="px-4 py-3"><div className="h-4 w-12 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-3"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-3"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-3 hidden sm:table-cell"><div className="h-4 w-10 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-3 hidden sm:table-cell"><div className="h-4 w-10 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-3 hidden md:table-cell"><div className="h-4 w-24 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ExplorerFrontend/app/pending/[query]/PendingList.tsx
+++ b/ExplorerFrontend/app/pending/[query]/PendingList.tsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import React, { useState } from 'react';
 import config from '../../../config';
 import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { formatAmount, formatGasPrice, timeAgo, truncateHash } from '../../lib/helpers';
 import type { PendingTransaction } from '@/app/types';
@@ -46,6 +47,7 @@ interface PendingListProps {
 }
 
 export default function PendingList({ initialData, currentPage }: PendingListProps): JSX.Element {
+  const router = useRouter();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const { data, isError, error, refetch, isFetching } = useQuery({
     queryKey: ['pending-transactions', currentPage],
@@ -173,8 +175,8 @@ export default function PendingList({ initialData, currentPage }: PendingListPro
             <Pagination
               currentPage={currentPage}
               totalPages={totalPages}
-              onPrevious={() => window.location.href = `/pending/${Math.max(currentPage - 1, 1)}`}
-              onNext={() => window.location.href = `/pending/${Math.min(currentPage + 1, totalPages)}`}
+              onPrevious={() => router.push(`/pending/${Math.max(currentPage - 1, 1)}`)}
+              onNext={() => router.push(`/pending/${Math.min(currentPage + 1, totalPages)}`)}
             />
           )}
         </>

--- a/ExplorerFrontend/app/pending/tx/[hash]/page.tsx
+++ b/ExplorerFrontend/app/pending/tx/[hash]/page.tsx
@@ -94,7 +94,7 @@ async function getTransactionStatus(hash: string): Promise<{
               blockNumber: tx.blockNumber?.toString(),
               accessList: [],
               blockHash: null,
-              chainId: '0x7e7e', // Zond chainId
+              chainId: '0x539', // QRL testnet v2 chainId (1337)
               from: tx.from || '',
               gas: tx.gas || '0x0',
               gasPrice: tx.gasPrice || '0x0',

--- a/ExplorerFrontend/app/richlist/loading.tsx
+++ b/ExplorerFrontend/app/richlist/loading.tsx
@@ -1,0 +1,45 @@
+/**
+ * Route-level skeleton for /richlist. The page is server-rendered and
+ * awaits the /richlist fetch (force-dynamic), so without a fallback the
+ * page is briefly blank between click and data.
+ *
+ * Shape mirrors RichlistClient: header + subtitle and the three-column
+ * (rank / address / balance) table card.
+ */
+export default function Loading(): JSX.Element {
+  return (
+    <div role="status" aria-label="Loading rich list" className="min-h-screen">
+      <div className="max-w-[1200px] mx-auto p-4 md:p-8">
+        <div className="mb-6 md:mb-8">
+          <h1 className="text-xl md:text-2xl font-bold text-[#ffa729]">Richlist</h1>
+          <p className="text-sm md:text-base text-gray-400 mt-2">
+            Top 50 QRL holders by balance
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-[#3d3d3d] bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f] shadow-xl overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="min-w-full">
+              <thead>
+                <tr className="border-b border-[#3d3d3d]">
+                  <th className="px-3 md:px-6 py-3 md:py-4 text-left text-xs md:text-sm font-medium text-[#ffa729]">Rank</th>
+                  <th className="px-3 md:px-6 py-3 md:py-4 text-left text-xs md:text-sm font-medium text-[#ffa729]">Address</th>
+                  <th className="px-3 md:px-6 py-3 md:py-4 text-right text-xs md:text-sm font-medium text-[#ffa729]">Balance</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[#3d3d3d]">
+                {Array.from({ length: 10 }).map((_, i) => (
+                  <tr key={i} className="border-b border-[#3d3d3d]">
+                    <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap"><div className="h-4 w-8 bg-[#3d3d3d] rounded animate-pulse" /></td>
+                    <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap"><div className="h-4 w-64 max-w-full bg-[#3d3d3d] rounded animate-pulse" /></td>
+                    <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap"><div className="h-4 w-24 bg-[#3d3d3d] rounded animate-pulse ml-auto" /></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/QRL2MongoDB/configs/setup.go
+++ b/QRL2MongoDB/configs/setup.go
@@ -14,7 +14,14 @@ import (
 )
 
 func ConnectDB() *mongo.Client {
-	client, err := mongo.NewClient(options.Client().ApplyURI(EnvMongoURI()))
+	uri := EnvMongoURI()
+	if uri == "" {
+		// Runs at package init (DB is an eager package-level var), so this is
+		// the real fail-fast point for a missing MONGOURI: a clear, actionable
+		// message instead of an opaque driver error.
+		log.Fatal("Required environment variable MONGOURI is not set")
+	}
+	client, err := mongo.NewClient(options.Client().ApplyURI(uri))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/QRL2MongoDB/configs/setup.go
+++ b/QRL2MongoDB/configs/setup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -264,7 +265,19 @@ func initializeCollections(db *mongo.Database) {
 		},
 	)
 	if err != nil {
-		Logger.Error("Failed to create index for pending token contracts collection", zap.Error(err))
+		// A previously-created index over the same (contractAddress, txHash)
+		// keys under a different name (e.g. the named "contract_tx_idx" set
+		// by db.InitializePendingTokenContractsCollection) makes Mongo reject
+		// this auto-named duplicate with IndexOptionsConflict. That is benign:
+		// the index already exists, so do not treat it as an error.
+		msg := err.Error()
+		if strings.Contains(msg, "IndexOptionsConflict") ||
+			strings.Contains(msg, "IndexKeySpecsConflict") ||
+			strings.Contains(msg, "already exists") {
+			Logger.Info("Pending token contracts unique index already exists, skipping")
+		} else {
+			Logger.Error("Failed to create index for pending token contracts collection", zap.Error(err))
+		}
 	}
 
 	// Also add index on the processed field for efficient querying

--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -351,6 +351,45 @@ func StoreInitialSyncStartBlock(blockNumber string) error {
 }
 
 // BlockExists checks if a block with the given number already exists in the database
+// BlocksExist returns the set of the given block numbers that already exist in
+// the blocks collection, as a map[blockNumber]bool. It runs a single $in query
+// rather than one round-trip per block, so the batch consumer can check a whole
+// batch (128/256 blocks) at once. A block absent from the returned map is not
+// present in the DB. On query error it returns a nil map (callers treat every
+// block as new, i.e. reprocess, which is the safe direction).
+func BlocksExist(blockNumbers []string) (map[string]bool, error) {
+	if len(blockNumbers) == 0 {
+		return map[string]bool{}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	filter := bson.M{"result.number": bson.M{"$in": blockNumbers}}
+	projection := options.Find().SetProjection(bson.M{"result.number": 1, "_id": 0})
+
+	cursor, err := configs.BlocksCollections.Find(ctx, filter, projection)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var results []struct {
+		Result struct {
+			Number string `bson:"number"`
+		} `bson:"result"`
+	}
+	if err := cursor.All(ctx, &results); err != nil {
+		return nil, err
+	}
+
+	existsMap := make(map[string]bool, len(results))
+	for _, r := range results {
+		existsMap[r.Result.Number] = true
+	}
+	return existsMap, nil
+}
+
 func BlockExists(blockNumber string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -595,8 +595,20 @@ func Rollback(blockNumber string) error {
 		return err
 	}
 
-	// Log blocks being removed
+	// Collect the exact hex block-number strings of the blocks being removed.
+	// The companion collections (transfer, transactionByAddress,
+	// tokenTransfers, tokenBalances) store blockNumber as the raw hex string
+	// (e.g. "0x1a2b"), NOT an int, so a numeric $gt range filter like the one
+	// used on the blocks collection would be unsafe here (hex strings lex-sort
+	// wrong, "0xa" > "0x100"). Matching the exact set of removed block numbers
+	// with $in is precise: it deletes rows for the rolled-back blocks and
+	// nothing else.
+	badBlockNumbers := make([]string, 0, len(blocks))
 	for _, block := range blocks {
+		if block.Result.Number != "" {
+			badBlockNumbers = append(badBlockNumbers, block.Result.Number)
+		}
+		// Log blocks being removed
 		configs.Logger.Info("Rolling back block",
 			zap.String("number", block.Result.Number),
 			zap.String("hash", block.Result.Hash))
@@ -616,6 +628,42 @@ func Rollback(blockNumber string) error {
 		_, err := configs.BlocksCollections.DeleteMany(sessCtx, filter)
 		if err != nil {
 			return nil, err
+		}
+
+		// Delete companion rows for the removed blocks so a rolled-back block
+		// leaves no orphans. All three of these collections key blockNumber as
+		// the raw hex string, so the exact-match $in filter is correct.
+		//
+		// NOT cleaned here (intentional, see report):
+		//   - internalTransactionByAddress stores no block-number field at all
+		//     (only blockTimestamp), so there is nothing to filter on. We do not
+		//     fabricate one. Orphan internal-tx rows may linger after a reorg;
+		//     flagged for manual review.
+		//   - tokenBalances is a last-write-wins snapshot keyed on
+		//     (contractAddress, holderAddress), not a per-block append. We delete
+		//     only the snapshots whose last update happened in a rolled-back
+		//     block (blockNumber $in badBlockNumbers); those values are stale and
+		//     get re-derived from RPC when the block is reprocessed. Snapshots
+		//     last touched by an older block are left intact.
+		if len(badBlockNumbers) > 0 {
+			companionFilter := bson.M{"blockNumber": bson.M{"$in": badBlockNumbers}}
+
+			if _, err := configs.TransferCollections.DeleteMany(sessCtx, companionFilter); err != nil {
+				return nil, fmt.Errorf("rollback: failed to delete transfer rows: %w", err)
+			}
+			if _, err := configs.TransactionByAddressCollections.DeleteMany(sessCtx, companionFilter); err != nil {
+				return nil, fmt.Errorf("rollback: failed to delete transactionByAddress rows: %w", err)
+			}
+
+			tokenTransfers := configs.GetTokenTransfersCollection()
+			if _, err := tokenTransfers.DeleteMany(sessCtx, companionFilter); err != nil {
+				return nil, fmt.Errorf("rollback: failed to delete tokenTransfers rows: %w", err)
+			}
+
+			tokenBalances := configs.GetTokenBalancesCollection()
+			if _, err := tokenBalances.DeleteMany(sessCtx, companionFilter); err != nil {
+				return nil, fmt.Errorf("rollback: failed to delete tokenBalances rows: %w", err)
+			}
 		}
 
 		// Update sync state

--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -644,9 +644,11 @@ func Rollback(blockNumber string) error {
 		//     balances from RPC whenever a contract is next processed, so a
 		//     left-in-place snapshot self-heals; a deleted one does not. Leave
 		//     it untouched.
-		//   - internalTransactionByAddress stores no block-number field (only
-		//     blockTimestamp), so there is nothing to filter on. Orphan
-		//     internal-tx rows may linger after a reorg; flagged for follow-up.
+		//
+		// internalTransactionByAddress now stores blockNumber (raw hex string),
+		// so it is cleaned here too. Rows written by an older syncer before that
+		// field existed lack blockNumber and will not match the $in filter, so
+		// pre-existing orphans cannot be cleaned retroactively; that is expected.
 		if len(badBlockNumbers) > 0 {
 			companionFilter := bson.M{"blockNumber": bson.M{"$in": badBlockNumbers}}
 
@@ -655,6 +657,9 @@ func Rollback(blockNumber string) error {
 			}
 			if _, err := configs.TransactionByAddressCollections.DeleteMany(sessCtx, companionFilter); err != nil {
 				return nil, fmt.Errorf("rollback: failed to delete transactionByAddress rows: %w", err)
+			}
+			if _, err := configs.InternalTransactionByAddressCollections.DeleteMany(sessCtx, companionFilter); err != nil {
+				return nil, fmt.Errorf("rollback: failed to delete internalTransactionByAddress rows: %w", err)
 			}
 
 			tokenTransfers := configs.GetTokenTransfersCollection()

--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -630,21 +630,23 @@ func Rollback(blockNumber string) error {
 			return nil, err
 		}
 
-		// Delete companion rows for the removed blocks so a rolled-back block
-		// leaves no orphans. All three of these collections key blockNumber as
-		// the raw hex string, so the exact-match $in filter is correct.
+		// Delete the append-only companion rows for the removed blocks so a
+		// rolled-back block leaves no orphan event records. These collections
+		// key blockNumber as the raw hex string, so the exact-match $in filter
+		// is correct (a numeric range would lex-sort hex strings wrong).
 		//
-		// NOT cleaned here (intentional, see report):
-		//   - internalTransactionByAddress stores no block-number field at all
-		//     (only blockTimestamp), so there is nothing to filter on. We do not
-		//     fabricate one. Orphan internal-tx rows may linger after a reorg;
-		//     flagged for manual review.
+		// NOT cleaned here (intentional):
 		//   - tokenBalances is a last-write-wins snapshot keyed on
-		//     (contractAddress, holderAddress), not a per-block append. We delete
-		//     only the snapshots whose last update happened in a rolled-back
-		//     block (blockNumber $in badBlockNumbers); those values are stale and
-		//     get re-derived from RPC when the block is reprocessed. Snapshots
-		//     last touched by an older block are left intact.
+		//     (contractAddress, holderAddress), NOT a per-block append. Deleting
+		//     a holder's snapshot just because its last update landed in a
+		//     rolled-back block would permanently drop a balance the new chain
+		//     may never re-touch (it would read as 0). The syncer re-derives
+		//     balances from RPC whenever a contract is next processed, so a
+		//     left-in-place snapshot self-heals; a deleted one does not. Leave
+		//     it untouched.
+		//   - internalTransactionByAddress stores no block-number field (only
+		//     blockTimestamp), so there is nothing to filter on. Orphan
+		//     internal-tx rows may linger after a reorg; flagged for follow-up.
 		if len(badBlockNumbers) > 0 {
 			companionFilter := bson.M{"blockNumber": bson.M{"$in": badBlockNumbers}}
 
@@ -658,11 +660,6 @@ func Rollback(blockNumber string) error {
 			tokenTransfers := configs.GetTokenTransfersCollection()
 			if _, err := tokenTransfers.DeleteMany(sessCtx, companionFilter); err != nil {
 				return nil, fmt.Errorf("rollback: failed to delete tokenTransfers rows: %w", err)
-			}
-
-			tokenBalances := configs.GetTokenBalancesCollection()
-			if _, err := tokenBalances.DeleteMany(sessCtx, companionFilter); err != nil {
-				return nil, fmt.Errorf("rollback: failed to delete tokenBalances rows: %w", err)
 			}
 		}
 

--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -609,7 +609,8 @@ func Rollback(blockNumber string) error {
 		return fmt.Errorf("rollback: block number cannot be negative: %d", rollbackTo)
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
 
 	filter := bson.M{
 		"blockNumberInt": bson.M{

--- a/QRL2MongoDB/db/contracts.go
+++ b/QRL2MongoDB/db/contracts.go
@@ -8,13 +8,58 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
+	"unicode"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.uber.org/zap"
 )
+
+// maxTokenStringRunes caps the stored length of on-chain token name/symbol
+// strings. On-chain name()/symbol() are attacker-controlled, an unbounded
+// string is both a storage-bloat and a downstream-rendering hazard.
+const maxTokenStringRunes = 128
+
+// sanitizeTokenString cleans an on-chain token name/symbol before it is
+// persisted. It is the single ingestion-time chokepoint for these
+// attacker-controlled strings: every StoreContract write passes through it,
+// so all downstream readers (API JSON, future CSV export, server-rendered
+// templates) receive an already-cleaned value rather than relying on a
+// specific sink to escape it.
+//
+// Behavior:
+//   - strips ASCII/Unicode control characters (C0/C1, DEL, etc.) that have no
+//     legitimate place in a display name and could break a non-JSX sink;
+//   - preserves all legitimate Unicode letters/marks/symbols/punctuation;
+//   - trims leading/trailing whitespace;
+//   - caps the result at maxTokenStringRunes runes (rune-safe, never splits a
+//     multibyte codepoint).
+func sanitizeTokenString(s string) string {
+	if s == "" {
+		return s
+	}
+
+	// Drop control characters; keep everything else (letters, marks, digits,
+	// punctuation, symbols, spaces) intact so legitimate unicode is preserved.
+	cleaned := strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+
+	cleaned = strings.TrimSpace(cleaned)
+
+	// Rune-safe length cap.
+	if runes := []rune(cleaned); len(runes) > maxTokenStringRunes {
+		cleaned = string(runes[:maxTokenStringRunes])
+	}
+
+	return cleaned
+}
 
 // StoreContract stores or merges contract information in the database.
 //
@@ -40,6 +85,12 @@ func StoreContract(contract models.ContractInfo) error {
 	// Normalize addresses to canonical Q-prefix form
 	contract.Address = validation.ConvertToQAddress(contract.Address)
 	contract.CreatorAddress = validation.ConvertToQAddress(contract.CreatorAddress)
+
+	// Sanitize attacker-controlled on-chain token strings at the single
+	// storage chokepoint so every write path (creation tx, reprocess,
+	// classifier) persists a control-char-free, length-capped value.
+	contract.Name = sanitizeTokenString(contract.Name)
+	contract.Symbol = sanitizeTokenString(contract.Symbol)
 
 	collection := configs.GetContractsCollection()
 	filter := bson.M{"address": contract.Address}
@@ -818,9 +869,15 @@ func findCreationTransaction(contractAddress string) *creationTxInfo {
 	}
 }
 
-// StartContractReprocessingJob starts a background job to periodically reprocess incomplete contracts
-func StartContractReprocessingJob() {
+// StartContractReprocessingJob starts a background job to periodically reprocess
+// incomplete contracts. The goroutine returns once stopCh is closed so a
+// graceful shutdown does not start a new reprocess pass while in-flight work
+// is draining.
+func StartContractReprocessingJob(stopCh <-chan struct{}) {
 	go func() {
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+
 		for {
 			configs.Logger.Info("Starting contract reprocessing job")
 
@@ -829,8 +886,13 @@ func StartContractReprocessingJob() {
 				configs.Logger.Error("Contract reprocessing job failed", zap.Error(err))
 			}
 
-			// Wait for 1 hour before next run
-			time.Sleep(1 * time.Hour)
+			// Wait for 1 hour before next run, or exit early on shutdown.
+			select {
+			case <-ticker.C:
+			case <-stopCh:
+				configs.Logger.Info("Stopping contract reprocessing job on shutdown signal")
+				return
+			}
 		}
 	}()
 }

--- a/QRL2MongoDB/db/contracts.go
+++ b/QRL2MongoDB/db/contracts.go
@@ -38,27 +38,35 @@ const maxTokenStringRunes = 128
 //   - caps the result at maxTokenStringRunes runes (rune-safe, never splits a
 //     multibyte codepoint).
 func sanitizeTokenString(s string) string {
+	s = strings.TrimSpace(s)
 	if s == "" {
 		return s
 	}
 
-	// Drop control characters; keep everything else (letters, marks, digits,
-	// punctuation, symbols, spaces) intact so legitimate unicode is preserved.
-	cleaned := strings.Map(func(r rune) rune {
-		if unicode.IsControl(r) {
-			return -1
-		}
-		return r
-	}, s)
-
-	cleaned = strings.TrimSpace(cleaned)
-
-	// Rune-safe length cap.
-	if runes := []rune(cleaned); len(runes) > maxTokenStringRunes {
-		cleaned = string(runes[:maxTokenStringRunes])
+	// name()/symbol() are attacker-controlled on-chain strings of unbounded
+	// length, so this must not allocate or scan the whole input. Cap the bytes
+	// examined first (a rune is at most 4 bytes, so maxTokenStringRunes runes
+	// fit in 4x that), then single-pass: drop control characters, keep all
+	// other unicode, and stop as soon as the rune budget is reached.
+	if len(s) > maxTokenStringRunes*4 {
+		s = s[:maxTokenStringRunes*4]
 	}
 
-	return cleaned
+	var b strings.Builder
+	b.Grow(len(s))
+	runeCount := 0
+	for _, r := range s {
+		if unicode.IsControl(r) {
+			continue
+		}
+		b.WriteRune(r)
+		runeCount++
+		if runeCount >= maxTokenStringRunes {
+			break
+		}
+	}
+
+	return strings.TrimSpace(b.String())
 }
 
 // StoreContract stores or merges contract information in the database.

--- a/QRL2MongoDB/db/transactions.go
+++ b/QRL2MongoDB/db/transactions.go
@@ -381,6 +381,7 @@ func processTransactionData(tx *models.Transaction, blockTimestamp string, to st
 			trace.AddressFunctionIdentifier,
 			fmt.Sprintf("0x%x", trace.AmountFunctionIdentifier),
 			blockTimestamp,
+			blockNumber,
 		)
 	}
 
@@ -491,7 +492,7 @@ func TransferCollection(blockNumber string, blockTimestamp string, from string, 
 	return result, err
 }
 
-func InternalTransactionByAddressCollection(transactionType string, callType string, hash string, from string, to string, input string, output string, traceAddress []int, value float64, gas string, gasUsed string, addressFunctionIdentifier string, amountFunctionIdentifier string, blockTimestamp string) (*mongo.InsertOneResult, error) {
+func InternalTransactionByAddressCollection(transactionType string, callType string, hash string, from string, to string, input string, output string, traceAddress []int, value float64, gas string, gasUsed string, addressFunctionIdentifier string, amountFunctionIdentifier string, blockTimestamp string, blockNumber string) (*mongo.InsertOneResult, error) {
 	// Normalize addresses to canonical Q-prefix form
 	if from != "" {
 		from = validation.ConvertToQAddress(from)
@@ -503,6 +504,8 @@ func InternalTransactionByAddressCollection(transactionType string, callType str
 		addressFunctionIdentifier = validation.ConvertToQAddress(addressFunctionIdentifier)
 	}
 
+	// blockNumber (raw hex string) lets Rollback delete this row on a reorg via
+	// the same $in companionFilter used for the other append-only collections.
 	doc := bson.D{
 		{Key: "type", Value: transactionType},
 		{Key: "callType", Value: callType},
@@ -518,6 +521,7 @@ func InternalTransactionByAddressCollection(transactionType string, callType str
 		{Key: "addressFunctionIdentifier", Value: addressFunctionIdentifier},
 		{Key: "amountFunctionIdentifier", Value: amountFunctionIdentifier},
 		{Key: "blockTimestamp", Value: blockTimestamp},
+		{Key: "blockNumber", Value: blockNumber},
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/QRL2MongoDB/db/transactions.go
+++ b/QRL2MongoDB/db/transactions.go
@@ -637,6 +637,7 @@ func UpsertTransactions(address string, value float64, isContract bool) (*mongo.
 }
 
 func GetContractByAddress(address string) *models.ContractInfo {
+	address = validation.ConvertToQAddress(address)
 	collection := configs.GetCollection(configs.DB, "contractCode")
 	var contract models.ContractInfo
 

--- a/QRL2MongoDB/db/wallet_sync.go
+++ b/QRL2MongoDB/db/wallet_sync.go
@@ -11,8 +11,10 @@ import (
 	"go.uber.org/zap"
 )
 
-// StartWalletCountSync starts a goroutine that syncs wallet count every 4 hours
-func StartWalletCountSync() {
+// StartWalletCountSync starts a goroutine that syncs wallet count every 4 hours.
+// The goroutine returns once stopCh is closed so a graceful shutdown does not
+// start a new count while in-flight work is draining.
+func StartWalletCountSync(stopCh <-chan struct{}) {
 	configs.Logger.Info("Initializing wallet count sync service")
 	go func() {
 		ticker := time.NewTicker(4 * time.Hour)
@@ -26,10 +28,15 @@ func StartWalletCountSync() {
 
 		// Then sync every 4 hours
 		configs.Logger.Info("Starting periodic wallet count sync (every 4 hours)")
-		for range ticker.C {
-			if err := syncWalletCount(); err != nil {
-				configs.Logger.Error("Failed wallet count sync", zap.Error(err))
-				continue
+		for {
+			select {
+			case <-ticker.C:
+				if err := syncWalletCount(); err != nil {
+					configs.Logger.Error("Failed wallet count sync", zap.Error(err))
+				}
+			case <-stopCh:
+				configs.Logger.Info("Stopping wallet count sync on shutdown signal")
+				return
 			}
 		}
 	}()

--- a/QRL2MongoDB/main.go
+++ b/QRL2MongoDB/main.go
@@ -125,9 +125,11 @@ func main() {
 		}
 	}()
 
-	// Start pending transaction sync (this is not started in sync.go)
+	// Start pending transaction sync (this is not started in sync.go).
+	// stopCh is threaded in so the mempool/cleanup/verify tickers stop
+	// accepting new work when a shutdown signal arrives.
 	configs.Logger.Info("Starting pending transaction sync service...")
-	synchroniser.StartPendingTransactionSync()
+	synchroniser.StartPendingTransactionSync(stopCh)
 
 	// Phase 3a: start the off-chain NFT collection metadata fetcher.
 	// Background goroutine that polls contractCode for unfetched
@@ -147,8 +149,9 @@ func main() {
 	go func() {
 		defer close(doneCh)
 		// Sync will now handle starting wallet count and contract reprocessing
-		// services after initial sync is complete
-		synchroniser.Sync()
+		// services after initial sync is complete. stopCh is threaded in so
+		// every background ticker goroutine Sync starts can observe shutdown.
+		synchroniser.Sync(stopCh)
 	}()
 
 	// Block until either sync finishes naturally or a shutdown signal arrives.

--- a/QRL2MongoDB/main.go
+++ b/QRL2MongoDB/main.go
@@ -6,6 +6,7 @@ import (
 	"QRL2MongoDB/synchroniser"
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -16,11 +17,32 @@ import (
 	"go.uber.org/zap"
 )
 
+// validateEnv fails fast if the env vars the syncer cannot run without are
+// missing. Without this, an empty NODE_URLS/NODE_URL only logs a warning in
+// rpc.newEndpointSelectorFromEnv and the first RPC call returns "no node
+// endpoints configured", so Sync exits silently with no obvious cause.
+// MONGOURI is also required (ConnectDB would already fail without it, but
+// naming the variable here gives an actionable message before any work starts).
+// .env has already been loaded by configs.ConnectDB (via EnvMongoURI) during
+// package init, so os.Getenv here sees any values from the .env file.
+func validateEnv() {
+	if os.Getenv("MONGOURI") == "" {
+		log.Fatal("Required environment variable MONGOURI is not set")
+	}
+	if os.Getenv("NODE_URLS") == "" && os.Getenv("NODE_URL") == "" {
+		log.Fatal("Required environment variable NODE_URLS (or legacy NODE_URL) is not set")
+	}
+}
+
 func main() {
 	// Ensure logger resources are properly released
 	defer configs.Logger.Sync()
 
 	configs.Logger.Info("Initializing QRL to MongoDB synchronizer...")
+
+	// Fail fast before any sync work if required env vars are missing.
+	validateEnv()
+
 	configs.Logger.Info("Connecting to MongoDB and RPC node...")
 
 	// stopCh is closed when a termination signal is received. Sync() and other

--- a/QRL2MongoDB/main.go
+++ b/QRL2MongoDB/main.go
@@ -17,18 +17,13 @@ import (
 	"go.uber.org/zap"
 )
 
-// validateEnv fails fast if the env vars the syncer cannot run without are
-// missing. Without this, an empty NODE_URLS/NODE_URL only logs a warning in
+// validateEnv fails fast if the node endpoint env vars are missing. Without
+// this, an empty NODE_URLS/NODE_URL only logs a warning in
 // rpc.newEndpointSelectorFromEnv and the first RPC call returns "no node
 // endpoints configured", so Sync exits silently with no obvious cause.
-// MONGOURI is also required (ConnectDB would already fail without it, but
-// naming the variable here gives an actionable message before any work starts).
-// .env has already been loaded by configs.ConnectDB (via EnvMongoURI) during
-// package init, so os.Getenv here sees any values from the .env file.
+// MONGOURI is validated in configs.ConnectDB, which runs at package init
+// (before main), so it is not rechecked here: a check here would be dead code.
 func validateEnv() {
-	if os.Getenv("MONGOURI") == "" {
-		log.Fatal("Required environment variable MONGOURI is not set")
-	}
 	if os.Getenv("NODE_URLS") == "" && os.Getenv("NODE_URL") == "" {
 		log.Fatal("Required environment variable NODE_URLS (or legacy NODE_URL) is not set")
 	}

--- a/QRL2MongoDB/synchroniser/gap_detection.go
+++ b/QRL2MongoDB/synchroniser/gap_detection.go
@@ -166,6 +166,21 @@ func fillGaps(gaps []string) int {
 			continue
 		}
 
+		// Idempotency guard: skip both the block insert and ProcessTransactions
+		// together if the block already exists. A "gap" can close between
+		// detection and fill (the single-block loop retries failed blocks, the
+		// batch path may overlap), and ProcessTransactions has no txHash unique
+		// index, so re-running it would duplicate transfer + transactionByAddress
+		// rows. InsertBlockDocument alone already no-ops on an existing block;
+		// the guard keeps the transaction processing consistent with it.
+		if db.BlockExists(blockNum) {
+			configs.Logger.Info("Gap block already exists, skipping insert and transaction processing",
+				zap.String("block", blockNum))
+			clearFailedBlock(blockNum)
+			filled++
+			continue
+		}
+
 		// Insert the block
 		db.UpdateTransactionStatuses(data)
 		db.InsertBlockDocument(*data)

--- a/QRL2MongoDB/synchroniser/pending_sync.go
+++ b/QRL2MongoDB/synchroniser/pending_sync.go
@@ -15,34 +15,36 @@ import (
 )
 
 const (
-	MEMPOOL_SYNC_INTERVAL       = 1 * time.Second  // Reduced for faster detection
-	CLEANUP_INTERVAL            = 1 * time.Hour
-	VERIFY_PENDING_INTERVAL     = 5 * time.Minute
-	MAX_PENDING_AGE             = 24 * time.Hour
+	MEMPOOL_SYNC_INTERVAL   = 1 * time.Second // Reduced for faster detection
+	CLEANUP_INTERVAL        = 1 * time.Hour
+	VERIFY_PENDING_INTERVAL = 5 * time.Minute
+	MAX_PENDING_AGE         = 24 * time.Hour
 )
 
-// StartPendingTransactionSync starts the periodic mempool monitoring
-func StartPendingTransactionSync() {
+// StartPendingTransactionSync starts the periodic mempool monitoring. The
+// stopCh is threaded into each periodic task so they stop accepting new work
+// when a shutdown signal arrives.
+func StartPendingTransactionSync(stopCh <-chan struct{}) {
 	// Start mempool sync
-	go runPeriodicTask(func() {
+	runPeriodicTask(func() {
 		if err := syncMempool(); err != nil {
 			configs.Logger.Error("Failed to sync mempool", zap.Error(err))
 		}
-	}, MEMPOOL_SYNC_INTERVAL, "mempool sync")
+	}, MEMPOOL_SYNC_INTERVAL, "mempool sync", stopCh)
 
 	// Start cleanup of old transactions
-	go runPeriodicTask(func() {
+	runPeriodicTask(func() {
 		if err := db.CleanupOldPendingTransactions(MAX_PENDING_AGE); err != nil {
 			configs.Logger.Error("Failed to cleanup old pending transactions", zap.Error(err))
 		}
-	}, CLEANUP_INTERVAL, "pending cleanup")
+	}, CLEANUP_INTERVAL, "pending cleanup", stopCh)
 
 	// Start verification of pending transactions against node
-	go runPeriodicTask(func() {
+	runPeriodicTask(func() {
 		if err := verifyPendingTransactions(); err != nil {
 			configs.Logger.Error("Failed to verify pending transactions", zap.Error(err))
 		}
-	}, VERIFY_PENDING_INTERVAL, "pending verification")
+	}, VERIFY_PENDING_INTERVAL, "pending verification", stopCh)
 }
 
 // UpdatePendingTransactionsInBlock checks if any pending transactions are included in the new block

--- a/QRL2MongoDB/synchroniser/periodic_tasks.go
+++ b/QRL2MongoDB/synchroniser/periodic_tasks.go
@@ -25,15 +25,15 @@ func runPeriodicTask(task func(), interval time.Duration, taskName string, stopC
 				configs.Logger.Error("Recovered from panic in periodic task",
 					zap.String("task", taskName),
 					zap.Any("error", r))
-				// Do not restart if we are shutting down.
+				// Restart the task after a short delay, but exit promptly if a
+				// shutdown signal arrives during the wait instead of blocking
+				// the whole delay on time.Sleep.
 				select {
 				case <-stopCh:
 					return
-				default:
+				case <-time.After(5 * time.Second):
+					runPeriodicTask(task, interval, taskName, stopCh)
 				}
-				// Restart the task after a short delay
-				time.Sleep(5 * time.Second)
-				runPeriodicTask(task, interval, taskName, stopCh)
 			}
 		}()
 

--- a/QRL2MongoDB/synchroniser/periodic_tasks.go
+++ b/QRL2MongoDB/synchroniser/periodic_tasks.go
@@ -202,13 +202,31 @@ func processBlockPeriodically() {
 				continue
 			}
 
+			// processSubsequentBlocks returns the next block to process. On a
+			// clean success that is currentBlock+1. On a reorg or a
+			// missing-parent it returns an EARLIER block (the parent), having
+			// rolled back the stale data, so the loop must resume from there
+			// instead of blindly advancing +1. Detect the forward-success case
+			// by comparing the returned value to currentBlock+1.
+			expectedNext := utils.AddHexNumbers(currentBlock, "0x1")
+			if result != expectedNext {
+				// Rollback / re-sync requested: jump to the returned block. Do
+				// NOT run token processing or clear failure tracking for the
+				// current block; it was not advanced past.
+				configs.Logger.Warn("Re-sync point returned (rollback or missing parent), resuming from earlier block",
+					zap.String("from_block", currentBlock),
+					zap.String("resume_block", result))
+				currentBlock = result
+				continue
+			}
+
 			// Clear any previous failure tracking on success
 			clearFailedBlock(currentBlock)
 
 			ProcessTokenTransfersForBlock(currentBlock)
 
-			// Move to next block
-			currentBlock = utils.AddHexNumbers(currentBlock, "0x1")
+			// Move to next block (== result on the success path)
+			currentBlock = result
 		}
 
 		// Attempt to fill any failed blocks from this run

--- a/QRL2MongoDB/synchroniser/periodic_tasks.go
+++ b/QRL2MongoDB/synchroniser/periodic_tasks.go
@@ -15,17 +15,25 @@ import (
 	"go.uber.org/zap"
 )
 
-// runPeriodicTask runs a task at regular intervals with panic recovery
-func runPeriodicTask(task func(), interval time.Duration, taskName string) {
+// runPeriodicTask runs a task at regular intervals with panic recovery.
+// The goroutine returns promptly once stopCh is closed so a graceful
+// shutdown does not start new work while in-flight DB ops are draining.
+func runPeriodicTask(task func(), interval time.Duration, taskName string, stopCh <-chan struct{}) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
 				configs.Logger.Error("Recovered from panic in periodic task",
 					zap.String("task", taskName),
 					zap.Any("error", r))
+				// Do not restart if we are shutting down.
+				select {
+				case <-stopCh:
+					return
+				default:
+				}
 				// Restart the task after a short delay
 				time.Sleep(5 * time.Second)
-				runPeriodicTask(task, interval, taskName)
+				runPeriodicTask(task, interval, taskName, stopCh)
 			}
 		}()
 
@@ -39,8 +47,15 @@ func runPeriodicTask(task func(), interval time.Duration, taskName string) {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 
-		for range ticker.C {
-			runTaskWithRetry(task, taskName)
+		for {
+			select {
+			case <-ticker.C:
+				runTaskWithRetry(task, taskName)
+			case <-stopCh:
+				configs.Logger.Info("Stopping periodic task on shutdown signal",
+					zap.String("task", taskName))
+				return
+			}
 		}
 	}()
 }
@@ -291,8 +306,11 @@ func updateDataPeriodically() {
 	}
 }
 
-// singleBlockInsertion starts continuous block monitoring with periodic tasks
-func singleBlockInsertion() {
+// singleBlockInsertion starts continuous block monitoring with periodic tasks.
+// Each periodic goroutine watches stopCh so a graceful shutdown stops them
+// from starting new work; wg.Wait then returns once they have all exited,
+// which lets Sync() (and therefore main.go's doneCh) complete cleanly.
+func singleBlockInsertion(stopCh <-chan struct{}) {
 	configs.Logger.Info("Starting single block insertion process")
 
 	// Initialize collections if they don't exist
@@ -322,8 +340,14 @@ func singleBlockInsertion() {
 			// Run immediately on start
 			processBlockPeriodically()
 
-			for range ticker.C {
-				processBlockPeriodically()
+			for {
+				select {
+				case <-ticker.C:
+					processBlockPeriodically()
+				case <-stopCh:
+					configs.Logger.Info("Stopping block processing on shutdown signal")
+					return
+				}
 			}
 		}
 	}()
@@ -341,8 +365,14 @@ func singleBlockInsertion() {
 		// Run immediately on start
 		updateDataPeriodically()
 
-		for range ticker.C {
-			updateDataPeriodically()
+		for {
+			select {
+			case <-ticker.C:
+				updateDataPeriodically()
+			case <-stopCh:
+				configs.Logger.Info("Stopping data updates on shutdown signal")
+				return
+			}
 		}
 	}()
 
@@ -359,8 +389,14 @@ func singleBlockInsertion() {
 		// Run immediately on start
 		updateValidatorsPeriodically()
 
-		for range ticker.C {
-			updateValidatorsPeriodically()
+		for {
+			select {
+			case <-ticker.C:
+				updateValidatorsPeriodically()
+			case <-stopCh:
+				configs.Logger.Info("Stopping validator updates on shutdown signal")
+				return
+			}
 		}
 	}()
 
@@ -374,15 +410,27 @@ func singleBlockInsertion() {
 		ticker := time.NewTicker(time.Minute * 5)
 		defer ticker.Stop()
 
-		// Wait 1 minute before first run to let initial sync settle
-		time.Sleep(time.Minute)
+		// Wait 1 minute before first run to let initial sync settle, but bail
+		// out early if a shutdown arrives during that initial delay.
+		select {
+		case <-time.After(time.Minute):
+		case <-stopCh:
+			configs.Logger.Info("Stopping gap detection on shutdown signal")
+			return
+		}
 
-		for range ticker.C {
-			detectAndFillGapsPeriodically()
+		for {
+			select {
+			case <-ticker.C:
+				detectAndFillGapsPeriodically()
+			case <-stopCh:
+				configs.Logger.Info("Stopping gap detection on shutdown signal")
+				return
+			}
 		}
 	}()
 
-	// Keep the main goroutine alive
+	// Keep the main goroutine alive until every periodic task has stopped.
 	wg.Wait()
 }
 

--- a/QRL2MongoDB/synchroniser/producer_consumer.go
+++ b/QRL2MongoDB/synchroniser/producer_consumer.go
@@ -97,10 +97,15 @@ func consumer(ch <-chan (<-chan Data)) {
 					// idempotency guard in sync.go and gap_detection.go.
 					// ProcessTransactions has no unique index on txHash, so
 					// re-running it on an already-synced block duplicates
-					// transfer + transactionByAddress rows.
-					alreadyExists := make([]bool, len(blocks))
+					// transfer + transactionByAddress rows. One $in query keeps
+					// this to a single round-trip instead of N per batch.
+					blockNumbers := make([]string, len(blocks))
 					for x := 0; x < len(blocks); x++ {
-						alreadyExists[x] = db.BlockExists(blocks[x].Result.Number)
+						blockNumbers[x] = blocks[x].Result.Number
+					}
+					alreadyExists, err := db.BlocksExist(blockNumbers)
+					if err != nil {
+						configs.Logger.Error("Failed to check existing blocks in batch", zap.Error(err))
 					}
 
 					db.InsertManyBlockDocuments(data.blockData)
@@ -108,7 +113,7 @@ func consumer(ch <-chan (<-chan Data)) {
 						zap.Int("count", len(data.blockData)))
 
 					for x := 0; x < len(blocks); x++ {
-						if alreadyExists[x] {
+						if alreadyExists[blocks[x].Result.Number] {
 							configs.Logger.Info("Batch block already processed, skipping transaction processing",
 								zap.String("block", blocks[x].Result.Number))
 							continue

--- a/QRL2MongoDB/synchroniser/producer_consumer.go
+++ b/QRL2MongoDB/synchroniser/producer_consumer.go
@@ -87,11 +87,32 @@ func consumer(ch <-chan (<-chan Data)) {
 						continue
 					}
 
+					// Snapshot which blocks already exist BEFORE the InsertMany.
+					// After InsertManyBlockDocuments runs, every block in the
+					// batch is present, so checking existence afterward would
+					// also skip ProcessTransactions for legitimately new blocks.
+					// Capturing it up front lets us skip ProcessTransactions only
+					// for blocks that were already synced (crash/restart during
+					// catch-up, overlapping ranges), matching the BlockExists
+					// idempotency guard in sync.go and gap_detection.go.
+					// ProcessTransactions has no unique index on txHash, so
+					// re-running it on an already-synced block duplicates
+					// transfer + transactionByAddress rows.
+					alreadyExists := make([]bool, len(blocks))
+					for x := 0; x < len(blocks); x++ {
+						alreadyExists[x] = db.BlockExists(blocks[x].Result.Number)
+					}
+
 					db.InsertManyBlockDocuments(data.blockData)
 					configs.Logger.Info("Inserted block batch",
 						zap.Int("count", len(data.blockData)))
 
 					for x := 0; x < len(blocks); x++ {
+						if alreadyExists[x] {
+							configs.Logger.Info("Batch block already processed, skipping transaction processing",
+								zap.String("block", blocks[x].Result.Number))
+							continue
+						}
 						db.ProcessTransactions(blocks[x])
 						// Tombstone any pending rows whose hashes are in this
 						// block. The single-block path (sync.go) calls this

--- a/QRL2MongoDB/synchroniser/sync.go
+++ b/QRL2MongoDB/synchroniser/sync.go
@@ -418,6 +418,13 @@ func processSubsequentBlocks(currentBlock string) string {
 				zap.String("rollback_target", rollbackTarget),
 				zap.String("stale_block", parentBlockNum),
 				zap.Error(err))
+			// Rollback did not delete the stale block. Returning parentBlockNum
+			// here would let the BlockExists guard skip the still-present N-1,
+			// advance to N, re-detect the mismatch, and ping-pong forever
+			// without ever repairing the data. Return currentBlock instead so
+			// the next tick retries this same block (and the rollback) until it
+			// succeeds.
+			return currentBlock
 		}
 		// Resume from the rolled-back point: re-sync the stale block (N-1)
 		// first so its parent linkage is rebuilt before N.

--- a/QRL2MongoDB/synchroniser/sync.go
+++ b/QRL2MongoDB/synchroniser/sync.go
@@ -246,7 +246,6 @@ func Sync() {
 	singleBlockInsertion()
 }
 
-
 // findHighestProcessedBlock finds the highest block number that exists in the database
 func findHighestProcessedBlock() string {
 	// First try to get the last synced block from the database
@@ -405,14 +404,45 @@ func processSubsequentBlocks(currentBlock string) string {
 			zap.String("expected_parent", dbParentHash),
 			zap.String("actual_parent", blockData.Result.ParentHash))
 
-		// Roll back one block and try again
-		err = db.Rollback(currentBlock)
+		// Reorg: block N (currentBlock) does not build on the stored block N-1
+		// (parentBlockNum), so the stored N-1 is stale and must be removed.
+		// Rollback deletes blocks with blockNumberInt > arg (strict $gt), so to
+		// include N-1 in the deletion set we pass N-2 (parentBlockNum - 0x1).
+		// Rollback then deletes every block >= N-1 (i.e. the stale N-1 and any
+		// stragglers above it) and resets the sync state to N-2, so the
+		// continuous loop re-syncs starting at N-1.
+		rollbackTarget := utils.SubtractHexNumbers(parentBlockNum, "0x1")
+		err = db.Rollback(rollbackTarget)
 		if err != nil {
 			configs.Logger.Error("Failed to rollback block",
-				zap.String("block", currentBlock),
+				zap.String("rollback_target", rollbackTarget),
+				zap.String("stale_block", parentBlockNum),
 				zap.Error(err))
 		}
+		// Resume from the rolled-back point: re-sync the stale block (N-1)
+		// first so its parent linkage is rebuilt before N.
 		return parentBlockNum
+	}
+
+	// Idempotency guard: if this block is already stored, skip BOTH the block
+	// insert and ProcessTransactions together. InsertBlockDocument already
+	// no-ops on an existing block, but ProcessTransactions used to run
+	// unconditionally right after, duplicating transfer + transactionByAddress
+	// rows (which have no unique index on txHash) on any re-process: retry
+	// after a partial failure, node restart, or gap-fill overlap. Guarding both
+	// with one BlockExists check keeps them consistent.
+	//
+	// This does NOT block the reorg re-sync path above: Rollback deletes the
+	// stale block first, so BlockExists returns false on the subsequent
+	// reprocess and the block is re-inserted correctly.
+	if db.BlockExists(currentBlock) {
+		configs.Logger.Info("Block already processed, skipping insert and transaction processing",
+			zap.String("block", currentBlock),
+			zap.String("hash", blockData.Result.Hash))
+		// Still advance the sync state and return the next block so the caller
+		// continues forward rather than re-checking the same block.
+		db.StoreLastKnownBlockNumber(currentBlock)
+		return utils.AddHexNumbers(currentBlock, "0x1")
 	}
 
 	// Process the block
@@ -437,4 +467,3 @@ func processSubsequentBlocks(currentBlock string) string {
 	// Return next block number
 	return utils.AddHexNumbers(currentBlock, "0x1")
 }
-

--- a/QRL2MongoDB/synchroniser/sync.go
+++ b/QRL2MongoDB/synchroniser/sync.go
@@ -92,8 +92,10 @@ func getRPCDelay(bulkSync bool) time.Duration {
 	return time.Duration(delay) * time.Millisecond
 }
 
-// Sync starts the synchronization process
-func Sync() {
+// Sync starts the synchronization process. stopCh is closed by main.go on a
+// termination signal; it is threaded into every background ticker goroutine
+// started here so they stop accepting new work during graceful shutdown.
+func Sync(stopCh <-chan struct{}) {
 	var err error
 	var nextBlock string
 	var maxHex string
@@ -231,11 +233,11 @@ func Sync() {
 	go func() {
 		// Start wallet count sync
 		configs.Logger.Info("Starting wallet count sync service...")
-		db.StartWalletCountSync()
+		db.StartWalletCountSync(stopCh)
 
 		// Start contract reprocessing job
 		configs.Logger.Info("Starting contract reprocessing service...")
-		db.StartContractReprocessingJob()
+		db.StartContractReprocessingJob(stopCh)
 	}()
 
 	// Signal that initial sync is done so mempool polling can begin
@@ -243,7 +245,7 @@ func Sync() {
 	configs.Logger.Info("Initial sync flag set, mempool polling enabled")
 
 	configs.Logger.Info("Starting continuous block monitoring...")
-	singleBlockInsertion()
+	singleBlockInsertion(stopCh)
 }
 
 // findHighestProcessedBlock finds the highest block number that exists in the database

--- a/backendAPI/configs/const.go
+++ b/backendAPI/configs/const.go
@@ -10,20 +10,32 @@ import (
 const QUANTA float64 = 1000000000000000000
 
 var Url string = os.Getenv("NODE_URL")
-var TransferCollections *mongo.Collection = GetCollection(DB, "transfer")
-var TransactionByAddressCollection *mongo.Collection = GetCollection(DB, "transactionByAddress")
-var InternalTransactionByAddressCollection *mongo.Collection = GetCollection(DB, "internalTransactionByAddress")
-var AddressesCollections *mongo.Collection = GetCollection(DB, "addresses")
-var BlocksCollection *mongo.Collection = GetCollection(DB, "blocks")
-var ValidatorsCollections *mongo.Collection = GetCollection(DB, "validators")
-var ContractInfoCollection *mongo.Collection = GetCollection(DB, "contractCode")
-var ContractVerificationsCollection *mongo.Collection = GetCollection(DB, "contractVerifications")
-var BlockSizesCollection *mongo.Collection = GetCollection(DB, "averageBlockSize")
-var TotalCirculatingSupplyCollection *mongo.Collection = GetCollection(DB, "totalCirculatingSupply")
-var CoinGeckoCollection *mongo.Collection = GetCollection(DB, "coingecko")
-var WalletCountCollections *mongo.Collection = GetCollection(DB, "walletCount")
-var DailyTransactionsVolumeCollection *mongo.Collection = GetCollection(DB, "dailyTransactionsVolume")
-var EpochInfoCollection *mongo.Collection = GetCollection(DB, "epoch_info")
-var ValidatorHistoryCollection *mongo.Collection = GetCollection(DB, "validator_history")
-var PriceHistoryCollection *mongo.Collection = GetCollection(DB, "priceHistory")
+
+// Collection handles. These are populated by ConnectDB once the client is
+// confirmed live (see initCollections), not at package-init time. Binding
+// them at declaration via GetCollection(DB, ...) used to force a Mongo
+// connect during package initialization (because DB is nil there, the
+// nil-guard in GetCollection calls ConnectDB), which meant a Mongo outage
+// log.Fatal'd before main's panic recovery was installed and left the
+// startup ordering fragile. Every reader of these vars runs inside an HTTP
+// handler, which only executes after RequestHandler has called ConnectDB.
+var (
+	TransferCollections                    *mongo.Collection
+	TransactionByAddressCollection         *mongo.Collection
+	InternalTransactionByAddressCollection *mongo.Collection
+	AddressesCollections                   *mongo.Collection
+	BlocksCollection                       *mongo.Collection
+	ValidatorsCollections                  *mongo.Collection
+	ContractInfoCollection                 *mongo.Collection
+	ContractVerificationsCollection        *mongo.Collection
+	BlockSizesCollection                   *mongo.Collection
+	TotalCirculatingSupplyCollection       *mongo.Collection
+	CoinGeckoCollection                    *mongo.Collection
+	WalletCountCollections                 *mongo.Collection
+	DailyTransactionsVolumeCollection      *mongo.Collection
+	EpochInfoCollection                    *mongo.Collection
+	ValidatorHistoryCollection             *mongo.Collection
+	PriceHistoryCollection                 *mongo.Collection
+)
+
 var Validate = validator.New()

--- a/backendAPI/configs/env.go
+++ b/backendAPI/configs/env.go
@@ -26,3 +26,18 @@ func EnvMongoURI() string {
 
 	return os.Getenv("MONGOURI")
 }
+
+// ValidateEnv fail-fasts on missing required configuration before the server
+// starts serving. Without this, a missing MONGOURI surfaces only as a late
+// log.Fatal inside ConnectDB, and a missing NODE_URL silently defaults to
+// localhost in db.NodeRPC, masking a misconfiguration in production. Call
+// this once early in main. EnvMongoURI() loads the .env file as a side
+// effect, so calling it first ensures NODE_URL is populated from .env too.
+func ValidateEnv() {
+	if EnvMongoURI() == "" {
+		log.Fatal("MONGOURI is not set; set it in the environment or .env before starting")
+	}
+	if os.Getenv("NODE_URL") == "" {
+		log.Fatal("NODE_URL is not set; set it in the environment or .env before starting")
+	}
+}

--- a/backendAPI/configs/setup.go
+++ b/backendAPI/configs/setup.go
@@ -51,9 +51,37 @@ func ConnectDB() *mongo.Client {
 
 		// Set the global DB variable
 		DB = client
+
+		// Bind the package-level collection handles now that the client is
+		// confirmed live. Doing this here (rather than at package-var
+		// declaration time) removes the nil-client window: every reader runs
+		// inside an HTTP handler, which only executes after this point.
+		bindCollections(client)
 	})
 
 	return DB
+}
+
+// bindCollections wires the package-level *mongo.Collection handles to the
+// live client. Called once from ConnectDB after the ping succeeds.
+func bindCollections(client *mongo.Client) {
+	db := client.Database("qrldata-z")
+	TransferCollections = db.Collection("transfer")
+	TransactionByAddressCollection = db.Collection("transactionByAddress")
+	InternalTransactionByAddressCollection = db.Collection("internalTransactionByAddress")
+	AddressesCollections = db.Collection("addresses")
+	BlocksCollection = db.Collection("blocks")
+	ValidatorsCollections = db.Collection("validators")
+	ContractInfoCollection = db.Collection("contractCode")
+	ContractVerificationsCollection = db.Collection("contractVerifications")
+	BlockSizesCollection = db.Collection("averageBlockSize")
+	TotalCirculatingSupplyCollection = db.Collection("totalCirculatingSupply")
+	CoinGeckoCollection = db.Collection("coingecko")
+	WalletCountCollections = db.Collection("walletCount")
+	DailyTransactionsVolumeCollection = db.Collection("dailyTransactionsVolume")
+	EpochInfoCollection = db.Collection("epoch_info")
+	ValidatorHistoryCollection = db.Collection("validator_history")
+	PriceHistoryCollection = db.Collection("priceHistory")
 }
 
 func createIndexes(db *mongo.Database) {
@@ -114,7 +142,12 @@ func createIndexes(db *mongo.Database) {
 		},
 	}
 
-	// internalTransactionByAddress collection indexes
+	// internalTransactionByAddress collection indexes.
+	// The compound (from|to, blockTimestamp desc) pair backs the $or+sort in
+	// ReturnAllInternalTransactionsByAddress; the hash index backs the
+	// per-tx lookups in GetInternalTransactionsByTxHash and
+	// CountInternalTxsByTxHashes. The legacy single-field from/to indexes
+	// are kept so existing query plans don't regress.
 	internalTransactionsIndexes := []mongo.IndexModel{
 		{
 			Keys:    bson.D{{Key: "from", Value: 1}},
@@ -123,6 +156,24 @@ func createIndexes(db *mongo.Database) {
 		{
 			Keys:    bson.D{{Key: "to", Value: 1}},
 			Options: options.Index().SetName("internal_to"),
+		},
+		{
+			Keys: bson.D{
+				{Key: "from", Value: 1},
+				{Key: "blockTimestamp", Value: -1},
+			},
+			Options: options.Index().SetName("internal_from_blocktimestamp_desc"),
+		},
+		{
+			Keys: bson.D{
+				{Key: "to", Value: 1},
+				{Key: "blockTimestamp", Value: -1},
+			},
+			Options: options.Index().SetName("internal_to_blocktimestamp_desc"),
+		},
+		{
+			Keys:    bson.D{{Key: "hash", Value: 1}},
+			Options: options.Index().SetName("internal_hash"),
 		},
 	}
 

--- a/backendAPI/configs/setup.go
+++ b/backendAPI/configs/setup.go
@@ -102,6 +102,15 @@ func createIndexes(db *mongo.Database) {
 			},
 			Options: options.Index().SetName("result_hash"),
 		},
+		{
+			// Backs the $elemMatch tx-by-hash lookup in ReturnSingleTransfer,
+			// which scans blocks for a transaction whose hash matches the
+			// query. Without this the lookup is a full collection scan.
+			Keys: bson.D{
+				{Key: "result.transactions.hash", Value: 1},
+			},
+			Options: options.Index().SetName("result_transactions_hash"),
+		},
 	}
 
 	// transactionByAddress collection indexes
@@ -183,6 +192,14 @@ func createIndexes(db *mongo.Database) {
 			Keys:    bson.D{{Key: "address", Value: 1}},
 			Options: options.Index().SetName("contract_address_unique").SetUnique(true),
 		},
+		{
+			// Backs GetContractByCreationTx (the /tx/:hash "contract created"
+			// lookup). Sparse because most contractCode rows have no
+			// creationTransaction field, so the index only holds the rows that
+			// do, keeping it small.
+			Keys:    bson.D{{Key: "creationTransaction", Value: 1}},
+			Options: options.Index().SetName("contract_creation_tx").SetSparse(true),
+		},
 	}
 
 	// transfer collection indexes
@@ -190,6 +207,40 @@ func createIndexes(db *mongo.Database) {
 		{
 			Keys:    bson.D{{Key: "txHash", Value: 1}},
 			Options: options.Index().SetName("transfer_txhash_unique").SetUnique(true),
+		},
+	}
+
+	// tokenTransfers collection indexes.
+	// The (contractAddress, blockNumber desc) compound backs the per-contract
+	// transfer feed in GetTokenTransfers; the (from|to, blockNumber desc) pair
+	// backs the by-holder $or+sort in GetTokenTransfersByAddress; the txHash
+	// index backs the per-tx lookups in GetTokenTransfersByTxHash and
+	// CountTokenTransfersByTxHashes.
+	tokenTransfersIndexes := []mongo.IndexModel{
+		{
+			Keys: bson.D{
+				{Key: "contractAddress", Value: 1},
+				{Key: "blockNumber", Value: -1},
+			},
+			Options: options.Index().SetName("token_contract_block_desc"),
+		},
+		{
+			Keys: bson.D{
+				{Key: "from", Value: 1},
+				{Key: "blockNumber", Value: -1},
+			},
+			Options: options.Index().SetName("token_from_block_desc"),
+		},
+		{
+			Keys: bson.D{
+				{Key: "to", Value: 1},
+				{Key: "blockNumber", Value: -1},
+			},
+			Options: options.Index().SetName("token_to_block_desc"),
+		},
+		{
+			Keys:    bson.D{{Key: "txHash", Value: 1}},
+			Options: options.Index().SetName("token_txhash"),
 		},
 	}
 
@@ -218,6 +269,7 @@ func createIndexes(db *mongo.Database) {
 		"contractCode":                 contractCodeIndexes,
 		"transfer":                     transferIndexes,
 		"validators":                   validatorsIndexes,
+		"tokenTransfers":               tokenTransfersIndexes,
 	}
 
 	for collName, indexes := range collections {

--- a/backendAPI/db/block.go
+++ b/backendAPI/db/block.go
@@ -130,7 +130,12 @@ func ReturnBlockSizes() ([]primitive.M, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	opts := options.Find().SetSort(primitive.D{{Key: "timestamp", Value: 1}})
+	// Cap the result set: averageBlockSize grows without bound as the syncer
+	// appends time-series rows, and this feeds a chart that only renders a
+	// finite window. 2000 points is well past what any chart shows.
+	opts := options.Find().
+		SetSort(primitive.D{{Key: "timestamp", Value: 1}}).
+		SetLimit(2000)
 
 	cursor, err := configs.BlockSizesCollection.Find(ctx, primitive.D{}, opts)
 	if err != nil {

--- a/backendAPI/db/contract.go
+++ b/backendAPI/db/contract.go
@@ -47,26 +47,37 @@ func ReturnContracts(page int64, limit int64, search string, isTokenFilter *bool
 		// address + creatorAddress exact-match branches).
 		normalizedSearch := normalizeAddress(search)
 
-		// Escape regex metacharacters in the user input so a `.` or `*`
-		// in the search term doesn't behave as a wildcard or DoS vector.
-		escaped := regexp.QuoteMeta(search)
-		nameRegex := bson.D{{Key: "$regex", Value: escaped}, {Key: "$options", Value: "i"}}
+		// Build the $or branches. Exact address/creatorAddress matches are
+		// always included so short queries can still resolve a contract by
+		// its address. The case-insensitive name/symbol/metadataName regex
+		// branches run an unanchored full-collection scan, so we only add
+		// them for queries of at least 3 chars: a 1-2 char regex matches
+		// nearly every row and turns search into a table scan with no useful
+		// result. Shorter queries simply return the exact-match results
+		// (often empty), which the contracts page renders as a normal empty
+		// paginated list.
+		orBranches := bson.A{
+			bson.D{{Key: "address", Value: normalizedSearch}},
+			bson.D{{Key: "creatorAddress", Value: normalizedSearch}},
+		}
+		if len(search) >= 3 {
+			// Escape regex metacharacters in the user input so a `.` or `*`
+			// in the search term doesn't behave as a wildcard or DoS vector.
+			escaped := regexp.QuoteMeta(search)
+			nameRegex := bson.D{{Key: "$regex", Value: escaped}, {Key: "$options", Value: "i"}}
 
-		// Search by exact address, exact creator address, OR partial
-		// case-insensitive match against name + symbol + metadataName.
-		// Symbol was previously absent, searching "MQW" missed tokens whose
-		// `name` field held the full project label instead of the ticker.
-		// Phase 3a adds metadataName so a user searching by the off-chain
-		// display title hits the row even when on-chain name() is empty.
-		searchFilter := bson.D{
-			{Key: "$or", Value: bson.A{
-				bson.D{{Key: "address", Value: normalizedSearch}},
-				bson.D{{Key: "creatorAddress", Value: normalizedSearch}},
+			// Symbol was previously absent, searching "MQW" missed tokens whose
+			// `name` field held the full project label instead of the ticker.
+			// Phase 3a adds metadataName so a user searching by the off-chain
+			// display title hits the row even when on-chain name() is empty.
+			orBranches = append(orBranches,
 				bson.D{{Key: "name", Value: nameRegex}},
 				bson.D{{Key: "symbol", Value: nameRegex}},
 				bson.D{{Key: "metadataName", Value: nameRegex}},
-			}},
+			)
 		}
+
+		searchFilter := bson.D{{Key: "$or", Value: orBranches}}
 		// Combine with existing filter
 		if len(filter) > 0 {
 			filter = bson.D{{Key: "$and", Value: bson.A{filter, searchFilter}}}

--- a/backendAPI/db/stats.go
+++ b/backendAPI/db/stats.go
@@ -95,7 +95,7 @@ func GetPriceHistory(interval string) ([]models.PriceHistory, error) {
 		limit = 1440 // ~30 min intervals for 30 days
 	case "all":
 		since = time.Time{} // Beginning of time
-		limit = 0           // No limit
+		limit = 5000        // Hard cap so an unbounded scan can't grow without limit
 	default:
 		// Default to 24h
 		since = now.Add(-24 * time.Hour)

--- a/backendAPI/db/token.go
+++ b/backendAPI/db/token.go
@@ -837,6 +837,11 @@ func GetNFTBalancesByAddress(address string, standardFilter *string) ([]models.N
 			{Key: "tokenIDLen", Value: 1},
 			{Key: "tokenID", Value: 1},
 		}},
+		// Bound the materialized result set. Without a cap a wallet holding
+		// thousands of NFT rows forces Mongo to sort + stream every row on
+		// each request. 500 covers any realistic single-wallet picker view;
+		// the route is not paginated so this is a hard ceiling, not a page.
+		{"$limit": 500},
 		{"$project": bson.M{"tokenIDLen": 0}},
 	}
 

--- a/backendAPI/db/validator.go
+++ b/backendAPI/db/validator.go
@@ -103,10 +103,20 @@ func CountValidators() (int64, error) {
 }
 
 // HexToInt converts a hex string (with or without 0x prefix) to int64.
+// Parses as unsigned first: ParseInt returns 0 for any value with the high
+// bit set (block numbers near 2^63), which would silently zero the epoch
+// math downstream. Values that overflow int64 are clamped to math.MaxInt64
+// so the result stays usable for the /128 epoch division callers perform.
 func HexToInt(hexStr string) int64 {
 	hexStr = strings.TrimPrefix(hexStr, "0x")
-	num, _ := strconv.ParseInt(hexStr, 16, 64)
-	return num
+	num, err := strconv.ParseUint(hexStr, 16, 64)
+	if err != nil {
+		return 0
+	}
+	if num > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(num)
 }
 
 // FAR_FUTURE_EPOCH represents a validator that hasn't exited.
@@ -386,7 +396,7 @@ func GetEpochDetail(epochId string) (*models.EpochDetailResponse, error) {
 	blockMap := make(map[int64]models.EpochDetailBlock)
 	for cursor.Next(ctx) {
 		var doc struct {
-			BlockNumberInt int64        `bson:"blockNumberInt"`
+			BlockNumberInt int64         `bson:"blockNumberInt"`
 			Result         models.Result `bson:"result"`
 		}
 		if err := cursor.Decode(&doc); err != nil {
@@ -481,8 +491,8 @@ func GetValidatorStats() (*models.ValidatorStatsResponse, error) {
 					"branches": []bson.M{
 						{
 							// slashed
-							"case":  bson.M{"$eq": []interface{}{"$slashed", true}},
-							"then":  "slashed",
+							"case": bson.M{"$eq": []interface{}{"$slashed", true}},
+							"then": "slashed",
 						},
 						{
 							// pending: activationEpoch > currentEpoch
@@ -503,8 +513,8 @@ func GetValidatorStats() (*models.ValidatorStatsResponse, error) {
 			},
 		}}},
 		bson.D{{Key: "$group", Value: bson.M{
-			"_id":          "$_computedStatus",
-			"count":        bson.M{"$sum": 1},
+			"_id":   "$_computedStatus",
+			"count": bson.M{"$sum": 1},
 			// We sum effective balance as strings; MongoDB can't do numeric sum on
 			// decimal-string fields, so we fall back to a cursor scan for totalStaked.
 		}}},
@@ -545,7 +555,7 @@ func GetValidatorStats() (*models.ValidatorStatsResponse, error) {
 	// so we convert with $toLong inside the pipeline.
 	sumPipeline := mongo.Pipeline{
 		bson.D{{Key: "$group", Value: bson.M{
-			"_id": nil,
+			"_id":         nil,
 			"totalStaked": bson.M{"$sum": bson.M{"$toLong": "$effectiveBalance"}},
 		}}},
 	}

--- a/backendAPI/main.go
+++ b/backendAPI/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"backendAPI/configs"
 	"backendAPI/handler"
 	"fmt"
 	"io"
@@ -22,6 +23,11 @@ func main() {
 
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile)
 	log.Println("BackendAPI starting...")
+
+	// Fail fast on missing required config before serving. A missing MONGOURI
+	// would otherwise surface only as a late log.Fatal inside ConnectDB, and a
+	// missing NODE_URL would silently default to localhost in db.NodeRPC.
+	configs.ValidateEnv()
 
 	// Recover from panics
 	defer func() {

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -1566,6 +1566,13 @@ func UserRoute(router *gin.Engine) {
 			return
 		}
 
+		// Cap the length before SetString: a uint256 token ID is at most 78
+		// decimal digits, so anything longer is invalid and parsing an
+		// arbitrarily long string into big.Int is a CPU-DoS vector.
+		if len(tokenID) > 80 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "tokenID is too large"})
+			return
+		}
 		if _, ok := new(big.Int).SetString(tokenID, 10); !ok {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "tokenID must be a decimal integer"})
 			return

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -1060,7 +1060,15 @@ func UserRoute(router *gin.Engine) {
 
 	router.GET("/validators", func(c *gin.Context) {
 		pageToken := c.Query("page_token")
-		validatorResponse, err := db.ReturnValidators(pageToken)
+		// ReturnValidators fetches the full validator set (one doc per
+		// validator) and sums TotalStaked, an expensive unsegmented read.
+		// The set only shifts at epoch boundaries (~minutes), so a 30s TTL
+		// caches the full-collection fetch instead of running it per request.
+		// Keyed by page_token so future server-side pagination stays correct.
+		key := "validators:" + pageToken
+		v, err := routeCache.GetOrCompute(key, 30*time.Second, func() (interface{}, error) {
+			return db.ReturnValidators(pageToken)
+		})
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": fmt.Sprintf("Failed to fetch validators: %v", err),
@@ -1068,7 +1076,7 @@ func UserRoute(router *gin.Engine) {
 			return
 		}
 
-		c.JSON(http.StatusOK, validatorResponse)
+		c.JSON(http.StatusOK, v)
 	})
 
 	// Get epoch detail by ID

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"math/big"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -18,6 +19,64 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo"
 )
+
+// Path-param format guards. These reject malformed input at the route
+// boundary (HTTP 400) before it reaches the db layer, instead of letting
+// a junk string fan out into Mongo filters / RPC calls. The accepted
+// shapes mirror what the frontend search resolver emits (see
+// ExplorerFrontend/app/lib/searchResolver.ts).
+var (
+	// txHashRe matches a "0x"-prefixed 32-byte hash (the only tx/block
+	// hash form the explorer surfaces).
+	txHashRe = regexp.MustCompile(`^0x[0-9a-fA-F]{64}$`)
+	// addrParamRe matches both address forms the frontend forwards: the
+	// canonical "Q" + 40 hex (case-insensitive Q) and the "0x" + 40 hex
+	// contract form. db.normalizeAddress canonicalises both downstream.
+	addrParamRe = regexp.MustCompile(`^([Qq]|0x|0X)[0-9a-fA-F]{40}$`)
+	// validatorPubkeyRe matches a hex public-key lookup key (optional 0x
+	// prefix). Even-length and an upper bound are enforced in
+	// isValidValidatorID rather than the pattern, because Go's regexp
+	// rejects the nested-repeat form that would express "even, bounded"
+	// inline. The decimal-index form is handled separately so plain
+	// integers still resolve.
+	validatorPubkeyRe = regexp.MustCompile(`^(0x|0X)?[0-9a-fA-F]+$`)
+)
+
+// isValidTxHash reports whether s is a "0x"-prefixed 32-byte hash.
+func isValidTxHash(s string) bool {
+	return txHashRe.MatchString(s)
+}
+
+// isValidAddressParam reports whether s is one of the address forms a
+// route path param legitimately carries (Q + 40 hex or 0x + 40 hex).
+// Use this for :address / :query route guards; the stricter Q-only
+// isValidAddress stays reserved for the contract-write endpoints whose
+// inputs are never 0x-form.
+func isValidAddressParam(s string) bool {
+	return addrParamRe.MatchString(s)
+}
+
+// isValidValidatorID reports whether s is a decimal validator index or a
+// hex public-key key. GetValidatorByID looks up by _id (decimal index)
+// then falls back to publicKeyHex, so both shapes are legitimate.
+func isValidValidatorID(s string) bool {
+	if s == "" {
+		return false
+	}
+	if _, err := strconv.ParseUint(s, 10, 64); err == nil {
+		return true
+	}
+	if !validatorPubkeyRe.MatchString(s) {
+		return false
+	}
+	// Strip an optional 0x prefix, then require an even-length hex body of
+	// a sane size (1..2000 hex chars covers any real pubkey scheme).
+	body := s
+	if len(body) >= 2 && (body[:2] == "0x" || body[:2] == "0X") {
+		body = body[2:]
+	}
+	return len(body) > 0 && len(body)%2 == 0 && len(body) <= 2000
+}
 
 // normalizeContractAddr maps any input address form (0x-hex, q-lower, bare
 // hex, Q-canonical) to the canonical "Q" + lowercase hex shape the syncer
@@ -254,6 +313,10 @@ func UserRoute(router *gin.Engine) {
 	// Add endpoint for fetching a specific pending transaction
 	router.GET("/pending-transaction/:hash", func(c *gin.Context) {
 		hash := c.Param("hash")
+		if !isValidTxHash(hash) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid transaction hash; expected 0x + 64 hex chars"})
+			return
+		}
 		transaction, err := db.GetPendingTransactionByHash(hash)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -495,6 +558,10 @@ func UserRoute(router *gin.Engine) {
 
 	router.GET("/address/aggregate/:query", func(c *gin.Context) {
 		param := c.Param("query")
+		if !isValidAddressParam(param) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		// db functions normalize the address to canonical q-prefix internally.
 
 		// Pagination for the tx-list aggregations. Defaults match the old
@@ -589,6 +656,10 @@ func UserRoute(router *gin.Engine) {
 
 	router.GET("/tx/:query", func(c *gin.Context) {
 		value := c.Param("query")
+		if !isValidTxHash(value) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid transaction hash; expected 0x + 64 hex chars"})
+			return
+		}
 		query, err := db.ReturnSingleTransfer(value)
 		if err != nil {
 			log.Printf("error fetching transfer %s: %v", value, err)
@@ -840,6 +911,10 @@ func UserRoute(router *gin.Engine) {
 
 	router.GET("/coinbase/:query", func(c *gin.Context) {
 		value := c.Param("query")
+		if !isValidTxHash(value) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid transaction hash; expected 0x + 64 hex chars"})
+			return
+		}
 		query, err := db.ReturnSingleTransfer(value)
 		// A missing tx is not a server fault: keep the historical 200-with-empty
 		// behavior for not-found. Any other DB error becomes a 500 instead of a
@@ -1054,6 +1129,10 @@ func UserRoute(router *gin.Engine) {
 	// Get individual validator details
 	router.GET("/validator/:id", func(c *gin.Context) {
 		id := c.Param("id")
+		if !isValidValidatorID(id) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid validator id; expected a decimal index or hex public key"})
+			return
+		}
 		validator, err := db.GetValidatorByID(id)
 		if err != nil {
 			c.JSON(http.StatusNotFound, gin.H{
@@ -1230,6 +1309,10 @@ func UserRoute(router *gin.Engine) {
 	// Add a new endpoint to get limited non-zero transactions for an address
 	router.GET("/address/:address/transactions", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		page, limit := getPaginationParams(c, 1, 5)
 
 		transactions, err := db.ReturnNonZeroTransactions(address, page, limit)
@@ -1268,6 +1351,10 @@ func UserRoute(router *gin.Engine) {
 	// by contract not by holder. Paginated like /address/:addr/transactions.
 	router.GET("/address/:address/token-transfers", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		// Match the address-page Transactions table's 5-rows-per-page default
 		// (paginated server-side, page-1-indexed). Cap matches the DB layer.
 		page, limit := getPaginationParams(c, 1, 5)
@@ -1304,6 +1391,10 @@ func UserRoute(router *gin.Engine) {
 	// fungibles.
 	router.GET("/address/:address/tokens", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 
 		var standardFilter *string
 		if s := c.Query("standard"); s != "" {
@@ -1343,6 +1434,10 @@ func UserRoute(router *gin.Engine) {
 	// on the sibling /tokens?standard=ERC-20.
 	router.GET("/address/:address/nfts", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 
 		var standardFilter *string
 		if s := c.Query("standard"); s != "" {
@@ -1376,6 +1471,10 @@ func UserRoute(router *gin.Engine) {
 	// Get token info (summary stats for a token contract)
 	router.GET("/token/:address/info", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 
 		info, err := db.GetTokenInfo(address)
 		if err != nil {
@@ -1395,6 +1494,10 @@ func UserRoute(router *gin.Engine) {
 	// holder, balance is the cross-id total). ERC-20 behaviour unchanged.
 	router.GET("/token/:address/holders", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		tokenID := c.Query("tokenID")
 		page, limit := getPaginationParams(c, 0, 25)
 
@@ -1423,6 +1526,10 @@ func UserRoute(router *gin.Engine) {
 	// when off-chain metadata has been fetched.
 	router.GET("/token/:address/tokens", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		page, limit := getPaginationParams(c, 0, 25)
 
 		tokens, totalCount, err := db.GetTokenIDs(address, page, limit)
@@ -1454,6 +1561,11 @@ func UserRoute(router *gin.Engine) {
 		address := c.Param("address")
 		tokenID := c.Param("id")
 
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
+
 		if _, ok := new(big.Int).SetString(tokenID, 10); !ok {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "tokenID must be a decimal integer"})
 			return
@@ -1475,6 +1587,10 @@ func UserRoute(router *gin.Engine) {
 	// Get token transfers with pagination
 	router.GET("/token/:address/transfers", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		page, limit := getPaginationParams(c, 0, 25)
 
 		transfers, totalCount, err := db.GetTokenTransfers(address, page, limit)
@@ -1503,6 +1619,10 @@ func UserRoute(router *gin.Engine) {
 	// db/gas.go; the route just plumbs it together.
 	router.GET("/pending-tx-eta/:hash", func(c *gin.Context) {
 		hash := c.Param("hash")
+		if !isValidTxHash(hash) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid transaction hash; expected 0x + 64 hex chars"})
+			return
+		}
 		v, err := routeCache.GetOrCompute("eta:"+hash, 5*time.Second, func() (interface{}, error) {
 			tx, err := db.GetPendingTransactionByHash(hash)
 			if err != nil {

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -304,7 +304,7 @@ func UserRoute(router *gin.Engine) {
 		})
 		if err != nil {
 			log.Printf("Error fetching pending transactions: %v", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -319,7 +319,8 @@ func UserRoute(router *gin.Engine) {
 		}
 		transaction, err := db.GetPendingTransactionByHash(hash)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error fetching pending transaction %s: %v", hash, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 
@@ -327,7 +328,8 @@ func UserRoute(router *gin.Engine) {
 		if transaction == nil {
 			tx, err := db.GetTransactionByHash(hash)
 			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				log.Printf("error fetching transaction %s: %v", hash, err)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 				return
 			}
 
@@ -442,7 +444,8 @@ func UserRoute(router *gin.Engine) {
 			}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error building overview: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -470,7 +473,7 @@ func UserRoute(router *gin.Engine) {
 		if err != nil {
 			log.Printf("Error fetching price history: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch price history: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -533,7 +536,8 @@ func UserRoute(router *gin.Engine) {
 			}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error fetching transactions: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -648,7 +652,8 @@ func UserRoute(router *gin.Engine) {
 			}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error aggregating address %s: %v", param, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -665,18 +670,30 @@ func UserRoute(router *gin.Engine) {
 			log.Printf("error fetching transfer %s: %v", value, err)
 		}
 
+		// ReturnSingleTransfer returns a zero-value Transfer (no error path
+		// distinguishes "found" from "missing" for the transfers-collection
+		// fallback), so detect not-found via an empty TxHash and return 404
+		// instead of a misleading 200 with empty fields. The frontend tx page
+		// maps 404 to notFound().
+		if query.TxHash == "" {
+			c.JSON(http.StatusNotFound, gin.H{"error": "transaction not found"})
+			return
+		}
+
 		latestBlockNumber, err := db.GetLatestBlockFromSyncState()
 		if err != nil {
+			log.Printf("error getting latest block: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to get latest block: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
 
 		latestBlockNum, err := parseHexBlockNumber(latestBlockNumber)
 		if err != nil {
+			log.Printf("error parsing latest block number %q: %v", latestBlockNumber, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to parse block number: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -903,7 +920,8 @@ func UserRoute(router *gin.Engine) {
 			}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error fetching latest block: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -933,7 +951,8 @@ func UserRoute(router *gin.Engine) {
 			return gin.H{"richlist": db.ReturnRichlist()}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error fetching richlist: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -1016,7 +1035,8 @@ func UserRoute(router *gin.Engine) {
 			return gin.H{"blocks": blocks, "total": countBlocks, "blockActivity": blockActivity}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error fetching blocks: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -1033,7 +1053,8 @@ func UserRoute(router *gin.Engine) {
 			return gin.H{"response": query}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error fetching block sizes: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -1045,8 +1066,9 @@ func UserRoute(router *gin.Engine) {
 
 		result, err := db.GetEpochs(page, limit)
 		if err != nil {
+			log.Printf("error fetching epochs: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch epochs: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1070,8 +1092,9 @@ func UserRoute(router *gin.Engine) {
 			return db.ReturnValidators(pageToken)
 		})
 		if err != nil {
+			log.Printf("error fetching validators: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch validators: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1088,8 +1111,9 @@ func UserRoute(router *gin.Engine) {
 				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 				return
 			}
+			log.Printf("error fetching epoch detail %s: %v", epochId, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch epoch detail: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1100,8 +1124,9 @@ func UserRoute(router *gin.Engine) {
 	router.GET("/epoch", func(c *gin.Context) {
 		epochInfo, err := db.GetEpochInfo()
 		if err != nil {
+			log.Printf("error fetching epoch info: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch epoch info: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1114,8 +1139,9 @@ func UserRoute(router *gin.Engine) {
 
 		history, err := db.GetValidatorHistory(limit)
 		if err != nil {
+			log.Printf("error fetching validator history: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch validator history: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1126,8 +1152,9 @@ func UserRoute(router *gin.Engine) {
 	router.GET("/validators/stats", func(c *gin.Context) {
 		stats, err := db.GetValidatorStats()
 		if err != nil {
+			log.Printf("error fetching validator stats: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch validator stats: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1167,7 +1194,8 @@ func UserRoute(router *gin.Engine) {
 			return gin.H{"response": query}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error fetching latest transactions: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -1185,7 +1213,8 @@ func UserRoute(router *gin.Engine) {
 			return counts, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error counting contracts by standard: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -1222,8 +1251,9 @@ func UserRoute(router *gin.Engine) {
 
 		query, total, err := db.ReturnContracts(page, limit, search, isTokenFilter, standardFilter)
 		if err != nil {
+			log.Printf("error fetching contracts: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch contracts: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1327,7 +1357,7 @@ func UserRoute(router *gin.Engine) {
 		if err != nil {
 			log.Printf("Error fetching non-zero transactions: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch transactions: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1372,7 +1402,7 @@ func UserRoute(router *gin.Engine) {
 		if err != nil {
 			log.Printf("Error fetching token transfers for %s: %v", address, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch token transfers: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1685,7 +1715,8 @@ func UserRoute(router *gin.Engine) {
 			}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error computing pending-tx eta %s: %v", hash, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		if v == nil {
@@ -1759,7 +1790,8 @@ func UserRoute(router *gin.Engine) {
 			}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error computing gas summary: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -1792,7 +1824,8 @@ func UserRoute(router *gin.Engine) {
 			return gin.H{"range": rng, "data": rows}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error fetching gas history: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)

--- a/backendAPI/routes/routes_test.go
+++ b/backendAPI/routes/routes_test.go
@@ -1,0 +1,94 @@
+package routes
+
+import "testing"
+
+// These cover the path-param format guards added to reject malformed
+// input at the route boundary (HTTP 400) before it reaches the db layer.
+// The accepted shapes mirror the frontend search resolver
+// (ExplorerFrontend/app/lib/searchResolver.ts).
+
+func TestIsValidTxHash(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"canonical 0x + 64 hex", "0x" + repeat("a", 64), true},
+		{"uppercase hex body", "0x" + repeat("AB", 32), true},
+		{"missing 0x prefix", repeat("a", 64), false},
+		{"one char short", "0x" + repeat("a", 63), false},
+		{"one char too long", "0x" + repeat("a", 65), false},
+		{"non-hex char", "0x" + repeat("g", 64), false},
+		{"address mistaken for hash", "Q" + repeat("a", 40), false},
+		{"empty", "", false},
+		{"mongo-operator injection attempt", `0x"; return true; //`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidTxHash(tc.in); got != tc.want {
+				t.Errorf("isValidTxHash(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsValidAddressParam(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"Q + 40 hex", "Q" + repeat("a", 40), true},
+		{"lowercase q + 40 hex", "q" + repeat("a", 40), true},
+		{"0x + 40 hex contract form", "0x" + repeat("a", 40), true},
+		{"uppercase 0X prefix", "0X" + repeat("AB", 20), true},
+		{"bare 40 hex rejected", repeat("a", 40), false},
+		{"too short", "Q" + repeat("a", 39), false},
+		{"too long", "Q" + repeat("a", 41), false},
+		{"tx hash rejected", "0x" + repeat("a", 64), false},
+		{"non-hex body", "Q" + repeat("z", 40), false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidAddressParam(tc.in); got != tc.want {
+				t.Errorf("isValidAddressParam(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsValidValidatorID(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"decimal index", "1", true},
+		{"large decimal index", "1048576", true},
+		{"zero index", "0", true},
+		{"bare hex pubkey", repeat("ab", 48), true},
+		{"0x-prefixed hex pubkey", "0x" + repeat("ab", 48), true},
+		{"odd-length hex rejected", "abc", false},
+		{"non-hex rejected", "xyz", false},
+		{"empty", "", false},
+		{"injection attempt", `{"$ne":null}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidValidatorID(tc.in); got != tc.want {
+				t.Errorf("isValidValidatorID(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// repeat returns s concatenated n times. Local helper so the table cases
+// stay readable without importing strings.Repeat at every call site.
+func repeat(s string, n int) string {
+	out := make([]byte, 0, len(s)*n)
+	for i := 0; i < n; i++ {
+		out = append(out, s...)
+	}
+	return string(out)
+}

--- a/backendAPI/routes/verification_routes.go
+++ b/backendAPI/routes/verification_routes.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -113,7 +114,8 @@ func RegisterVerificationRoutes(router *gin.Engine) {
 			},
 		}
 		if err := db.CreateVerificationJob(job); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "create job: " + err.Error()})
+			log.Printf("create verification job %s: %v", jobID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 
@@ -130,7 +132,8 @@ func RegisterVerificationRoutes(router *gin.Engine) {
 		jobID := c.Param("jobId")
 		job, err := db.GetVerificationJob(jobID)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "lookup: " + err.Error()})
+			log.Printf("lookup verification job %s: %v", jobID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		if job == nil {


### PR DESCRIPTION
## Summary

Batch 5: medium-severity bugs, security hardening, and indexes. **Stacked on #138** (base `fix/codebase-review-batch4`); GitHub retargets to `dev` as the stack merges. Review #135 to #138 first.

Several other mediums were verified as already-working (contracts page=0 is intentionally 0-indexed, validators/history limit is read correctly, holders field names match) or already fixed in earlier batches (Rollback companion cleanup, /debug/blocks, dead address-client, port 8080), so they are not re-touched here.

## Backend (backendAPI)
- **`/tx/:hash` returns 404** when the transaction is not found (was 200 with empty fields).
- **No raw MongoDB error leakage:** 5xx paths log server-side and return a generic `internal server error`; validation 400s/404s keep their specific messages.
- **`HexToInt`** uses `ParseUint` + range check so high-bit hex block numbers no longer truncate to 0 in epoch math.
- **Contract search** requires >= 3 chars before the case-insensitive `$regex`, cutting full-collection scans.
- **Bounded reads:** `ReturnBlockSizes` `SetLimit(2000)`; `GetPriceHistory` `all` interval `SetLimit(5000)`.
- **Indexes:** `blocks {result.transactions.hash}`, `contractCode {creationTransaction}` sparse, `tokenTransfers` `{contractAddress,blockNumber}` / `{from,blockNumber}` / `{to,blockNumber}` / `{txHash}`.
- **Fail-fast env validation** (MONGOURI, NODE_URL) before serving.

## Syncer (QRL2MongoDB)
- **`GetContractByAddress`** normalizes the address (`ConvertToQAddress`) so lookups match canonical-Q storage.
- **pending_token_contracts** index creation ignores AlreadyExists/conflict.
- **Rollback** runs under a 60s context timeout instead of `context.Background()`.
- **Fail-fast env validation** (MONGOURI, NODE_URLS/NODE_URL) before sync.

## Frontend (ExplorerFrontend)
- **chainId** corrected from `0x7e7e` to `0x539` (1337) in the synthetic pending-tx fallback.
- **Pending pagination** uses `router.push` instead of `window.location.href` (no full reload, keeps query cache).
- **loading.tsx** added for richlist, epochs, contracts (validators and gas are client-fetched, so a loading.tsx would not fire; correctly skipped).

## Validation
- backendAPI: build/vet/test clean, gofmt clean. QRL2MongoDB: build/vet clean, gofmt clean. ExplorerFrontend: tsc clean, lint 0 errors.

## Deferred (need migration/schema work)
- `tokenTransfers` `blockNumberInt` sort field (hex-string sort mis-orders past 0xffff) - needs the field + a backfill of existing rows.
- `Address.Balance` float32 precision loss - model type change + migration.

## Ops note
The new indexes build on next backend start; on large `blocks`/`tokenTransfers` collections the initial build can take time and I/O.
