### PR TITLE
fix: Address.Balance precision + broken circulating-supply decode (batch 10)

### DIFF
--- a/ExplorerFrontend/app/address/[query]/address-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-view.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import CopyButton from "../../components/CopyButton";
 import QRCodeButton from "../../components/QRCodeButton";
 import ContractTabs from "../../components/ContractTabs";

--- a/ExplorerFrontend/app/address/[query]/panels/_table-utils.tsx
+++ b/ExplorerFrontend/app/address/[query]/panels/_table-utils.tsx
@@ -1,8 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { flexRender } from '@tanstack/react-table';
 import type { Cell, Header, HeaderGroup, Row, Table } from '@tanstack/react-table';
+
+// Re-exported from the shared hooks module so existing panel imports
+// (`useIsMobile` from this file) keep working after consolidation.
+export { useIsMobile } from '../../../lib/hooks';
 
 /**
  * Shared TanStack table primitives for the address-page tab panels.
@@ -129,19 +132,3 @@ export const Paginator = ({
   );
 };
 
-/**
- * Mobile / desktop switch for panels that render a card list under the
- * 768px breakpoint and a `<table>` above it. Lifted out of the old
- * TanStackTable so every panel can use the same threshold instead of
- * redefining the listener.
- */
-export const useIsMobile = (breakpointPx = 768): boolean => {
-  const [isMobile, setIsMobile] = useState(false);
-  useEffect(() => {
-    const check = (): void => setIsMobile(window.innerWidth < breakpointPx);
-    check();
-    window.addEventListener('resize', check);
-    return () => window.removeEventListener('resize', check);
-  }, [breakpointPx]);
-  return isMobile;
-};

--- a/ExplorerFrontend/app/address/layout.tsx
+++ b/ExplorerFrontend/app/address/layout.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { ReactNode } from "react";
 
 export default function AddressLayout({

--- a/ExplorerFrontend/app/block/[query]/block-detail-client.tsx
+++ b/ExplorerFrontend/app/block/[query]/block-detail-client.tsx
@@ -6,7 +6,7 @@ import { useSearchParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import config from '../../../config';
 import Link from 'next/link';
-import { formatAmount, truncateHash, timeAgo, formatPlanckAdaptive } from '../../lib/helpers';
+import { formatAmount, truncateHash, timeAgo, formatPlanckAdaptive, formatNumberWithCommas, hexToNumber } from '../../lib/helpers';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import DetailRow from '../../components/DetailRow';
 import CopyButton from '../../components/CopyButton';
@@ -66,15 +66,6 @@ type Block = {
 interface BlockDetailClientProps {
   blockNumber: string;
 }
-
-const formatHexValue = (hex: string | null | undefined): string => {
-  if (!hex) return '0';
-  const num = typeof hex === 'string' && hex.startsWith('0x')
-    ? parseInt(hex, 16)
-    : parseInt(hex);
-  if (isNaN(num)) return '0';
-  return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-};
 
 const formatTimestampUTC = (timestamp: string | null | undefined): string => {
   if (!timestamp) return 'N/A';
@@ -266,7 +257,7 @@ export default function BlockDetailClient({ blockNumber }: BlockDetailClientProp
             <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-[#ffa729]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5} aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
             </svg>
-            <h1 id="block-heading" className="text-xl sm:text-2xl font-bold text-[#ffa729]">Block #{formatHexValue(blockData.number)}</h1>
+            <h1 id="block-heading" className="text-xl sm:text-2xl font-bold text-[#ffa729]">Block #{formatNumberWithCommas(hexToNumber(blockData.number).toString())}</h1>
             {/* Live depth: surfaces how settled this block is. "Latest"
                 when we're looking at the head, otherwise "N
                 confirmations". Hidden until the first /latestblock
@@ -320,8 +311,8 @@ export default function BlockDetailClient({ blockNumber }: BlockDetailClientProp
           <DetailRow label="Transactions">
             {blockData.transactions?.length ?? 0}
           </DetailRow>
-          <DetailRow label="Gas Used">{formatHexValue(blockData.gasUsed)}</DetailRow>
-          <DetailRow label="Gas Limit">{formatHexValue(blockData.gasLimit)}</DetailRow>
+          <DetailRow label="Gas Used">{formatNumberWithCommas(hexToNumber(blockData.gasUsed).toString())}</DetailRow>
+          <DetailRow label="Gas Limit">{formatNumberWithCommas(hexToNumber(blockData.gasLimit).toString())}</DetailRow>
           <DetailRow label="Base Fee">
             {(() => {
               const [val, unit] = formatPlanckAdaptive(blockData.baseFeePerGas);

--- a/ExplorerFrontend/app/components/AnimatedLogo.tsx
+++ b/ExplorerFrontend/app/components/AnimatedLogo.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import React from "react"
+import Image from "next/image"
 
 /**
  * ZondScan logo with a lightweight video animation.
@@ -34,11 +35,13 @@ export default function AnimatedLogo({
 
   return (
     <div className={`relative h-full w-full ${className}`}>
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
+      <Image
         src="/ZondScan_Logo_static.webp"
         alt={alt}
-        className="absolute inset-0 h-full w-full object-contain"
+        fill
+        priority
+        sizes="(max-width: 768px) 50vw, 200px"
+        className="object-contain"
       />
       <video
         ref={videoRef}

--- a/ExplorerFrontend/app/components/Footer.tsx
+++ b/ExplorerFrontend/app/components/Footer.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Link from 'next/link';
 
 export default function Footer(): JSX.Element {

--- a/ExplorerFrontend/app/components/TradingViewWidget.tsx
+++ b/ExplorerFrontend/app/components/TradingViewWidget.tsx
@@ -2,9 +2,17 @@
 
 import React, { useEffect, useRef } from 'react';
 
+interface TradingViewWidgetConstructor {
+  new (config: Record<string, unknown>): unknown;
+}
+
+interface TradingViewNamespace {
+  widget: TradingViewWidgetConstructor;
+}
+
 declare global {
   interface Window {
-    TradingView: any;
+    TradingView?: TradingViewNamespace;
   }
 }
 

--- a/ExplorerFrontend/app/contracts/contracts-client.tsx
+++ b/ExplorerFrontend/app/contracts/contracts-client.tsx
@@ -88,7 +88,9 @@ function TabButton({
   return (
     <button
       role="tab"
+      id={`contracts-tab-${tab}`}
       aria-selected={active}
+      aria-controls="contracts-tabpanel"
       onClick={() => onSelect(tab)}
       className={`px-4 py-2 text-sm font-medium rounded-lg transition-all duration-200 ${
         active ? 'bg-[#ffa729] text-black' : 'bg-[#2d2d2d] text-gray-300 hover:bg-[#3d3d3d]'
@@ -320,7 +322,12 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
       </div>
 
       {/* Content */}
-      <div role="tabpanel" className="bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f] rounded-xl border border-[#3d3d3d] overflow-hidden">
+      <div
+        role="tabpanel"
+        id="contracts-tabpanel"
+        aria-labelledby={`contracts-tab-${activeTab}`}
+        className="bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f] rounded-xl border border-[#3d3d3d] overflow-hidden"
+      >
         {loading ? (
           <div className="p-4 space-y-4">
             {[...Array(5)].map((_, i) => (

--- a/ExplorerFrontend/app/contracts/loading.tsx
+++ b/ExplorerFrontend/app/contracts/loading.tsx
@@ -1,0 +1,28 @@
+/**
+ * Route-level skeleton for /contracts. The page is server-rendered and
+ * awaits the /contracts fetch, so without a fallback the page is briefly
+ * blank between click and data.
+ *
+ * Shape mirrors ContractsClient: header + tab strip stub and a stack of
+ * contract row placeholders.
+ */
+export default function Loading(): JSX.Element {
+  return (
+    <div role="status" aria-label="Loading contracts" className="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8">
+      <div className="mb-6">
+        <h1 className="text-xl sm:text-2xl font-bold text-[#ffa729] mb-2">Smart Contracts</h1>
+        <div className="flex gap-2">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="h-9 w-28 bg-[#2d2d2d] rounded-lg animate-pulse" />
+          ))}
+        </div>
+      </div>
+
+      <div className="p-4 space-y-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="h-16 bg-gray-700/30 rounded animate-pulse" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ExplorerFrontend/app/epochs/loading.tsx
+++ b/ExplorerFrontend/app/epochs/loading.tsx
@@ -1,0 +1,48 @@
+/**
+ * Route-level skeleton for /epochs/<page>. The page is server-rendered
+ * and awaits the beacon-chain epochs fetch (force-dynamic), so without a
+ * fallback the page is briefly blank between click and data.
+ *
+ * Shape mirrors EpochsClient: header + search bar stub + the six-column
+ * epochs table so the transition reads as "the data is filling in".
+ */
+export default function Loading(): JSX.Element {
+  return (
+    <div role="status" aria-label="Loading epochs" className="p-4 sm:p-8 max-w-6xl mx-auto">
+      <h1 className="text-xl sm:text-2xl font-bold mb-4 text-[#ffa729]">Epochs</h1>
+
+      <div className="mb-6">
+        <div className="h-11 w-full bg-[#1e1e1e] border border-[#2a2a2a] rounded-lg animate-pulse" />
+      </div>
+
+      <div className="rounded-xl bg-[#1e1e1e] border border-[#2a2a2a] overflow-hidden mb-6">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[#2a2a2a]">
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Epoch</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Time</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider">Status</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden sm:table-cell">Validators</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden sm:table-cell">Active</th>
+                <th className="text-left px-4 py-3 text-[11px] font-normal text-gray-600 uppercase tracking-wider hidden md:table-cell">Total Staked</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from({ length: 15 }).map((_, i) => (
+                <tr key={i} className="border-b border-[#2a2a2a] last:border-b-0">
+                  <td className="px-4 py-3"><div className="h-4 w-12 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-3"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-3"><div className="h-4 w-16 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-3 hidden sm:table-cell"><div className="h-4 w-10 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-3 hidden sm:table-cell"><div className="h-4 w-10 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                  <td className="px-4 py-3 hidden md:table-cell"><div className="h-4 w-24 bg-[#2a2a2a] rounded animate-pulse" /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ExplorerFrontend/app/error.tsx
+++ b/ExplorerFrontend/app/error.tsx
@@ -19,7 +19,7 @@ export default function Error({ error, reset }: { error: Error & { digest?: stri
         <h2 className="text-xl font-semibold text-white mb-2">Something went wrong</h2>
         <p className="text-gray-400 mb-6">An unexpected error occurred while loading this page.</p>
         <div className="flex gap-3 justify-center">
-          <button onClick={reset} className="px-4 py-2 text-sm font-medium rounded-lg bg-[#ffa729] text-black hover:bg-[#ffb952] transition-colors">
+          <button type="button" onClick={reset} className="px-4 py-2 text-sm font-medium rounded-lg bg-[#ffa729] text-black hover:bg-[#ffb952] transition-colors">
             Try again
           </button>
           <Link href="/" className="px-4 py-2 text-sm font-medium rounded-lg bg-[#2d2d2d] text-gray-300 border border-[#3d3d3d] hover:border-[#ffa729] hover:text-white transition-colors">

--- a/ExplorerFrontend/app/home-client.tsx
+++ b/ExplorerFrontend/app/home-client.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import axios from 'axios';
 import { useQuery } from '@tanstack/react-query';
 import { formatNumberWithCommas, timeAgo, formatStaked, formatGasPrice, truncateHash, formatAmount, formatAddress } from './lib/helpers';
+import type { EpochInfo } from './types';
 import config from '../config.js';
 import SearchBar from './components/SearchBar';
 
@@ -20,24 +21,14 @@ const Charts = dynamic(() => import('./components/Charts'), {
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
-interface EpochInfo {
-  headEpoch: string;
-  headSlot: string;
-  finalizedEpoch: string;
-  justifiedEpoch: string;
-  slotsPerEpoch: number;
-  secondsPerSlot: number;
-  slotInEpoch: number;
-  timeToNextEpoch: number;
-  updatedAt: number;
-}
-
 interface BlockResult {
   number: string;
   timestamp: string;
   hash: string;
   miner: string;
-  transactions: any[];
+  // Only `.length` is read on the home page; the per-tx shape varies by
+  // endpoint, so `unknown[]` keeps it honest without inventing a type.
+  transactions: unknown[];
 }
 
 interface TxResult {

--- a/ExplorerFrontend/app/lib/helpers.ts
+++ b/ExplorerFrontend/app/lib/helpers.ts
@@ -11,6 +11,15 @@ function keccakHex(sig: string): string {
   return bytesToHex(keccak_256(utf8ToBytes(sig)));
 }
 
+// Canonical transaction-hash shape: "0x" + exactly 64 hex chars. Shared so
+// the tx page, pending-tx page, and search resolver all validate identically.
+export const TX_HASH_RE = /^0x[0-9a-fA-F]{64}$/;
+
+/** True when `value` is a well-formed "0x"-prefixed 32-byte transaction hash. */
+export function isTxHash(value: string | undefined | null): boolean {
+  return !!value && TX_HASH_RE.test(value);
+}
+
 export function timeAgo(unixSeconds: number): string {
   const now = Math.floor(Date.now() / 1000);
   const diff = now - unixSeconds;

--- a/ExplorerFrontend/app/lib/hooks.ts
+++ b/ExplorerFrontend/app/lib/hooks.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Mobile / desktop switch for components that render a card list under the
+ * breakpoint and a `<table>` (or wider layout) above it. SSR-safe: starts
+ * false on the server and resyncs on mount + every resize.
+ *
+ * Single shared implementation so the address-page table panels and the
+ * transaction detail view use the same threshold instead of redefining the
+ * resize listener each time.
+ */
+export const useIsMobile = (breakpointPx = 768): boolean => {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const check = (): void => setIsMobile(window.innerWidth < breakpointPx);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, [breakpointPx]);
+  return isMobile;
+};

--- a/ExplorerFrontend/app/lib/searchResolver.ts
+++ b/ExplorerFrontend/app/lib/searchResolver.ts
@@ -16,13 +16,15 @@
  * generic "Invalid input".
  */
 
+import { TX_HASH_RE } from './helpers';
+
 export type SearchResolution =
   | { path: string }
   | { error: string };
 
 const RE_DECIMAL = /^[0-9]+$/;
 const RE_HEX_BLOCK = /^0x[0-9a-fA-F]{1,16}$/;
-const RE_TX_HASH = /^0x[0-9a-fA-F]{64}$/;
+const RE_TX_HASH = TX_HASH_RE;
 const RE_BARE_TX_HASH = /^[0-9a-fA-F]{64}$/;
 const RE_Q_ADDR = /^[Qq][0-9a-fA-F]{40}$/;
 const RE_HEX_ADDR = /^0x[0-9a-fA-F]{40}$/;

--- a/ExplorerFrontend/app/pending/[query]/PendingList.tsx
+++ b/ExplorerFrontend/app/pending/[query]/PendingList.tsx
@@ -54,6 +54,7 @@ export default function PendingList({ initialData, currentPage }: PendingListPro
     queryFn: () => fetchPendingTransactions(currentPage),
     initialData,
     refetchInterval: 5000,
+    refetchIntervalInBackground: false,
   });
 
   const handleRefresh = async (): Promise<void> => {

--- a/ExplorerFrontend/app/pending/[query]/PendingList.tsx
+++ b/ExplorerFrontend/app/pending/[query]/PendingList.tsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import React, { useState } from 'react';
 import config from '../../../config';
 import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { formatAmount, formatGasPrice, timeAgo, truncateHash } from '../../lib/helpers';
 import type { PendingTransaction } from '@/app/types';
@@ -46,6 +47,7 @@ interface PendingListProps {
 }
 
 export default function PendingList({ initialData, currentPage }: PendingListProps): JSX.Element {
+  const router = useRouter();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const { data, isError, error, refetch, isFetching } = useQuery({
     queryKey: ['pending-transactions', currentPage],
@@ -173,8 +175,8 @@ export default function PendingList({ initialData, currentPage }: PendingListPro
             <Pagination
               currentPage={currentPage}
               totalPages={totalPages}
-              onPrevious={() => window.location.href = `/pending/${Math.max(currentPage - 1, 1)}`}
-              onNext={() => window.location.href = `/pending/${Math.min(currentPage + 1, totalPages)}`}
+              onPrevious={() => router.push(`/pending/${Math.max(currentPage - 1, 1)}`)}
+              onNext={() => router.push(`/pending/${Math.min(currentPage + 1, totalPages)}`)}
             />
           )}
         </>

--- a/ExplorerFrontend/app/pending/tx/[hash]/page.tsx
+++ b/ExplorerFrontend/app/pending/tx/[hash]/page.tsx
@@ -94,7 +94,7 @@ async function getTransactionStatus(hash: string): Promise<{
               blockNumber: tx.blockNumber?.toString(),
               accessList: [],
               blockHash: null,
-              chainId: '0x7e7e', // Zond chainId
+              chainId: '0x539', // QRL testnet v2 chainId (1337)
               from: tx.from || '',
               gas: tx.gas || '0x0',
               gasPrice: tx.gasPrice || '0x0',

--- a/ExplorerFrontend/app/pending/tx/[hash]/page.tsx
+++ b/ExplorerFrontend/app/pending/tx/[hash]/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation';
 import config from '../../../../config';
 import type { PendingTransaction } from '@/app/types';
 import { sharedMetadata } from '@/app/lib/seo/metaData';
+import { isTxHash } from '@/app/lib/helpers';
 import PendingTransactionView from './pending-transaction-view';
 
 interface PageProps {
@@ -49,8 +50,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 function validateTransactionHash(hash: string): boolean {
-  const hashRegex = /^0x[0-9a-fA-F]{64}$/;
-  return hashRegex.test(hash);
+  return isTxHash(hash);
 }
 
 async function getTransactionStatus(hash: string): Promise<{
@@ -77,11 +77,11 @@ async function getTransactionStatus(hash: string): Promise<{
       blockNumber: tx.blockNumber,
       targetContract: response.data.targetContract,
     };
-  } catch (error: any) {
+  } catch (error) {
     console.error('Error fetching transaction status:', error);
-    
+
     // If we got a 404, check if it exists in regular transactions
-    if (error.response?.status === 404) {
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
       try {
         const txResponse = await axios.get(`${config.handlerUrl}/tx/${hash}`);
         if (txResponse.data?.response) {

--- a/ExplorerFrontend/app/pending/tx/[hash]/pending-transaction-view.tsx
+++ b/ExplorerFrontend/app/pending/tx/[hash]/pending-transaction-view.tsx
@@ -134,6 +134,7 @@ export default function PendingTransactionView({ pendingTx, targetContract }: Pe
       }
     },
     refetchInterval: 5000,
+    refetchIntervalInBackground: false,
     enabled: statusQuery.data?.status === 'pending',
   });
 

--- a/ExplorerFrontend/app/richlist/loading.tsx
+++ b/ExplorerFrontend/app/richlist/loading.tsx
@@ -1,0 +1,45 @@
+/**
+ * Route-level skeleton for /richlist. The page is server-rendered and
+ * awaits the /richlist fetch (force-dynamic), so without a fallback the
+ * page is briefly blank between click and data.
+ *
+ * Shape mirrors RichlistClient: header + subtitle and the three-column
+ * (rank / address / balance) table card.
+ */
+export default function Loading(): JSX.Element {
+  return (
+    <div role="status" aria-label="Loading rich list" className="min-h-screen">
+      <div className="max-w-[1200px] mx-auto p-4 md:p-8">
+        <div className="mb-6 md:mb-8">
+          <h1 className="text-xl md:text-2xl font-bold text-[#ffa729]">Richlist</h1>
+          <p className="text-sm md:text-base text-gray-400 mt-2">
+            Top 50 QRL holders by balance
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-[#3d3d3d] bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f] shadow-xl overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="min-w-full">
+              <thead>
+                <tr className="border-b border-[#3d3d3d]">
+                  <th className="px-3 md:px-6 py-3 md:py-4 text-left text-xs md:text-sm font-medium text-[#ffa729]">Rank</th>
+                  <th className="px-3 md:px-6 py-3 md:py-4 text-left text-xs md:text-sm font-medium text-[#ffa729]">Address</th>
+                  <th className="px-3 md:px-6 py-3 md:py-4 text-right text-xs md:text-sm font-medium text-[#ffa729]">Balance</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[#3d3d3d]">
+                {Array.from({ length: 10 }).map((_, i) => (
+                  <tr key={i} className="border-b border-[#3d3d3d]">
+                    <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap"><div className="h-4 w-8 bg-[#3d3d3d] rounded animate-pulse" /></td>
+                    <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap"><div className="h-4 w-64 max-w-full bg-[#3d3d3d] rounded animate-pulse" /></td>
+                    <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap"><div className="h-4 w-24 bg-[#3d3d3d] rounded animate-pulse ml-auto" /></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ExplorerFrontend/app/richlist/richlist-client.tsx
+++ b/ExplorerFrontend/app/richlist/richlist-client.tsx
@@ -4,8 +4,13 @@ import React from "react";
 import Link from "next/link";
 import { toFixed } from "../lib/helpers";
 
+interface RichlistEntry {
+  id: string;
+  balance: string | number;
+}
+
 interface RichlistProps {
-  richlist: any[];
+  richlist: RichlistEntry[];
 }
 
 export default function RichlistClient({ richlist }: RichlistProps): JSX.Element {
@@ -24,7 +29,7 @@ export default function RichlistClient({ richlist }: RichlistProps): JSX.Element
 
   const renderMobileView = (): JSX.Element => (
     <div className="space-y-4">
-      {safeRichlist.map((item: any, index: number) => (
+      {safeRichlist.map((item, index) => (
         <div
           key={item.id}
           className="p-4 rounded-lg border border-[#3d3d3d] bg-gradient-to-br from-[#2d2d2d] to-[#1f1f1f]"
@@ -89,7 +94,7 @@ export default function RichlistClient({ richlist }: RichlistProps): JSX.Element
           </tr>
         </thead>
         <tbody className="divide-y divide-[#3d3d3d]">
-          {safeRichlist.map((item: any, index: number) => (
+          {safeRichlist.map((item, index) => (
             <tr
               key={item.id}
               className="border-b border-[#3d3d3d] hover:bg-[rgba(255,167,41,0.05)] transition-colors"

--- a/ExplorerFrontend/app/tx/[query]/page.tsx
+++ b/ExplorerFrontend/app/tx/[query]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from 'next/navigation';
 import TransactionView from './transaction-view';
 import type { TransactionDetails } from '@/app/types';
 import { sharedMetadata } from '@/app/lib/seo/metaData';
+import { isTxHash } from '@/app/lib/helpers';
 import config from '../../../config';
 
 interface PageProps {
@@ -70,8 +71,7 @@ function isEmptyTransaction(txData: MaybeTxRecord): boolean {
 
 async function getTransaction(txHash: string): Promise<TransactionDetails> {
   // Validate transaction hash format
-  const hashRegex = /^0x[0-9a-fA-F]{64}$/;
-  if (!hashRegex.test(txHash)) {
+  if (!isTxHash(txHash)) {
     throw new Error('Invalid transaction hash format');
   }
 
@@ -152,8 +152,7 @@ export default async function TransactionPage({ params }: PageProps): Promise<JS
   const resolvedParams = await params;
   const txHash = resolvedParams.query;
 
-  const hashRegex = /^0x[0-9a-fA-F]{64}$/;
-  if (!hashRegex.test(txHash)) {
+  if (!isTxHash(txHash)) {
     return (
       <div className="container mx-auto px-4">
         <div className="bg-red-900/20 border border-red-500/50 rounded-xl p-6 shadow-lg mt-6">

--- a/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
+++ b/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import React, { useState, useEffect, Suspense } from 'react';
+import { Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import axios from 'axios';
 import { useQuery } from '@tanstack/react-query';
 import { type TransactionDetails, getConfirmations, getTransactionStatus } from '@/app/types';
 import { formatAmount, formatTokenAmount, decodeEventLog, decodeTokenTransferInput, decodeContractCall } from '../../lib/helpers';
+import { useIsMobile } from '../../lib/hooks';
 import config from '../../../config';
 import CopyButton from '../../components/CopyButton';
 import Breadcrumbs from '../../components/Breadcrumbs';
@@ -84,16 +85,7 @@ interface TransactionViewProps {
 }
 
 export default function TransactionView({ transaction }: TransactionViewProps): JSX.Element {
-  const [isMobile, setIsMobile] = useState(false);
-
-  useEffect(() => {
-    const checkScreenSize = (): void => {
-      setIsMobile(window.innerWidth < 768);
-    };
-    checkScreenSize();
-    window.addEventListener('resize', checkScreenSize);
-    return () => window.removeEventListener('resize', checkScreenSize);
-  }, []);
+  const isMobile = useIsMobile();
 
   // Poll /latestblock so the confirmation count ticks up live; stops
   // once we cross the terminal-confirmations threshold to bound load

--- a/ExplorerFrontend/app/types/epoch.ts
+++ b/ExplorerFrontend/app/types/epoch.ts
@@ -1,0 +1,14 @@
+// Beacon-chain epoch snapshot surfaced by the backend and rendered on the
+// home page, the validators page, and the EpochInfoPanel. Shared here so the
+// three call sites stay in lock-step instead of each redeclaring the shape.
+export interface EpochInfo {
+  headEpoch: string;
+  headSlot: string;
+  finalizedEpoch: string;
+  justifiedEpoch: string;
+  slotsPerEpoch: number;
+  secondsPerSlot: number;
+  slotInEpoch: number;
+  timeToNextEpoch: number;
+  updatedAt: number;
+}

--- a/ExplorerFrontend/app/types/index.ts
+++ b/ExplorerFrontend/app/types/index.ts
@@ -21,6 +21,11 @@ export {
   type BlocksResponse,
 } from './block';
 
+// Epoch types
+export {
+  type EpochInfo,
+} from './epoch';
+
 // Address types
 export {
   type ContractData,

--- a/ExplorerFrontend/app/validators/components/EpochInfoPanel.tsx
+++ b/ExplorerFrontend/app/validators/components/EpochInfoPanel.tsx
@@ -1,18 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-
-interface EpochInfo {
-  headEpoch: string;
-  headSlot: string;
-  finalizedEpoch: string;
-  justifiedEpoch: string;
-  slotsPerEpoch: number;
-  secondsPerSlot: number;
-  slotInEpoch: number;
-  timeToNextEpoch: number;
-  updatedAt: number;
-}
+import type { EpochInfo } from '../../types';
 
 interface EpochInfoPanelProps {
   epochInfo: EpochInfo | null;

--- a/ExplorerFrontend/app/validators/components/ValidatorTable.tsx
+++ b/ExplorerFrontend/app/validators/components/ValidatorTable.tsx
@@ -228,7 +228,9 @@ export default function ValidatorTable({ validators, loading }: ValidatorTablePr
             </tr>
           </thead>
           <tbody className="divide-y divide-[#3d3d3d]">
-            {currentValidators.map((validator) => (
+            {currentValidators.map((validator) => {
+              const [stakeValue, stakeUnit] = formatValidatorStake(validator.stakedAmount);
+              return (
               <tr
                 key={validator.index}
                 className="hover:bg-[#2d2d2d]/30 cursor-pointer"
@@ -261,10 +263,11 @@ export default function ValidatorTable({ validators, loading }: ValidatorTablePr
                   {epochsToDays(validator.age).toFixed(1)} days
                 </td>
                 <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-300 font-mono">
-                  {formatValidatorStake(validator.stakedAmount)[0]} {formatValidatorStake(validator.stakedAmount)[1]}
+                  {stakeValue} {stakeUnit}
                 </td>
               </tr>
-            ))}
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/ExplorerFrontend/app/validators/validators-client.tsx
+++ b/ExplorerFrontend/app/validators/validators-client.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import config from '../../config';
+import type { EpochInfo } from '../types';
 import EpochInfoPanel from './components/EpochInfoPanel';
 import ValidatorStatsCards from './components/ValidatorStatsCards';
 import ValidatorStatusChart from './components/ValidatorStatusChart';
@@ -16,18 +17,6 @@ interface Validator {
   age: number;
   stakedAmount: string;
   isActive: boolean;
-}
-
-interface EpochInfo {
-  headEpoch: string;
-  headSlot: string;
-  finalizedEpoch: string;
-  justifiedEpoch: string;
-  slotsPerEpoch: number;
-  secondsPerSlot: number;
-  slotInEpoch: number;
-  timeToNextEpoch: number;
-  updatedAt: number;
 }
 
 interface ValidatorStats {

--- a/QRL2MongoDB/configs/setup.go
+++ b/QRL2MongoDB/configs/setup.go
@@ -14,7 +14,14 @@ import (
 )
 
 func ConnectDB() *mongo.Client {
-	client, err := mongo.NewClient(options.Client().ApplyURI(EnvMongoURI()))
+	uri := EnvMongoURI()
+	if uri == "" {
+		// Runs at package init (DB is an eager package-level var), so this is
+		// the real fail-fast point for a missing MONGOURI: a clear, actionable
+		// message instead of an opaque driver error.
+		log.Fatal("Required environment variable MONGOURI is not set")
+	}
+	client, err := mongo.NewClient(options.Client().ApplyURI(uri))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/QRL2MongoDB/configs/setup.go
+++ b/QRL2MongoDB/configs/setup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -264,7 +265,19 @@ func initializeCollections(db *mongo.Database) {
 		},
 	)
 	if err != nil {
-		Logger.Error("Failed to create index for pending token contracts collection", zap.Error(err))
+		// A previously-created index over the same (contractAddress, txHash)
+		// keys under a different name (e.g. the named "contract_tx_idx" set
+		// by db.InitializePendingTokenContractsCollection) makes Mongo reject
+		// this auto-named duplicate with IndexOptionsConflict. That is benign:
+		// the index already exists, so do not treat it as an error.
+		msg := err.Error()
+		if strings.Contains(msg, "IndexOptionsConflict") ||
+			strings.Contains(msg, "IndexKeySpecsConflict") ||
+			strings.Contains(msg, "already exists") {
+			Logger.Info("Pending token contracts unique index already exists, skipping")
+		} else {
+			Logger.Error("Failed to create index for pending token contracts collection", zap.Error(err))
+		}
 	}
 
 	// Also add index on the processed field for efficient querying

--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -351,6 +351,45 @@ func StoreInitialSyncStartBlock(blockNumber string) error {
 }
 
 // BlockExists checks if a block with the given number already exists in the database
+// BlocksExist returns the set of the given block numbers that already exist in
+// the blocks collection, as a map[blockNumber]bool. It runs a single $in query
+// rather than one round-trip per block, so the batch consumer can check a whole
+// batch (128/256 blocks) at once. A block absent from the returned map is not
+// present in the DB. On query error it returns a nil map (callers treat every
+// block as new, i.e. reprocess, which is the safe direction).
+func BlocksExist(blockNumbers []string) (map[string]bool, error) {
+	if len(blockNumbers) == 0 {
+		return map[string]bool{}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	filter := bson.M{"result.number": bson.M{"$in": blockNumbers}}
+	projection := options.Find().SetProjection(bson.M{"result.number": 1, "_id": 0})
+
+	cursor, err := configs.BlocksCollections.Find(ctx, filter, projection)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var results []struct {
+		Result struct {
+			Number string `bson:"number"`
+		} `bson:"result"`
+	}
+	if err := cursor.All(ctx, &results); err != nil {
+		return nil, err
+	}
+
+	existsMap := make(map[string]bool, len(results))
+	for _, r := range results {
+		existsMap[r.Result.Number] = true
+	}
+	return existsMap, nil
+}
+
 func BlockExists(blockNumber string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -595,8 +595,20 @@ func Rollback(blockNumber string) error {
 		return err
 	}
 
-	// Log blocks being removed
+	// Collect the exact hex block-number strings of the blocks being removed.
+	// The companion collections (transfer, transactionByAddress,
+	// tokenTransfers, tokenBalances) store blockNumber as the raw hex string
+	// (e.g. "0x1a2b"), NOT an int, so a numeric $gt range filter like the one
+	// used on the blocks collection would be unsafe here (hex strings lex-sort
+	// wrong, "0xa" > "0x100"). Matching the exact set of removed block numbers
+	// with $in is precise: it deletes rows for the rolled-back blocks and
+	// nothing else.
+	badBlockNumbers := make([]string, 0, len(blocks))
 	for _, block := range blocks {
+		if block.Result.Number != "" {
+			badBlockNumbers = append(badBlockNumbers, block.Result.Number)
+		}
+		// Log blocks being removed
 		configs.Logger.Info("Rolling back block",
 			zap.String("number", block.Result.Number),
 			zap.String("hash", block.Result.Hash))
@@ -616,6 +628,42 @@ func Rollback(blockNumber string) error {
 		_, err := configs.BlocksCollections.DeleteMany(sessCtx, filter)
 		if err != nil {
 			return nil, err
+		}
+
+		// Delete companion rows for the removed blocks so a rolled-back block
+		// leaves no orphans. All three of these collections key blockNumber as
+		// the raw hex string, so the exact-match $in filter is correct.
+		//
+		// NOT cleaned here (intentional, see report):
+		//   - internalTransactionByAddress stores no block-number field at all
+		//     (only blockTimestamp), so there is nothing to filter on. We do not
+		//     fabricate one. Orphan internal-tx rows may linger after a reorg;
+		//     flagged for manual review.
+		//   - tokenBalances is a last-write-wins snapshot keyed on
+		//     (contractAddress, holderAddress), not a per-block append. We delete
+		//     only the snapshots whose last update happened in a rolled-back
+		//     block (blockNumber $in badBlockNumbers); those values are stale and
+		//     get re-derived from RPC when the block is reprocessed. Snapshots
+		//     last touched by an older block are left intact.
+		if len(badBlockNumbers) > 0 {
+			companionFilter := bson.M{"blockNumber": bson.M{"$in": badBlockNumbers}}
+
+			if _, err := configs.TransferCollections.DeleteMany(sessCtx, companionFilter); err != nil {
+				return nil, fmt.Errorf("rollback: failed to delete transfer rows: %w", err)
+			}
+			if _, err := configs.TransactionByAddressCollections.DeleteMany(sessCtx, companionFilter); err != nil {
+				return nil, fmt.Errorf("rollback: failed to delete transactionByAddress rows: %w", err)
+			}
+
+			tokenTransfers := configs.GetTokenTransfersCollection()
+			if _, err := tokenTransfers.DeleteMany(sessCtx, companionFilter); err != nil {
+				return nil, fmt.Errorf("rollback: failed to delete tokenTransfers rows: %w", err)
+			}
+
+			tokenBalances := configs.GetTokenBalancesCollection()
+			if _, err := tokenBalances.DeleteMany(sessCtx, companionFilter); err != nil {
+				return nil, fmt.Errorf("rollback: failed to delete tokenBalances rows: %w", err)
+			}
 		}
 
 		// Update sync state

--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -644,9 +644,11 @@ func Rollback(blockNumber string) error {
 		//     balances from RPC whenever a contract is next processed, so a
 		//     left-in-place snapshot self-heals; a deleted one does not. Leave
 		//     it untouched.
-		//   - internalTransactionByAddress stores no block-number field (only
-		//     blockTimestamp), so there is nothing to filter on. Orphan
-		//     internal-tx rows may linger after a reorg; flagged for follow-up.
+		//
+		// internalTransactionByAddress now stores blockNumber (raw hex string),
+		// so it is cleaned here too. Rows written by an older syncer before that
+		// field existed lack blockNumber and will not match the $in filter, so
+		// pre-existing orphans cannot be cleaned retroactively; that is expected.
 		if len(badBlockNumbers) > 0 {
 			companionFilter := bson.M{"blockNumber": bson.M{"$in": badBlockNumbers}}
 
@@ -655,6 +657,9 @@ func Rollback(blockNumber string) error {
 			}
 			if _, err := configs.TransactionByAddressCollections.DeleteMany(sessCtx, companionFilter); err != nil {
 				return nil, fmt.Errorf("rollback: failed to delete transactionByAddress rows: %w", err)
+			}
+			if _, err := configs.InternalTransactionByAddressCollections.DeleteMany(sessCtx, companionFilter); err != nil {
+				return nil, fmt.Errorf("rollback: failed to delete internalTransactionByAddress rows: %w", err)
 			}
 
 			tokenTransfers := configs.GetTokenTransfersCollection()

--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -630,21 +630,23 @@ func Rollback(blockNumber string) error {
 			return nil, err
 		}
 
-		// Delete companion rows for the removed blocks so a rolled-back block
-		// leaves no orphans. All three of these collections key blockNumber as
-		// the raw hex string, so the exact-match $in filter is correct.
+		// Delete the append-only companion rows for the removed blocks so a
+		// rolled-back block leaves no orphan event records. These collections
+		// key blockNumber as the raw hex string, so the exact-match $in filter
+		// is correct (a numeric range would lex-sort hex strings wrong).
 		//
-		// NOT cleaned here (intentional, see report):
-		//   - internalTransactionByAddress stores no block-number field at all
-		//     (only blockTimestamp), so there is nothing to filter on. We do not
-		//     fabricate one. Orphan internal-tx rows may linger after a reorg;
-		//     flagged for manual review.
+		// NOT cleaned here (intentional):
 		//   - tokenBalances is a last-write-wins snapshot keyed on
-		//     (contractAddress, holderAddress), not a per-block append. We delete
-		//     only the snapshots whose last update happened in a rolled-back
-		//     block (blockNumber $in badBlockNumbers); those values are stale and
-		//     get re-derived from RPC when the block is reprocessed. Snapshots
-		//     last touched by an older block are left intact.
+		//     (contractAddress, holderAddress), NOT a per-block append. Deleting
+		//     a holder's snapshot just because its last update landed in a
+		//     rolled-back block would permanently drop a balance the new chain
+		//     may never re-touch (it would read as 0). The syncer re-derives
+		//     balances from RPC whenever a contract is next processed, so a
+		//     left-in-place snapshot self-heals; a deleted one does not. Leave
+		//     it untouched.
+		//   - internalTransactionByAddress stores no block-number field (only
+		//     blockTimestamp), so there is nothing to filter on. Orphan
+		//     internal-tx rows may linger after a reorg; flagged for follow-up.
 		if len(badBlockNumbers) > 0 {
 			companionFilter := bson.M{"blockNumber": bson.M{"$in": badBlockNumbers}}
 
@@ -658,11 +660,6 @@ func Rollback(blockNumber string) error {
 			tokenTransfers := configs.GetTokenTransfersCollection()
 			if _, err := tokenTransfers.DeleteMany(sessCtx, companionFilter); err != nil {
 				return nil, fmt.Errorf("rollback: failed to delete tokenTransfers rows: %w", err)
-			}
-
-			tokenBalances := configs.GetTokenBalancesCollection()
-			if _, err := tokenBalances.DeleteMany(sessCtx, companionFilter); err != nil {
-				return nil, fmt.Errorf("rollback: failed to delete tokenBalances rows: %w", err)
 			}
 		}
 

--- a/QRL2MongoDB/db/blocks.go
+++ b/QRL2MongoDB/db/blocks.go
@@ -609,7 +609,8 @@ func Rollback(blockNumber string) error {
 		return fmt.Errorf("rollback: block number cannot be negative: %d", rollbackTo)
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
 
 	filter := bson.M{
 		"blockNumberInt": bson.M{

--- a/QRL2MongoDB/db/circulating.go
+++ b/QRL2MongoDB/db/circulating.go
@@ -11,8 +11,12 @@ import (
 	"go.uber.org/zap"
 )
 
+// Balance is decoded as float64 because the addresses collection stores the
+// balance (in QRL units) as a BSON double. Decoding it into an int64 field made
+// the driver error on every document, which left the circulating total stuck
+// at 0.
 type Address struct {
-	Balance int64              `bson:"balance"`
+	Balance float64            `bson:"balance"`
 	ID      primitive.ObjectID `bson:"_id"`
 }
 
@@ -24,8 +28,10 @@ func UpdateTotalBalance() {
 
 	destCollection := configs.GetCollection(configs.DB, "totalCirculatingSupply")
 
-	// Get initial total balance
-	total := big.NewInt(0)
+	// Accumulate in a big.Float so summing many balances does not lose
+	// precision, then emit an integer-QRL string to preserve the existing
+	// `circulating` string contract the backend reads.
+	total := new(big.Float).SetPrec(256)
 	cursor, err := configs.AddressesCollections.Find(ctx, primitive.D{})
 	if err != nil {
 		configs.Logger.Error("Failed to query addresses", zap.Error(err))
@@ -40,9 +46,7 @@ func UpdateTotalBalance() {
 			continue // Skip this address but continue processing others
 		}
 
-		balanceBigInt := new(big.Int)
-		balanceBigInt.SetInt64(address.Balance)
-		total.Add(total, balanceBigInt)
+		total.Add(total, new(big.Float).SetFloat64(address.Balance))
 	}
 
 	if err := cursor.Err(); err != nil {
@@ -50,11 +54,15 @@ func UpdateTotalBalance() {
 		return
 	}
 
+	// Integer-QRL decimal string (no scientific notation), matching the prior
+	// big.Int string contract the backend's `circulating` field expects.
+	totalStr := total.Text('f', 0)
+
 	// Upsert the total balance
 	filter := primitive.D{{Key: "_id", Value: "totalBalance"}}
 	update := primitive.D{
 		{Key: "$set", Value: primitive.D{
-			{Key: "circulating", Value: total.String()},
+			{Key: "circulating", Value: totalStr},
 		}},
 	}
 
@@ -66,5 +74,5 @@ func UpdateTotalBalance() {
 	}
 
 	configs.Logger.Info("Successfully updated total circulating supply",
-		zap.String("total", total.String()))
+		zap.String("total", totalStr))
 }

--- a/QRL2MongoDB/db/contracts.go
+++ b/QRL2MongoDB/db/contracts.go
@@ -8,13 +8,58 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
+	"unicode"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.uber.org/zap"
 )
+
+// maxTokenStringRunes caps the stored length of on-chain token name/symbol
+// strings. On-chain name()/symbol() are attacker-controlled, an unbounded
+// string is both a storage-bloat and a downstream-rendering hazard.
+const maxTokenStringRunes = 128
+
+// sanitizeTokenString cleans an on-chain token name/symbol before it is
+// persisted. It is the single ingestion-time chokepoint for these
+// attacker-controlled strings: every StoreContract write passes through it,
+// so all downstream readers (API JSON, future CSV export, server-rendered
+// templates) receive an already-cleaned value rather than relying on a
+// specific sink to escape it.
+//
+// Behavior:
+//   - strips ASCII/Unicode control characters (C0/C1, DEL, etc.) that have no
+//     legitimate place in a display name and could break a non-JSX sink;
+//   - preserves all legitimate Unicode letters/marks/symbols/punctuation;
+//   - trims leading/trailing whitespace;
+//   - caps the result at maxTokenStringRunes runes (rune-safe, never splits a
+//     multibyte codepoint).
+func sanitizeTokenString(s string) string {
+	if s == "" {
+		return s
+	}
+
+	// Drop control characters; keep everything else (letters, marks, digits,
+	// punctuation, symbols, spaces) intact so legitimate unicode is preserved.
+	cleaned := strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+
+	cleaned = strings.TrimSpace(cleaned)
+
+	// Rune-safe length cap.
+	if runes := []rune(cleaned); len(runes) > maxTokenStringRunes {
+		cleaned = string(runes[:maxTokenStringRunes])
+	}
+
+	return cleaned
+}
 
 // StoreContract stores or merges contract information in the database.
 //
@@ -40,6 +85,12 @@ func StoreContract(contract models.ContractInfo) error {
 	// Normalize addresses to canonical Q-prefix form
 	contract.Address = validation.ConvertToQAddress(contract.Address)
 	contract.CreatorAddress = validation.ConvertToQAddress(contract.CreatorAddress)
+
+	// Sanitize attacker-controlled on-chain token strings at the single
+	// storage chokepoint so every write path (creation tx, reprocess,
+	// classifier) persists a control-char-free, length-capped value.
+	contract.Name = sanitizeTokenString(contract.Name)
+	contract.Symbol = sanitizeTokenString(contract.Symbol)
 
 	collection := configs.GetContractsCollection()
 	filter := bson.M{"address": contract.Address}
@@ -818,9 +869,15 @@ func findCreationTransaction(contractAddress string) *creationTxInfo {
 	}
 }
 
-// StartContractReprocessingJob starts a background job to periodically reprocess incomplete contracts
-func StartContractReprocessingJob() {
+// StartContractReprocessingJob starts a background job to periodically reprocess
+// incomplete contracts. The goroutine returns once stopCh is closed so a
+// graceful shutdown does not start a new reprocess pass while in-flight work
+// is draining.
+func StartContractReprocessingJob(stopCh <-chan struct{}) {
 	go func() {
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+
 		for {
 			configs.Logger.Info("Starting contract reprocessing job")
 
@@ -829,8 +886,13 @@ func StartContractReprocessingJob() {
 				configs.Logger.Error("Contract reprocessing job failed", zap.Error(err))
 			}
 
-			// Wait for 1 hour before next run
-			time.Sleep(1 * time.Hour)
+			// Wait for 1 hour before next run, or exit early on shutdown.
+			select {
+			case <-ticker.C:
+			case <-stopCh:
+				configs.Logger.Info("Stopping contract reprocessing job on shutdown signal")
+				return
+			}
 		}
 	}()
 }

--- a/QRL2MongoDB/db/contracts.go
+++ b/QRL2MongoDB/db/contracts.go
@@ -38,27 +38,35 @@ const maxTokenStringRunes = 128
 //   - caps the result at maxTokenStringRunes runes (rune-safe, never splits a
 //     multibyte codepoint).
 func sanitizeTokenString(s string) string {
+	s = strings.TrimSpace(s)
 	if s == "" {
 		return s
 	}
 
-	// Drop control characters; keep everything else (letters, marks, digits,
-	// punctuation, symbols, spaces) intact so legitimate unicode is preserved.
-	cleaned := strings.Map(func(r rune) rune {
-		if unicode.IsControl(r) {
-			return -1
-		}
-		return r
-	}, s)
-
-	cleaned = strings.TrimSpace(cleaned)
-
-	// Rune-safe length cap.
-	if runes := []rune(cleaned); len(runes) > maxTokenStringRunes {
-		cleaned = string(runes[:maxTokenStringRunes])
+	// name()/symbol() are attacker-controlled on-chain strings of unbounded
+	// length, so this must not allocate or scan the whole input. Cap the bytes
+	// examined first (a rune is at most 4 bytes, so maxTokenStringRunes runes
+	// fit in 4x that), then single-pass: drop control characters, keep all
+	// other unicode, and stop as soon as the rune budget is reached.
+	if len(s) > maxTokenStringRunes*4 {
+		s = s[:maxTokenStringRunes*4]
 	}
 
-	return cleaned
+	var b strings.Builder
+	b.Grow(len(s))
+	runeCount := 0
+	for _, r := range s {
+		if unicode.IsControl(r) {
+			continue
+		}
+		b.WriteRune(r)
+		runeCount++
+		if runeCount >= maxTokenStringRunes {
+			break
+		}
+	}
+
+	return strings.TrimSpace(b.String())
 }
 
 // StoreContract stores or merges contract information in the database.

--- a/QRL2MongoDB/db/pending.go
+++ b/QRL2MongoDB/db/pending.go
@@ -82,19 +82,38 @@ func UpdatePendingTransactionStatus(hash string, status string) error {
 	return nil
 }
 
-// CleanupOldPendingTransactions removes rows that haven't been seen recently ,
+// CleanupOldPendingTransactions removes rows that haven't been seen recently,
 // both genuinely-pending rows the node has forgotten about, and "mined"
 // tombstones that have aged out. The tombstones must be cleaned here too;
 // the per-status helpers (UpdatePendingTransactionsInBlock,
 // verifyPendingTransactions) intentionally leave them in place to block
 // stale mempool re-inserts.
-func CleanupOldPendingTransactions(maxAge time.Duration) error {
+//
+// Mined tombstones get the shorter minedMaxAge cutoff: once a tx is mined its
+// row only exists to block a stale mempool re-poll re-inserting it as
+// "pending". That race window is bounded by the mempool sync interval, so a
+// mined tombstone does not need the full pending maxAge to linger. Pending
+// rows keep the conservative maxAge so we never delete a row the node might
+// still surface. lastSeen is set at tombstone time and never refreshed (the
+// mempool no longer sees mined hashes), so it measures time-since-mined.
+func CleanupOldPendingTransactions(maxAge, minedMaxAge time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cutoff := time.Now().Add(-maxAge)
+	now := time.Now()
 	filter := bson.M{
-		"lastSeen": bson.M{"$lt": cutoff},
+		"$or": []bson.M{
+			// Mined tombstones aged past the shorter mined cutoff.
+			{
+				"status":   "mined",
+				"lastSeen": bson.M{"$lt": now.Add(-minedMaxAge)},
+			},
+			// Any non-mined (pending) row past the conservative pending cutoff.
+			{
+				"status":   bson.M{"$ne": "mined"},
+				"lastSeen": bson.M{"$lt": now.Add(-maxAge)},
+			},
+		},
 	}
 
 	_, err := configs.PendingTransactionsCollections.DeleteMany(ctx, filter)

--- a/QRL2MongoDB/db/tokentransfers.go
+++ b/QRL2MongoDB/db/tokentransfers.go
@@ -39,6 +39,11 @@ func StoreTokenTransfer(transfer models.TokenTransfer) error {
 	transfer.To = validation.ConvertToQAddress(transfer.To)
 	transfer.ContractAddress = validation.ConvertToQAddress(transfer.ContractAddress)
 
+	// Populate the numeric block number so sort operations order correctly.
+	// BlockNumber is the raw hex string; HexToInt64 lives in the same db
+	// package (db/blocks.go) and returns 0 on any parse error.
+	transfer.BlockNumberInt = HexToInt64(transfer.BlockNumber)
+
 	// Debug-level log for per-record operations; Info is reserved for batch summaries.
 	configs.Logger.Debug("Inserting token transfer document",
 		zap.String("token", transfer.TokenSymbol),
@@ -61,6 +66,103 @@ func StoreTokenTransfer(transfer models.TokenTransfer) error {
 	return nil
 }
 
+// BackfillTokenTransferBlockNumberInt populates the blockNumberInt field on any
+// tokenTransfers document that predates it. Rows written before the field was
+// introduced were sorted by the hex STRING blockNumber, which lex-orders
+// incorrectly past width boundaries (0xffff -> 0x10000). This one-time, idempotent
+// pass derives the numeric value from the existing hex blockNumber so the new
+// numeric sorts (and the backend) order correctly across the full history.
+//
+// Design:
+//   - Only touches rows missing the field ({blockNumberInt: {$exists: false}}),
+//     so a second invocation after completion is a pure no-op (the cursor is
+//     empty).
+//   - Streams a projection of just _id + blockNumber, batches UpdateOne models
+//     and flushes via BulkWrite every backfillBatchSize rows, bounded memory.
+//   - The outer context is the caller's; each bulk flush uses a bounded child
+//     timeout so a stalled write can't hang the pass forever.
+//   - Cursor errors are logged and returned (never panic).
+func BackfillTokenTransferBlockNumberInt(ctx context.Context) error {
+	const backfillBatchSize = 1000
+
+	collection := configs.GetTokenTransfersCollection()
+
+	filter := bson.M{"blockNumberInt": bson.M{"$exists": false}}
+	findOpts := options.Find().SetProjection(bson.M{"_id": 1, "blockNumber": 1})
+
+	cursor, err := collection.Find(ctx, filter, findOpts)
+	if err != nil {
+		configs.Logger.Error("Backfill: failed to query tokenTransfers missing blockNumberInt",
+			zap.Error(err))
+		return err
+	}
+	defer cursor.Close(ctx)
+
+	configs.Logger.Info("Backfill: starting tokenTransfers blockNumberInt backfill")
+
+	var (
+		models  []mongo.WriteModel
+		updated int64
+	)
+
+	flush := func() error {
+		if len(models) == 0 {
+			return nil
+		}
+		flushCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		defer cancel()
+		res, bwErr := collection.BulkWrite(flushCtx, models, options.BulkWrite().SetOrdered(false))
+		if bwErr != nil {
+			configs.Logger.Error("Backfill: bulk write failed",
+				zap.Int("batchSize", len(models)),
+				zap.Error(bwErr))
+			return bwErr
+		}
+		updated += res.ModifiedCount
+		models = models[:0]
+		configs.Logger.Info("Backfill: tokenTransfers blockNumberInt progress",
+			zap.Int64("updatedSoFar", updated))
+		return nil
+	}
+
+	for cursor.Next(ctx) {
+		var doc struct {
+			ID          interface{} `bson:"_id"`
+			BlockNumber string      `bson:"blockNumber"`
+		}
+		if decErr := cursor.Decode(&doc); decErr != nil {
+			configs.Logger.Error("Backfill: failed to decode tokenTransfers document",
+				zap.Error(decErr))
+			return decErr
+		}
+
+		models = append(models, mongo.NewUpdateOneModel().
+			SetFilter(bson.M{"_id": doc.ID}).
+			SetUpdate(bson.M{"$set": bson.M{"blockNumberInt": HexToInt64(doc.BlockNumber)}}))
+
+		if len(models) >= backfillBatchSize {
+			if flushErr := flush(); flushErr != nil {
+				return flushErr
+			}
+		}
+	}
+
+	if curErr := cursor.Err(); curErr != nil {
+		configs.Logger.Error("Backfill: cursor error while iterating tokenTransfers",
+			zap.Error(curErr))
+		return curErr
+	}
+
+	// Flush the final partial batch.
+	if flushErr := flush(); flushErr != nil {
+		return flushErr
+	}
+
+	configs.Logger.Info("Backfill: completed tokenTransfers blockNumberInt backfill",
+		zap.Int64("totalUpdated", updated))
+	return nil
+}
+
 // GetTokenTransfersByContract retrieves all transfers for a specific token contract
 func GetTokenTransfersByContract(contractAddress string, skip, limit int64) ([]models.TokenTransfer, error) {
 	collection := configs.GetCollection(configs.DB, "tokenTransfers")
@@ -69,7 +171,7 @@ func GetTokenTransfersByContract(contractAddress string, skip, limit int64) ([]m
 	defer cancel()
 
 	opts := options.Find().
-		SetSort(bson.D{{Key: "blockNumber", Value: -1}}).
+		SetSort(bson.D{{Key: "blockNumberInt", Value: -1}}).
 		SetSkip(skip).
 		SetLimit(limit)
 
@@ -98,7 +200,7 @@ func GetTokenTransfersByAddress(address string, skip, limit int64) ([]models.Tok
 	defer cancel()
 
 	opts := options.Find().
-		SetSort(bson.D{{Key: "blockNumber", Value: -1}}).
+		SetSort(bson.D{{Key: "blockNumberInt", Value: -1}}).
 		SetSkip(skip).
 		SetLimit(limit)
 
@@ -635,6 +737,7 @@ func InitializeTokenTransfersCollection() error {
 			{{Key: "from", Value: 1}, {Key: "blockNumber", Value: 1}},
 			{{Key: "to", Value: 1}, {Key: "blockNumber", Value: 1}},
 			{{Key: "txHash", Value: 1}},
+			{{Key: "blockNumberInt", Value: -1}},
 		},
 	)
 
@@ -696,6 +799,19 @@ func InitializeTokenTransfersCollection() error {
 			},
 			Options: options.Index().
 				SetName("contract_tokenID_block_idx").
+				SetBackground(true),
+		},
+		{
+			// Numeric block-number sort. The contract/from/to + blockNumber
+			// compound indexes above still key on the hex STRING blockNumber
+			// (lexicographic), so the recency sorts in GetTokenTransfersBy*
+			// use this standalone numeric index instead. Descending to match
+			// the SetSort(blockNumberInt: -1) on those queries.
+			Keys: bson.D{
+				{Key: "blockNumberInt", Value: -1},
+			},
+			Options: options.Index().
+				SetName("blockNumberInt_desc_idx").
 				SetBackground(true),
 		},
 	}

--- a/QRL2MongoDB/db/transactions.go
+++ b/QRL2MongoDB/db/transactions.go
@@ -381,6 +381,7 @@ func processTransactionData(tx *models.Transaction, blockTimestamp string, to st
 			trace.AddressFunctionIdentifier,
 			fmt.Sprintf("0x%x", trace.AmountFunctionIdentifier),
 			blockTimestamp,
+			blockNumber,
 		)
 	}
 
@@ -491,7 +492,7 @@ func TransferCollection(blockNumber string, blockTimestamp string, from string, 
 	return result, err
 }
 
-func InternalTransactionByAddressCollection(transactionType string, callType string, hash string, from string, to string, input string, output string, traceAddress []int, value float64, gas string, gasUsed string, addressFunctionIdentifier string, amountFunctionIdentifier string, blockTimestamp string) (*mongo.InsertOneResult, error) {
+func InternalTransactionByAddressCollection(transactionType string, callType string, hash string, from string, to string, input string, output string, traceAddress []int, value float64, gas string, gasUsed string, addressFunctionIdentifier string, amountFunctionIdentifier string, blockTimestamp string, blockNumber string) (*mongo.InsertOneResult, error) {
 	// Normalize addresses to canonical Q-prefix form
 	if from != "" {
 		from = validation.ConvertToQAddress(from)
@@ -503,6 +504,8 @@ func InternalTransactionByAddressCollection(transactionType string, callType str
 		addressFunctionIdentifier = validation.ConvertToQAddress(addressFunctionIdentifier)
 	}
 
+	// blockNumber (raw hex string) lets Rollback delete this row on a reorg via
+	// the same $in companionFilter used for the other append-only collections.
 	doc := bson.D{
 		{Key: "type", Value: transactionType},
 		{Key: "callType", Value: callType},
@@ -518,6 +521,7 @@ func InternalTransactionByAddressCollection(transactionType string, callType str
 		{Key: "addressFunctionIdentifier", Value: addressFunctionIdentifier},
 		{Key: "amountFunctionIdentifier", Value: amountFunctionIdentifier},
 		{Key: "blockTimestamp", Value: blockTimestamp},
+		{Key: "blockNumber", Value: blockNumber},
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/QRL2MongoDB/db/transactions.go
+++ b/QRL2MongoDB/db/transactions.go
@@ -637,6 +637,7 @@ func UpsertTransactions(address string, value float64, isContract bool) (*mongo.
 }
 
 func GetContractByAddress(address string) *models.ContractInfo {
+	address = validation.ConvertToQAddress(address)
 	collection := configs.GetCollection(configs.DB, "contractCode")
 	var contract models.ContractInfo
 

--- a/QRL2MongoDB/db/wallet_sync.go
+++ b/QRL2MongoDB/db/wallet_sync.go
@@ -11,8 +11,10 @@ import (
 	"go.uber.org/zap"
 )
 
-// StartWalletCountSync starts a goroutine that syncs wallet count every 4 hours
-func StartWalletCountSync() {
+// StartWalletCountSync starts a goroutine that syncs wallet count every 4 hours.
+// The goroutine returns once stopCh is closed so a graceful shutdown does not
+// start a new count while in-flight work is draining.
+func StartWalletCountSync(stopCh <-chan struct{}) {
 	configs.Logger.Info("Initializing wallet count sync service")
 	go func() {
 		ticker := time.NewTicker(4 * time.Hour)
@@ -26,10 +28,15 @@ func StartWalletCountSync() {
 
 		// Then sync every 4 hours
 		configs.Logger.Info("Starting periodic wallet count sync (every 4 hours)")
-		for range ticker.C {
-			if err := syncWalletCount(); err != nil {
-				configs.Logger.Error("Failed wallet count sync", zap.Error(err))
-				continue
+		for {
+			select {
+			case <-ticker.C:
+				if err := syncWalletCount(); err != nil {
+					configs.Logger.Error("Failed wallet count sync", zap.Error(err))
+				}
+			case <-stopCh:
+				configs.Logger.Info("Stopping wallet count sync on shutdown signal")
+				return
 			}
 		}
 	}()

--- a/QRL2MongoDB/main.go
+++ b/QRL2MongoDB/main.go
@@ -125,9 +125,11 @@ func main() {
 		}
 	}()
 
-	// Start pending transaction sync (this is not started in sync.go)
+	// Start pending transaction sync (this is not started in sync.go).
+	// stopCh is threaded in so the mempool/cleanup/verify tickers stop
+	// accepting new work when a shutdown signal arrives.
 	configs.Logger.Info("Starting pending transaction sync service...")
-	synchroniser.StartPendingTransactionSync()
+	synchroniser.StartPendingTransactionSync(stopCh)
 
 	// Phase 3a: start the off-chain NFT collection metadata fetcher.
 	// Background goroutine that polls contractCode for unfetched
@@ -147,8 +149,9 @@ func main() {
 	go func() {
 		defer close(doneCh)
 		// Sync will now handle starting wallet count and contract reprocessing
-		// services after initial sync is complete
-		synchroniser.Sync()
+		// services after initial sync is complete. stopCh is threaded in so
+		// every background ticker goroutine Sync starts can observe shutdown.
+		synchroniser.Sync(stopCh)
 	}()
 
 	// Block until either sync finishes naturally or a shutdown signal arrives.

--- a/QRL2MongoDB/main.go
+++ b/QRL2MongoDB/main.go
@@ -6,6 +6,7 @@ import (
 	"QRL2MongoDB/synchroniser"
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -16,11 +17,32 @@ import (
 	"go.uber.org/zap"
 )
 
+// validateEnv fails fast if the env vars the syncer cannot run without are
+// missing. Without this, an empty NODE_URLS/NODE_URL only logs a warning in
+// rpc.newEndpointSelectorFromEnv and the first RPC call returns "no node
+// endpoints configured", so Sync exits silently with no obvious cause.
+// MONGOURI is also required (ConnectDB would already fail without it, but
+// naming the variable here gives an actionable message before any work starts).
+// .env has already been loaded by configs.ConnectDB (via EnvMongoURI) during
+// package init, so os.Getenv here sees any values from the .env file.
+func validateEnv() {
+	if os.Getenv("MONGOURI") == "" {
+		log.Fatal("Required environment variable MONGOURI is not set")
+	}
+	if os.Getenv("NODE_URLS") == "" && os.Getenv("NODE_URL") == "" {
+		log.Fatal("Required environment variable NODE_URLS (or legacy NODE_URL) is not set")
+	}
+}
+
 func main() {
 	// Ensure logger resources are properly released
 	defer configs.Logger.Sync()
 
 	configs.Logger.Info("Initializing QRL to MongoDB synchronizer...")
+
+	// Fail fast before any sync work if required env vars are missing.
+	validateEnv()
+
 	configs.Logger.Info("Connecting to MongoDB and RPC node...")
 
 	// stopCh is closed when a termination signal is received. Sync() and other

--- a/QRL2MongoDB/main.go
+++ b/QRL2MongoDB/main.go
@@ -91,28 +91,13 @@ func main() {
 	// now (not just that the process is alive).
 	go func() {
 		http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+			// Probe synchronously under the request context with a 5s cap.
+			// ProbeChainHeadCtx honours ctx for the in-flight HTTP request, so
+			// a client disconnect cancels the probe instead of leaking a
+			// detached goroutine that outlives the handler.
 			ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 			defer cancel()
-			done := make(chan struct {
-				height uint64
-				err    error
-			}, 1)
-			go func() {
-				h, e := rpc.ProbeChainHead()
-				done <- struct {
-					height uint64
-					err    error
-				}{h, e}
-			}()
-			var height uint64
-			var probeErr error
-			select {
-			case <-ctx.Done():
-				probeErr = ctx.Err()
-			case res := <-done:
-				height = res.height
-				probeErr = res.err
-			}
+			height, probeErr := rpc.ProbeChainHeadCtx(ctx)
 
 			w.Header().Set("Content-Type", "application/json")
 			payload := map[string]interface{}{

--- a/QRL2MongoDB/main.go
+++ b/QRL2MongoDB/main.go
@@ -17,18 +17,13 @@ import (
 	"go.uber.org/zap"
 )
 
-// validateEnv fails fast if the env vars the syncer cannot run without are
-// missing. Without this, an empty NODE_URLS/NODE_URL only logs a warning in
+// validateEnv fails fast if the node endpoint env vars are missing. Without
+// this, an empty NODE_URLS/NODE_URL only logs a warning in
 // rpc.newEndpointSelectorFromEnv and the first RPC call returns "no node
 // endpoints configured", so Sync exits silently with no obvious cause.
-// MONGOURI is also required (ConnectDB would already fail without it, but
-// naming the variable here gives an actionable message before any work starts).
-// .env has already been loaded by configs.ConnectDB (via EnvMongoURI) during
-// package init, so os.Getenv here sees any values from the .env file.
+// MONGOURI is validated in configs.ConnectDB, which runs at package init
+// (before main), so it is not rechecked here: a check here would be dead code.
 func validateEnv() {
-	if os.Getenv("MONGOURI") == "" {
-		log.Fatal("Required environment variable MONGOURI is not set")
-	}
 	if os.Getenv("NODE_URLS") == "" && os.Getenv("NODE_URL") == "" {
 		log.Fatal("Required environment variable NODE_URLS (or legacy NODE_URL) is not set")
 	}

--- a/QRL2MongoDB/models/address.go
+++ b/QRL2MongoDB/models/address.go
@@ -7,6 +7,6 @@ import (
 type Address struct {
 	ObjectId primitive.ObjectID `bson:"_id"`
 	ID       string             `json:"id"` // Store as hex string
-	Balance  float32            `json:"balance"`
+	Balance  float64            `json:"balance"`
 	Nonce    uint64             `json:"nonce"`
 }

--- a/QRL2MongoDB/models/tokentransfer.go
+++ b/QRL2MongoDB/models/tokentransfer.go
@@ -17,18 +17,23 @@ type TokenTransfer struct {
 	To              string `bson:"to"`
 	Amount          string `bson:"amount"`
 	BlockNumber     string `bson:"blockNumber"`
-	TxHash          string `bson:"txHash"`
+	// BlockNumberInt is the numeric form of BlockNumber, set at write time
+	// via HexToInt64. Sorting on the hex string lex-orders incorrectly
+	// ("0x9" sorts after "0x10", and width boundaries like 0xffff -> 0x10000
+	// break ordering entirely), so all sort operations use this field instead.
+	BlockNumberInt int64  `bson:"blockNumberInt"`
+	TxHash         string `bson:"txHash"`
 	// Stored ALWAYS, including the empty-string sentinel for the
 	// direct-calldata path. The `omitempty` tag would drop the field
 	// when LogIndex is "", and then BSON queries `{logIndex: ""}`
 	// would no longer match those documents, which is exactly what
 	// TokenTransferExists relies on for idempotent reprocess.
-	LogIndex        string `bson:"logIndex"`
-	Timestamp       string `bson:"timestamp"`
-	TokenSymbol     string `bson:"tokenSymbol"`
-	TokenDecimals   uint8  `bson:"tokenDecimals"`
-	TokenName       string `bson:"tokenName"`
-	TransferType    string `bson:"transferType"` // "direct" for direct transfers, "event" for Transfer events
+	LogIndex      string `bson:"logIndex"`
+	Timestamp     string `bson:"timestamp"`
+	TokenSymbol   string `bson:"tokenSymbol"`
+	TokenDecimals uint8  `bson:"tokenDecimals"`
+	TokenName     string `bson:"tokenName"`
+	TransferType  string `bson:"transferType"` // "direct" for direct transfers, "event" for Transfer events
 	// TokenStandard denormalises ContractInfo.TokenStandard for query
 	// convenience (so /token-transfer endpoints can filter by standard
 	// without joining contractCode). Empty for legacy ERC-20 rows.

--- a/QRL2MongoDB/rpc/endpoints.go
+++ b/QRL2MongoDB/rpc/endpoints.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -237,6 +238,88 @@ func ProbeChainHead() (uint64, error) {
 		return 0, fmt.Errorf("parse height: %w", err)
 	}
 	return height, nil
+}
+
+// ProbeChainHeadCtx is the context-aware variant of ProbeChainHead used by the
+// /health handler. It runs synchronously and honours ctx cancellation/deadline
+// for every endpoint attempt, so the handler can bound the probe with the
+// request context without leaking a goroutine when the client disconnects.
+// Same probe semantics as ProbeChainHead: a single attempt per endpoint with
+// one failover hop, no retry budget.
+func ProbeChainHeadCtx(ctx context.Context) (uint64, error) {
+	body, err := doNodeRPCCtx(ctx, []byte(`{"jsonrpc":"2.0","method":"qrl_blockNumber","params":[],"id":1}`))
+	if err != nil {
+		return 0, err
+	}
+	var resp struct {
+		Result string `json:"result"`
+		Error  *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return 0, fmt.Errorf("unmarshal qrl_blockNumber: %w", err)
+	}
+	if resp.Error != nil {
+		return 0, fmt.Errorf("rpc error %d: %s", resp.Error.Code, resp.Error.Message)
+	}
+	if !strings.HasPrefix(resp.Result, "0x") {
+		return 0, fmt.Errorf("unexpected qrl_blockNumber result: %q", resp.Result)
+	}
+	height, err := strconv.ParseUint(resp.Result[2:], 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse height: %w", err)
+	}
+	return height, nil
+}
+
+// doNodeRPCCtx posts a JSON-RPC body honouring the caller's context: one
+// attempt per endpoint, failing over to the next on transport error. Used by
+// the health probe so cancellation/deadline propagate to the in-flight HTTP
+// request instead of being abandoned in a detached goroutine.
+func doNodeRPCCtx(ctx context.Context, reqBody []byte) ([]byte, error) {
+	sel := Endpoints()
+	attempts := sel.orderedAttempts()
+	if len(attempts) == 0 {
+		return nil, fmt.Errorf("no node endpoints configured (set NODE_URLS or NODE_URL)")
+	}
+
+	var lastErr error
+	for _, st := range attempts {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		req, err := http.NewRequestWithContext(ctx, "POST", st.url, bytes.NewBuffer(reqBody))
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := GetHTTPClient().Do(req)
+		if err != nil {
+			sel.markFailed(st.url)
+			lastErr = err
+			continue
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			resp.Body.Close()
+			sel.markFailed(st.url)
+			lastErr = fmt.Errorf("HTTP %d", resp.StatusCode)
+			continue
+		}
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			sel.markFailed(st.url)
+			lastErr = readErr
+			continue
+		}
+		sel.markSucceeded(st.url)
+		return body, nil
+	}
+	return nil, fmt.Errorf("all node endpoints exhausted; last error: %w", lastErr)
 }
 
 // DoNodeRPC posts a JSON-RPC body to the first healthy node endpoint; on

--- a/QRL2MongoDB/synchroniser/gap_detection.go
+++ b/QRL2MongoDB/synchroniser/gap_detection.go
@@ -166,6 +166,21 @@ func fillGaps(gaps []string) int {
 			continue
 		}
 
+		// Idempotency guard: skip both the block insert and ProcessTransactions
+		// together if the block already exists. A "gap" can close between
+		// detection and fill (the single-block loop retries failed blocks, the
+		// batch path may overlap), and ProcessTransactions has no txHash unique
+		// index, so re-running it would duplicate transfer + transactionByAddress
+		// rows. InsertBlockDocument alone already no-ops on an existing block;
+		// the guard keeps the transaction processing consistent with it.
+		if db.BlockExists(blockNum) {
+			configs.Logger.Info("Gap block already exists, skipping insert and transaction processing",
+				zap.String("block", blockNum))
+			clearFailedBlock(blockNum)
+			filled++
+			continue
+		}
+
 		// Insert the block
 		db.UpdateTransactionStatuses(data)
 		db.InsertBlockDocument(*data)

--- a/QRL2MongoDB/synchroniser/pending_sync.go
+++ b/QRL2MongoDB/synchroniser/pending_sync.go
@@ -19,6 +19,11 @@ const (
 	CLEANUP_INTERVAL        = 1 * time.Hour
 	VERIFY_PENDING_INTERVAL = 5 * time.Minute
 	MAX_PENDING_AGE         = 24 * time.Hour
+	// MAX_MINED_TOMBSTONE_AGE is the shorter cutoff for "mined" tombstone
+	// rows. A mined tombstone only needs to outlive the stale-mempool re-insert
+	// race (bounded by MEMPOOL_SYNC_INTERVAL); 1h is a generous margin and
+	// stops mined rows from lingering for the full MAX_PENDING_AGE.
+	MAX_MINED_TOMBSTONE_AGE = 1 * time.Hour
 )
 
 // StartPendingTransactionSync starts the periodic mempool monitoring. The
@@ -34,7 +39,7 @@ func StartPendingTransactionSync(stopCh <-chan struct{}) {
 
 	// Start cleanup of old transactions
 	runPeriodicTask(func() {
-		if err := db.CleanupOldPendingTransactions(MAX_PENDING_AGE); err != nil {
+		if err := db.CleanupOldPendingTransactions(MAX_PENDING_AGE, MAX_MINED_TOMBSTONE_AGE); err != nil {
 			configs.Logger.Error("Failed to cleanup old pending transactions", zap.Error(err))
 		}
 	}, CLEANUP_INTERVAL, "pending cleanup", stopCh)

--- a/QRL2MongoDB/synchroniser/pending_sync.go
+++ b/QRL2MongoDB/synchroniser/pending_sync.go
@@ -15,34 +15,36 @@ import (
 )
 
 const (
-	MEMPOOL_SYNC_INTERVAL       = 1 * time.Second  // Reduced for faster detection
-	CLEANUP_INTERVAL            = 1 * time.Hour
-	VERIFY_PENDING_INTERVAL     = 5 * time.Minute
-	MAX_PENDING_AGE             = 24 * time.Hour
+	MEMPOOL_SYNC_INTERVAL   = 1 * time.Second // Reduced for faster detection
+	CLEANUP_INTERVAL        = 1 * time.Hour
+	VERIFY_PENDING_INTERVAL = 5 * time.Minute
+	MAX_PENDING_AGE         = 24 * time.Hour
 )
 
-// StartPendingTransactionSync starts the periodic mempool monitoring
-func StartPendingTransactionSync() {
+// StartPendingTransactionSync starts the periodic mempool monitoring. The
+// stopCh is threaded into each periodic task so they stop accepting new work
+// when a shutdown signal arrives.
+func StartPendingTransactionSync(stopCh <-chan struct{}) {
 	// Start mempool sync
-	go runPeriodicTask(func() {
+	runPeriodicTask(func() {
 		if err := syncMempool(); err != nil {
 			configs.Logger.Error("Failed to sync mempool", zap.Error(err))
 		}
-	}, MEMPOOL_SYNC_INTERVAL, "mempool sync")
+	}, MEMPOOL_SYNC_INTERVAL, "mempool sync", stopCh)
 
 	// Start cleanup of old transactions
-	go runPeriodicTask(func() {
+	runPeriodicTask(func() {
 		if err := db.CleanupOldPendingTransactions(MAX_PENDING_AGE); err != nil {
 			configs.Logger.Error("Failed to cleanup old pending transactions", zap.Error(err))
 		}
-	}, CLEANUP_INTERVAL, "pending cleanup")
+	}, CLEANUP_INTERVAL, "pending cleanup", stopCh)
 
 	// Start verification of pending transactions against node
-	go runPeriodicTask(func() {
+	runPeriodicTask(func() {
 		if err := verifyPendingTransactions(); err != nil {
 			configs.Logger.Error("Failed to verify pending transactions", zap.Error(err))
 		}
-	}, VERIFY_PENDING_INTERVAL, "pending verification")
+	}, VERIFY_PENDING_INTERVAL, "pending verification", stopCh)
 }
 
 // UpdatePendingTransactionsInBlock checks if any pending transactions are included in the new block

--- a/QRL2MongoDB/synchroniser/periodic_tasks.go
+++ b/QRL2MongoDB/synchroniser/periodic_tasks.go
@@ -25,15 +25,15 @@ func runPeriodicTask(task func(), interval time.Duration, taskName string, stopC
 				configs.Logger.Error("Recovered from panic in periodic task",
 					zap.String("task", taskName),
 					zap.Any("error", r))
-				// Do not restart if we are shutting down.
+				// Restart the task after a short delay, but exit promptly if a
+				// shutdown signal arrives during the wait instead of blocking
+				// the whole delay on time.Sleep.
 				select {
 				case <-stopCh:
 					return
-				default:
+				case <-time.After(5 * time.Second):
+					runPeriodicTask(task, interval, taskName, stopCh)
 				}
-				// Restart the task after a short delay
-				time.Sleep(5 * time.Second)
-				runPeriodicTask(task, interval, taskName, stopCh)
 			}
 		}()
 

--- a/QRL2MongoDB/synchroniser/periodic_tasks.go
+++ b/QRL2MongoDB/synchroniser/periodic_tasks.go
@@ -202,13 +202,31 @@ func processBlockPeriodically() {
 				continue
 			}
 
+			// processSubsequentBlocks returns the next block to process. On a
+			// clean success that is currentBlock+1. On a reorg or a
+			// missing-parent it returns an EARLIER block (the parent), having
+			// rolled back the stale data, so the loop must resume from there
+			// instead of blindly advancing +1. Detect the forward-success case
+			// by comparing the returned value to currentBlock+1.
+			expectedNext := utils.AddHexNumbers(currentBlock, "0x1")
+			if result != expectedNext {
+				// Rollback / re-sync requested: jump to the returned block. Do
+				// NOT run token processing or clear failure tracking for the
+				// current block; it was not advanced past.
+				configs.Logger.Warn("Re-sync point returned (rollback or missing parent), resuming from earlier block",
+					zap.String("from_block", currentBlock),
+					zap.String("resume_block", result))
+				currentBlock = result
+				continue
+			}
+
 			// Clear any previous failure tracking on success
 			clearFailedBlock(currentBlock)
 
 			ProcessTokenTransfersForBlock(currentBlock)
 
-			// Move to next block
-			currentBlock = utils.AddHexNumbers(currentBlock, "0x1")
+			// Move to next block (== result on the success path)
+			currentBlock = result
 		}
 
 		// Attempt to fill any failed blocks from this run

--- a/QRL2MongoDB/synchroniser/periodic_tasks.go
+++ b/QRL2MongoDB/synchroniser/periodic_tasks.go
@@ -15,17 +15,25 @@ import (
 	"go.uber.org/zap"
 )
 
-// runPeriodicTask runs a task at regular intervals with panic recovery
-func runPeriodicTask(task func(), interval time.Duration, taskName string) {
+// runPeriodicTask runs a task at regular intervals with panic recovery.
+// The goroutine returns promptly once stopCh is closed so a graceful
+// shutdown does not start new work while in-flight DB ops are draining.
+func runPeriodicTask(task func(), interval time.Duration, taskName string, stopCh <-chan struct{}) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
 				configs.Logger.Error("Recovered from panic in periodic task",
 					zap.String("task", taskName),
 					zap.Any("error", r))
+				// Do not restart if we are shutting down.
+				select {
+				case <-stopCh:
+					return
+				default:
+				}
 				// Restart the task after a short delay
 				time.Sleep(5 * time.Second)
-				runPeriodicTask(task, interval, taskName)
+				runPeriodicTask(task, interval, taskName, stopCh)
 			}
 		}()
 
@@ -39,8 +47,15 @@ func runPeriodicTask(task func(), interval time.Duration, taskName string) {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 
-		for range ticker.C {
-			runTaskWithRetry(task, taskName)
+		for {
+			select {
+			case <-ticker.C:
+				runTaskWithRetry(task, taskName)
+			case <-stopCh:
+				configs.Logger.Info("Stopping periodic task on shutdown signal",
+					zap.String("task", taskName))
+				return
+			}
 		}
 	}()
 }
@@ -291,8 +306,11 @@ func updateDataPeriodically() {
 	}
 }
 
-// singleBlockInsertion starts continuous block monitoring with periodic tasks
-func singleBlockInsertion() {
+// singleBlockInsertion starts continuous block monitoring with periodic tasks.
+// Each periodic goroutine watches stopCh so a graceful shutdown stops them
+// from starting new work; wg.Wait then returns once they have all exited,
+// which lets Sync() (and therefore main.go's doneCh) complete cleanly.
+func singleBlockInsertion(stopCh <-chan struct{}) {
 	configs.Logger.Info("Starting single block insertion process")
 
 	// Initialize collections if they don't exist
@@ -322,8 +340,14 @@ func singleBlockInsertion() {
 			// Run immediately on start
 			processBlockPeriodically()
 
-			for range ticker.C {
-				processBlockPeriodically()
+			for {
+				select {
+				case <-ticker.C:
+					processBlockPeriodically()
+				case <-stopCh:
+					configs.Logger.Info("Stopping block processing on shutdown signal")
+					return
+				}
 			}
 		}
 	}()
@@ -341,8 +365,14 @@ func singleBlockInsertion() {
 		// Run immediately on start
 		updateDataPeriodically()
 
-		for range ticker.C {
-			updateDataPeriodically()
+		for {
+			select {
+			case <-ticker.C:
+				updateDataPeriodically()
+			case <-stopCh:
+				configs.Logger.Info("Stopping data updates on shutdown signal")
+				return
+			}
 		}
 	}()
 
@@ -359,8 +389,14 @@ func singleBlockInsertion() {
 		// Run immediately on start
 		updateValidatorsPeriodically()
 
-		for range ticker.C {
-			updateValidatorsPeriodically()
+		for {
+			select {
+			case <-ticker.C:
+				updateValidatorsPeriodically()
+			case <-stopCh:
+				configs.Logger.Info("Stopping validator updates on shutdown signal")
+				return
+			}
 		}
 	}()
 
@@ -374,15 +410,27 @@ func singleBlockInsertion() {
 		ticker := time.NewTicker(time.Minute * 5)
 		defer ticker.Stop()
 
-		// Wait 1 minute before first run to let initial sync settle
-		time.Sleep(time.Minute)
+		// Wait 1 minute before first run to let initial sync settle, but bail
+		// out early if a shutdown arrives during that initial delay.
+		select {
+		case <-time.After(time.Minute):
+		case <-stopCh:
+			configs.Logger.Info("Stopping gap detection on shutdown signal")
+			return
+		}
 
-		for range ticker.C {
-			detectAndFillGapsPeriodically()
+		for {
+			select {
+			case <-ticker.C:
+				detectAndFillGapsPeriodically()
+			case <-stopCh:
+				configs.Logger.Info("Stopping gap detection on shutdown signal")
+				return
+			}
 		}
 	}()
 
-	// Keep the main goroutine alive
+	// Keep the main goroutine alive until every periodic task has stopped.
 	wg.Wait()
 }
 

--- a/QRL2MongoDB/synchroniser/producer_consumer.go
+++ b/QRL2MongoDB/synchroniser/producer_consumer.go
@@ -97,10 +97,15 @@ func consumer(ch <-chan (<-chan Data)) {
 					// idempotency guard in sync.go and gap_detection.go.
 					// ProcessTransactions has no unique index on txHash, so
 					// re-running it on an already-synced block duplicates
-					// transfer + transactionByAddress rows.
-					alreadyExists := make([]bool, len(blocks))
+					// transfer + transactionByAddress rows. One $in query keeps
+					// this to a single round-trip instead of N per batch.
+					blockNumbers := make([]string, len(blocks))
 					for x := 0; x < len(blocks); x++ {
-						alreadyExists[x] = db.BlockExists(blocks[x].Result.Number)
+						blockNumbers[x] = blocks[x].Result.Number
+					}
+					alreadyExists, err := db.BlocksExist(blockNumbers)
+					if err != nil {
+						configs.Logger.Error("Failed to check existing blocks in batch", zap.Error(err))
 					}
 
 					db.InsertManyBlockDocuments(data.blockData)
@@ -108,7 +113,7 @@ func consumer(ch <-chan (<-chan Data)) {
 						zap.Int("count", len(data.blockData)))
 
 					for x := 0; x < len(blocks); x++ {
-						if alreadyExists[x] {
+						if alreadyExists[blocks[x].Result.Number] {
 							configs.Logger.Info("Batch block already processed, skipping transaction processing",
 								zap.String("block", blocks[x].Result.Number))
 							continue

--- a/QRL2MongoDB/synchroniser/producer_consumer.go
+++ b/QRL2MongoDB/synchroniser/producer_consumer.go
@@ -87,11 +87,32 @@ func consumer(ch <-chan (<-chan Data)) {
 						continue
 					}
 
+					// Snapshot which blocks already exist BEFORE the InsertMany.
+					// After InsertManyBlockDocuments runs, every block in the
+					// batch is present, so checking existence afterward would
+					// also skip ProcessTransactions for legitimately new blocks.
+					// Capturing it up front lets us skip ProcessTransactions only
+					// for blocks that were already synced (crash/restart during
+					// catch-up, overlapping ranges), matching the BlockExists
+					// idempotency guard in sync.go and gap_detection.go.
+					// ProcessTransactions has no unique index on txHash, so
+					// re-running it on an already-synced block duplicates
+					// transfer + transactionByAddress rows.
+					alreadyExists := make([]bool, len(blocks))
+					for x := 0; x < len(blocks); x++ {
+						alreadyExists[x] = db.BlockExists(blocks[x].Result.Number)
+					}
+
 					db.InsertManyBlockDocuments(data.blockData)
 					configs.Logger.Info("Inserted block batch",
 						zap.Int("count", len(data.blockData)))
 
 					for x := 0; x < len(blocks); x++ {
+						if alreadyExists[x] {
+							configs.Logger.Info("Batch block already processed, skipping transaction processing",
+								zap.String("block", blocks[x].Result.Number))
+							continue
+						}
 						db.ProcessTransactions(blocks[x])
 						// Tombstone any pending rows whose hashes are in this
 						// block. The single-block path (sync.go) calls this

--- a/QRL2MongoDB/synchroniser/sync.go
+++ b/QRL2MongoDB/synchroniser/sync.go
@@ -418,6 +418,13 @@ func processSubsequentBlocks(currentBlock string) string {
 				zap.String("rollback_target", rollbackTarget),
 				zap.String("stale_block", parentBlockNum),
 				zap.Error(err))
+			// Rollback did not delete the stale block. Returning parentBlockNum
+			// here would let the BlockExists guard skip the still-present N-1,
+			// advance to N, re-detect the mismatch, and ping-pong forever
+			// without ever repairing the data. Return currentBlock instead so
+			// the next tick retries this same block (and the rollback) until it
+			// succeeds.
+			return currentBlock
 		}
 		// Resume from the rolled-back point: re-sync the stale block (N-1)
 		// first so its parent linkage is rebuilt before N.

--- a/QRL2MongoDB/synchroniser/sync.go
+++ b/QRL2MongoDB/synchroniser/sync.go
@@ -246,7 +246,6 @@ func Sync() {
 	singleBlockInsertion()
 }
 
-
 // findHighestProcessedBlock finds the highest block number that exists in the database
 func findHighestProcessedBlock() string {
 	// First try to get the last synced block from the database
@@ -405,14 +404,45 @@ func processSubsequentBlocks(currentBlock string) string {
 			zap.String("expected_parent", dbParentHash),
 			zap.String("actual_parent", blockData.Result.ParentHash))
 
-		// Roll back one block and try again
-		err = db.Rollback(currentBlock)
+		// Reorg: block N (currentBlock) does not build on the stored block N-1
+		// (parentBlockNum), so the stored N-1 is stale and must be removed.
+		// Rollback deletes blocks with blockNumberInt > arg (strict $gt), so to
+		// include N-1 in the deletion set we pass N-2 (parentBlockNum - 0x1).
+		// Rollback then deletes every block >= N-1 (i.e. the stale N-1 and any
+		// stragglers above it) and resets the sync state to N-2, so the
+		// continuous loop re-syncs starting at N-1.
+		rollbackTarget := utils.SubtractHexNumbers(parentBlockNum, "0x1")
+		err = db.Rollback(rollbackTarget)
 		if err != nil {
 			configs.Logger.Error("Failed to rollback block",
-				zap.String("block", currentBlock),
+				zap.String("rollback_target", rollbackTarget),
+				zap.String("stale_block", parentBlockNum),
 				zap.Error(err))
 		}
+		// Resume from the rolled-back point: re-sync the stale block (N-1)
+		// first so its parent linkage is rebuilt before N.
 		return parentBlockNum
+	}
+
+	// Idempotency guard: if this block is already stored, skip BOTH the block
+	// insert and ProcessTransactions together. InsertBlockDocument already
+	// no-ops on an existing block, but ProcessTransactions used to run
+	// unconditionally right after, duplicating transfer + transactionByAddress
+	// rows (which have no unique index on txHash) on any re-process: retry
+	// after a partial failure, node restart, or gap-fill overlap. Guarding both
+	// with one BlockExists check keeps them consistent.
+	//
+	// This does NOT block the reorg re-sync path above: Rollback deletes the
+	// stale block first, so BlockExists returns false on the subsequent
+	// reprocess and the block is re-inserted correctly.
+	if db.BlockExists(currentBlock) {
+		configs.Logger.Info("Block already processed, skipping insert and transaction processing",
+			zap.String("block", currentBlock),
+			zap.String("hash", blockData.Result.Hash))
+		// Still advance the sync state and return the next block so the caller
+		// continues forward rather than re-checking the same block.
+		db.StoreLastKnownBlockNumber(currentBlock)
+		return utils.AddHexNumbers(currentBlock, "0x1")
 	}
 
 	// Process the block
@@ -437,4 +467,3 @@ func processSubsequentBlocks(currentBlock string) string {
 	// Return next block number
 	return utils.AddHexNumbers(currentBlock, "0x1")
 }
-

--- a/QRL2MongoDB/synchroniser/sync.go
+++ b/QRL2MongoDB/synchroniser/sync.go
@@ -92,8 +92,10 @@ func getRPCDelay(bulkSync bool) time.Duration {
 	return time.Duration(delay) * time.Millisecond
 }
 
-// Sync starts the synchronization process
-func Sync() {
+// Sync starts the synchronization process. stopCh is closed by main.go on a
+// termination signal; it is threaded into every background ticker goroutine
+// started here so they stop accepting new work during graceful shutdown.
+func Sync(stopCh <-chan struct{}) {
 	var err error
 	var nextBlock string
 	var maxHex string
@@ -231,11 +233,11 @@ func Sync() {
 	go func() {
 		// Start wallet count sync
 		configs.Logger.Info("Starting wallet count sync service...")
-		db.StartWalletCountSync()
+		db.StartWalletCountSync(stopCh)
 
 		// Start contract reprocessing job
 		configs.Logger.Info("Starting contract reprocessing service...")
-		db.StartContractReprocessingJob()
+		db.StartContractReprocessingJob(stopCh)
 	}()
 
 	// Signal that initial sync is done so mempool polling can begin
@@ -243,7 +245,7 @@ func Sync() {
 	configs.Logger.Info("Initial sync flag set, mempool polling enabled")
 
 	configs.Logger.Info("Starting continuous block monitoring...")
-	singleBlockInsertion()
+	singleBlockInsertion(stopCh)
 }
 
 // findHighestProcessedBlock finds the highest block number that exists in the database

--- a/QRL2MongoDB/synchroniser/token_sync.go
+++ b/QRL2MongoDB/synchroniser/token_sync.go
@@ -16,8 +16,8 @@ import (
 
 // TokenSyncConfig holds configuration for token sync operations
 type TokenSyncConfig struct {
-	BatchSize      int
-	BatchDelayMs   int
+	BatchSize       int
+	BatchDelayMs    int
 	QueryTimeoutSec int
 }
 
@@ -207,6 +207,20 @@ func InitializeTokenCollections() error {
 		initErrors = append(initErrors, err)
 	} else {
 		configs.Logger.Info("Successfully initialized token transfers collection")
+
+		// Self-applying, idempotent backfill of blockNumberInt on legacy rows.
+		// Runs synchronously AFTER the index exists so the numeric sorts (and
+		// the backend, which sorts on the same field) order the full history
+		// correctly before the sync loop starts. Bounded by batched bulk
+		// writes; a second startup is a no-op once complete. A failure here is
+		// non-fatal: log it and continue, the field still populates for new
+		// rows at write time and the next restart retries the remaining rows.
+		backfillCtx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		if err := db.BackfillTokenTransferBlockNumberInt(backfillCtx); err != nil {
+			configs.Logger.Error("tokenTransfers blockNumberInt backfill failed; will retry on next restart",
+				zap.Error(err))
+		}
+		cancel()
 	}
 
 	// Initialize token balances collection

--- a/backendAPI/configs/const.go
+++ b/backendAPI/configs/const.go
@@ -10,20 +10,32 @@ import (
 const QUANTA float64 = 1000000000000000000
 
 var Url string = os.Getenv("NODE_URL")
-var TransferCollections *mongo.Collection = GetCollection(DB, "transfer")
-var TransactionByAddressCollection *mongo.Collection = GetCollection(DB, "transactionByAddress")
-var InternalTransactionByAddressCollection *mongo.Collection = GetCollection(DB, "internalTransactionByAddress")
-var AddressesCollections *mongo.Collection = GetCollection(DB, "addresses")
-var BlocksCollection *mongo.Collection = GetCollection(DB, "blocks")
-var ValidatorsCollections *mongo.Collection = GetCollection(DB, "validators")
-var ContractInfoCollection *mongo.Collection = GetCollection(DB, "contractCode")
-var ContractVerificationsCollection *mongo.Collection = GetCollection(DB, "contractVerifications")
-var BlockSizesCollection *mongo.Collection = GetCollection(DB, "averageBlockSize")
-var TotalCirculatingSupplyCollection *mongo.Collection = GetCollection(DB, "totalCirculatingSupply")
-var CoinGeckoCollection *mongo.Collection = GetCollection(DB, "coingecko")
-var WalletCountCollections *mongo.Collection = GetCollection(DB, "walletCount")
-var DailyTransactionsVolumeCollection *mongo.Collection = GetCollection(DB, "dailyTransactionsVolume")
-var EpochInfoCollection *mongo.Collection = GetCollection(DB, "epoch_info")
-var ValidatorHistoryCollection *mongo.Collection = GetCollection(DB, "validator_history")
-var PriceHistoryCollection *mongo.Collection = GetCollection(DB, "priceHistory")
+
+// Collection handles. These are populated by ConnectDB once the client is
+// confirmed live (see initCollections), not at package-init time. Binding
+// them at declaration via GetCollection(DB, ...) used to force a Mongo
+// connect during package initialization (because DB is nil there, the
+// nil-guard in GetCollection calls ConnectDB), which meant a Mongo outage
+// log.Fatal'd before main's panic recovery was installed and left the
+// startup ordering fragile. Every reader of these vars runs inside an HTTP
+// handler, which only executes after RequestHandler has called ConnectDB.
+var (
+	TransferCollections                    *mongo.Collection
+	TransactionByAddressCollection         *mongo.Collection
+	InternalTransactionByAddressCollection *mongo.Collection
+	AddressesCollections                   *mongo.Collection
+	BlocksCollection                       *mongo.Collection
+	ValidatorsCollections                  *mongo.Collection
+	ContractInfoCollection                 *mongo.Collection
+	ContractVerificationsCollection        *mongo.Collection
+	BlockSizesCollection                   *mongo.Collection
+	TotalCirculatingSupplyCollection       *mongo.Collection
+	CoinGeckoCollection                    *mongo.Collection
+	WalletCountCollections                 *mongo.Collection
+	DailyTransactionsVolumeCollection      *mongo.Collection
+	EpochInfoCollection                    *mongo.Collection
+	ValidatorHistoryCollection             *mongo.Collection
+	PriceHistoryCollection                 *mongo.Collection
+)
+
 var Validate = validator.New()

--- a/backendAPI/configs/env.go
+++ b/backendAPI/configs/env.go
@@ -26,3 +26,18 @@ func EnvMongoURI() string {
 
 	return os.Getenv("MONGOURI")
 }
+
+// ValidateEnv fail-fasts on missing required configuration before the server
+// starts serving. Without this, a missing MONGOURI surfaces only as a late
+// log.Fatal inside ConnectDB, and a missing NODE_URL silently defaults to
+// localhost in db.NodeRPC, masking a misconfiguration in production. Call
+// this once early in main. EnvMongoURI() loads the .env file as a side
+// effect, so calling it first ensures NODE_URL is populated from .env too.
+func ValidateEnv() {
+	if EnvMongoURI() == "" {
+		log.Fatal("MONGOURI is not set; set it in the environment or .env before starting")
+	}
+	if os.Getenv("NODE_URL") == "" {
+		log.Fatal("NODE_URL is not set; set it in the environment or .env before starting")
+	}
+}

--- a/backendAPI/configs/setup.go
+++ b/backendAPI/configs/setup.go
@@ -51,9 +51,37 @@ func ConnectDB() *mongo.Client {
 
 		// Set the global DB variable
 		DB = client
+
+		// Bind the package-level collection handles now that the client is
+		// confirmed live. Doing this here (rather than at package-var
+		// declaration time) removes the nil-client window: every reader runs
+		// inside an HTTP handler, which only executes after this point.
+		bindCollections(client)
 	})
 
 	return DB
+}
+
+// bindCollections wires the package-level *mongo.Collection handles to the
+// live client. Called once from ConnectDB after the ping succeeds.
+func bindCollections(client *mongo.Client) {
+	db := client.Database("qrldata-z")
+	TransferCollections = db.Collection("transfer")
+	TransactionByAddressCollection = db.Collection("transactionByAddress")
+	InternalTransactionByAddressCollection = db.Collection("internalTransactionByAddress")
+	AddressesCollections = db.Collection("addresses")
+	BlocksCollection = db.Collection("blocks")
+	ValidatorsCollections = db.Collection("validators")
+	ContractInfoCollection = db.Collection("contractCode")
+	ContractVerificationsCollection = db.Collection("contractVerifications")
+	BlockSizesCollection = db.Collection("averageBlockSize")
+	TotalCirculatingSupplyCollection = db.Collection("totalCirculatingSupply")
+	CoinGeckoCollection = db.Collection("coingecko")
+	WalletCountCollections = db.Collection("walletCount")
+	DailyTransactionsVolumeCollection = db.Collection("dailyTransactionsVolume")
+	EpochInfoCollection = db.Collection("epoch_info")
+	ValidatorHistoryCollection = db.Collection("validator_history")
+	PriceHistoryCollection = db.Collection("priceHistory")
 }
 
 func createIndexes(db *mongo.Database) {
@@ -114,7 +142,12 @@ func createIndexes(db *mongo.Database) {
 		},
 	}
 
-	// internalTransactionByAddress collection indexes
+	// internalTransactionByAddress collection indexes.
+	// The compound (from|to, blockTimestamp desc) pair backs the $or+sort in
+	// ReturnAllInternalTransactionsByAddress; the hash index backs the
+	// per-tx lookups in GetInternalTransactionsByTxHash and
+	// CountInternalTxsByTxHashes. The legacy single-field from/to indexes
+	// are kept so existing query plans don't regress.
 	internalTransactionsIndexes := []mongo.IndexModel{
 		{
 			Keys:    bson.D{{Key: "from", Value: 1}},
@@ -123,6 +156,24 @@ func createIndexes(db *mongo.Database) {
 		{
 			Keys:    bson.D{{Key: "to", Value: 1}},
 			Options: options.Index().SetName("internal_to"),
+		},
+		{
+			Keys: bson.D{
+				{Key: "from", Value: 1},
+				{Key: "blockTimestamp", Value: -1},
+			},
+			Options: options.Index().SetName("internal_from_blocktimestamp_desc"),
+		},
+		{
+			Keys: bson.D{
+				{Key: "to", Value: 1},
+				{Key: "blockTimestamp", Value: -1},
+			},
+			Options: options.Index().SetName("internal_to_blocktimestamp_desc"),
+		},
+		{
+			Keys:    bson.D{{Key: "hash", Value: 1}},
+			Options: options.Index().SetName("internal_hash"),
 		},
 	}
 

--- a/backendAPI/configs/setup.go
+++ b/backendAPI/configs/setup.go
@@ -2,7 +2,6 @@ package configs
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -20,7 +19,17 @@ var dbOnce sync.Once
 // It uses a sync.Once to ensure the connection is only established once
 func ConnectDB() *mongo.Client {
 	dbOnce.Do(func() {
-		client, err := mongo.NewClient(options.Client().ApplyURI(EnvMongoURI()))
+		// Conservative connection-pool defaults so a burst of concurrent HTTP
+		// handlers doesn't exhaust or thrash Mongo connections. The driver's
+		// zero-value pool is effectively unbounded, which lets a traffic spike
+		// open an unbounded number of sockets.
+		clientOpts := options.Client().
+			ApplyURI(EnvMongoURI()).
+			SetMaxPoolSize(100).
+			SetMinPoolSize(5).
+			SetMaxConnIdleTime(60 * time.Second)
+
+		client, err := mongo.NewClient(clientOpts)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -38,7 +47,7 @@ func ConnectDB() *mongo.Client {
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Println("Connected to MongoDB")
+		log.Println("Connected to MongoDB")
 
 		// Initialize collections with validators and indexes
 		db := client.Database("qrldata-z")

--- a/backendAPI/configs/setup.go
+++ b/backendAPI/configs/setup.go
@@ -260,6 +260,30 @@ func createIndexes(db *mongo.Database) {
 		},
 	}
 
+	// tokenBalances collection indexes.
+	// holderAddress backs the per-wallet balance reads (GetTokenBalancesByAddress,
+	// GetNFTBalancesByAddress) and the by-holder $group in GetTokenHolders.
+	// contractAddress backs the per-contract reads (GetTokenHolders /
+	// GetTokenInfo holder count). The (contractAddress, tokenID) compound backs
+	// the tokenID-scoped holders path and the GetTokenIDs distinct-id aggregation.
+	tokenBalancesIndexes := []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "holderAddress", Value: 1}},
+			Options: options.Index().SetName("token_balances_holder"),
+		},
+		{
+			Keys:    bson.D{{Key: "contractAddress", Value: 1}},
+			Options: options.Index().SetName("token_balances_contract"),
+		},
+		{
+			Keys: bson.D{
+				{Key: "contractAddress", Value: 1},
+				{Key: "tokenID", Value: 1},
+			},
+			Options: options.Index().SetName("token_balances_contract_tokenid"),
+		},
+	}
+
 	// validators collection indexes (per-document model)
 	validatorsIndexes := []mongo.IndexModel{
 		{
@@ -286,6 +310,7 @@ func createIndexes(db *mongo.Database) {
 		"transfer":                     transferIndexes,
 		"validators":                   validatorsIndexes,
 		"tokenTransfers":               tokenTransfersIndexes,
+		"tokenBalances":                tokenBalancesIndexes,
 	}
 
 	for collName, indexes := range collections {

--- a/backendAPI/configs/setup.go
+++ b/backendAPI/configs/setup.go
@@ -220,32 +220,39 @@ func createIndexes(db *mongo.Database) {
 	}
 
 	// tokenTransfers collection indexes.
-	// The (contractAddress, blockNumber desc) compound backs the per-contract
-	// transfer feed in GetTokenTransfers; the (from|to, blockNumber desc) pair
+	// The (contractAddress, blockNumberInt desc) compound backs the per-contract
+	// transfer feed in GetTokenTransfers; the (from|to, blockNumberInt desc) pair
 	// backs the by-holder $or+sort in GetTokenTransfersByAddress; the txHash
 	// index backs the per-tx lookups in GetTokenTransfersByTxHash and
 	// CountTokenTransfersByTxHashes.
+	//
+	// The compound sorts run on the numeric blockNumberInt field (true chain
+	// order) rather than the hex string blockNumber (lexicographic). The index
+	// names carry an _int suffix so they are created fresh on DBs that still
+	// hold the older blockNumber-keyed indexes (the existence check is by name;
+	// the legacy token_*_block_desc indexes become redundant and can be dropped
+	// manually).
 	tokenTransfersIndexes := []mongo.IndexModel{
 		{
 			Keys: bson.D{
 				{Key: "contractAddress", Value: 1},
-				{Key: "blockNumber", Value: -1},
+				{Key: "blockNumberInt", Value: -1},
 			},
-			Options: options.Index().SetName("token_contract_block_desc"),
+			Options: options.Index().SetName("token_contract_block_int_desc"),
 		},
 		{
 			Keys: bson.D{
 				{Key: "from", Value: 1},
-				{Key: "blockNumber", Value: -1},
+				{Key: "blockNumberInt", Value: -1},
 			},
-			Options: options.Index().SetName("token_from_block_desc"),
+			Options: options.Index().SetName("token_from_block_int_desc"),
 		},
 		{
 			Keys: bson.D{
 				{Key: "to", Value: 1},
-				{Key: "blockNumber", Value: -1},
+				{Key: "blockNumberInt", Value: -1},
 			},
-			Options: options.Index().SetName("token_to_block_desc"),
+			Options: options.Index().SetName("token_to_block_int_desc"),
 		},
 		{
 			Keys:    bson.D{{Key: "txHash", Value: 1}},

--- a/backendAPI/configs/setup.go
+++ b/backendAPI/configs/setup.go
@@ -102,6 +102,15 @@ func createIndexes(db *mongo.Database) {
 			},
 			Options: options.Index().SetName("result_hash"),
 		},
+		{
+			// Backs the $elemMatch tx-by-hash lookup in ReturnSingleTransfer,
+			// which scans blocks for a transaction whose hash matches the
+			// query. Without this the lookup is a full collection scan.
+			Keys: bson.D{
+				{Key: "result.transactions.hash", Value: 1},
+			},
+			Options: options.Index().SetName("result_transactions_hash"),
+		},
 	}
 
 	// transactionByAddress collection indexes
@@ -183,6 +192,14 @@ func createIndexes(db *mongo.Database) {
 			Keys:    bson.D{{Key: "address", Value: 1}},
 			Options: options.Index().SetName("contract_address_unique").SetUnique(true),
 		},
+		{
+			// Backs GetContractByCreationTx (the /tx/:hash "contract created"
+			// lookup). Sparse because most contractCode rows have no
+			// creationTransaction field, so the index only holds the rows that
+			// do, keeping it small.
+			Keys:    bson.D{{Key: "creationTransaction", Value: 1}},
+			Options: options.Index().SetName("contract_creation_tx").SetSparse(true),
+		},
 	}
 
 	// transfer collection indexes
@@ -190,6 +207,40 @@ func createIndexes(db *mongo.Database) {
 		{
 			Keys:    bson.D{{Key: "txHash", Value: 1}},
 			Options: options.Index().SetName("transfer_txhash_unique").SetUnique(true),
+		},
+	}
+
+	// tokenTransfers collection indexes.
+	// The (contractAddress, blockNumber desc) compound backs the per-contract
+	// transfer feed in GetTokenTransfers; the (from|to, blockNumber desc) pair
+	// backs the by-holder $or+sort in GetTokenTransfersByAddress; the txHash
+	// index backs the per-tx lookups in GetTokenTransfersByTxHash and
+	// CountTokenTransfersByTxHashes.
+	tokenTransfersIndexes := []mongo.IndexModel{
+		{
+			Keys: bson.D{
+				{Key: "contractAddress", Value: 1},
+				{Key: "blockNumber", Value: -1},
+			},
+			Options: options.Index().SetName("token_contract_block_desc"),
+		},
+		{
+			Keys: bson.D{
+				{Key: "from", Value: 1},
+				{Key: "blockNumber", Value: -1},
+			},
+			Options: options.Index().SetName("token_from_block_desc"),
+		},
+		{
+			Keys: bson.D{
+				{Key: "to", Value: 1},
+				{Key: "blockNumber", Value: -1},
+			},
+			Options: options.Index().SetName("token_to_block_desc"),
+		},
+		{
+			Keys:    bson.D{{Key: "txHash", Value: 1}},
+			Options: options.Index().SetName("token_txhash"),
 		},
 	}
 
@@ -218,6 +269,7 @@ func createIndexes(db *mongo.Database) {
 		"contractCode":                 contractCodeIndexes,
 		"transfer":                     transferIndexes,
 		"validators":                   validatorsIndexes,
+		"tokenTransfers":               tokenTransfersIndexes,
 	}
 
 	for collName, indexes := range collections {

--- a/backendAPI/db/block.go
+++ b/backendAPI/db/block.go
@@ -130,7 +130,12 @@ func ReturnBlockSizes() ([]primitive.M, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	opts := options.Find().SetSort(primitive.D{{Key: "timestamp", Value: 1}})
+	// Cap the result set: averageBlockSize grows without bound as the syncer
+	// appends time-series rows, and this feeds a chart that only renders a
+	// finite window. 2000 points is well past what any chart shows.
+	opts := options.Find().
+		SetSort(primitive.D{{Key: "timestamp", Value: 1}}).
+		SetLimit(2000)
 
 	cursor, err := configs.BlockSizesCollection.Find(ctx, primitive.D{}, opts)
 	if err != nil {

--- a/backendAPI/db/contract.go
+++ b/backendAPI/db/contract.go
@@ -47,26 +47,37 @@ func ReturnContracts(page int64, limit int64, search string, isTokenFilter *bool
 		// address + creatorAddress exact-match branches).
 		normalizedSearch := normalizeAddress(search)
 
-		// Escape regex metacharacters in the user input so a `.` or `*`
-		// in the search term doesn't behave as a wildcard or DoS vector.
-		escaped := regexp.QuoteMeta(search)
-		nameRegex := bson.D{{Key: "$regex", Value: escaped}, {Key: "$options", Value: "i"}}
+		// Build the $or branches. Exact address/creatorAddress matches are
+		// always included so short queries can still resolve a contract by
+		// its address. The case-insensitive name/symbol/metadataName regex
+		// branches run an unanchored full-collection scan, so we only add
+		// them for queries of at least 3 chars: a 1-2 char regex matches
+		// nearly every row and turns search into a table scan with no useful
+		// result. Shorter queries simply return the exact-match results
+		// (often empty), which the contracts page renders as a normal empty
+		// paginated list.
+		orBranches := bson.A{
+			bson.D{{Key: "address", Value: normalizedSearch}},
+			bson.D{{Key: "creatorAddress", Value: normalizedSearch}},
+		}
+		if len(search) >= 3 {
+			// Escape regex metacharacters in the user input so a `.` or `*`
+			// in the search term doesn't behave as a wildcard or DoS vector.
+			escaped := regexp.QuoteMeta(search)
+			nameRegex := bson.D{{Key: "$regex", Value: escaped}, {Key: "$options", Value: "i"}}
 
-		// Search by exact address, exact creator address, OR partial
-		// case-insensitive match against name + symbol + metadataName.
-		// Symbol was previously absent, searching "MQW" missed tokens whose
-		// `name` field held the full project label instead of the ticker.
-		// Phase 3a adds metadataName so a user searching by the off-chain
-		// display title hits the row even when on-chain name() is empty.
-		searchFilter := bson.D{
-			{Key: "$or", Value: bson.A{
-				bson.D{{Key: "address", Value: normalizedSearch}},
-				bson.D{{Key: "creatorAddress", Value: normalizedSearch}},
+			// Symbol was previously absent, searching "MQW" missed tokens whose
+			// `name` field held the full project label instead of the ticker.
+			// Phase 3a adds metadataName so a user searching by the off-chain
+			// display title hits the row even when on-chain name() is empty.
+			orBranches = append(orBranches,
 				bson.D{{Key: "name", Value: nameRegex}},
 				bson.D{{Key: "symbol", Value: nameRegex}},
 				bson.D{{Key: "metadataName", Value: nameRegex}},
-			}},
+			)
 		}
+
+		searchFilter := bson.D{{Key: "$or", Value: orBranches}}
 		// Combine with existing filter
 		if len(filter) > 0 {
 			filter = bson.D{{Key: "$and", Value: bson.A{filter, searchFilter}}}

--- a/backendAPI/db/contract.go
+++ b/backendAPI/db/contract.go
@@ -92,12 +92,25 @@ func ReturnContracts(page int64, limit int64, search string, isTokenFilter *bool
 		return nil, 0, err
 	}
 
-	// Set up pagination options
+	// Set up pagination options. The contracts list/grid renders only the
+	// lightweight summary fields (address, name, symbol, decimals, standard,
+	// metadata thumbnail, etc), so project out the heavy verification blobs
+	// (full source, ABI, constructor args, libraries, raw bytecode, AI
+	// explanation). These can be tens to hundreds of KB per row and would
+	// otherwise be streamed for every page even though no consumer reads them.
 	skip := page * limit
 	opts := options.Find().
 		SetSkip(skip).
 		SetLimit(limit).
-		SetSort(bson.D{{Key: "_id", Value: -1}}) // Latest first
+		SetSort(bson.D{{Key: "_id", Value: -1}}). // Latest first
+		SetProjection(bson.D{
+			{Key: "sourceCode", Value: 0},
+			{Key: "abi", Value: 0},
+			{Key: "constructorArguments", Value: 0},
+			{Key: "libraries", Value: 0},
+			{Key: "contractCode", Value: 0},
+			{Key: "aiExplanation", Value: 0},
+		})
 
 	cursor, err := configs.ContractInfoCollection.Find(ctx, filter, opts)
 	if err != nil {
@@ -232,9 +245,22 @@ func GetContractsByAddresses(addresses []string) (map[string]models.ContractInfo
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	// The /tx and /pending-transaction consumers read only the lightweight
+	// metadata (name, symbol, tokenStandard, verified, contractName) plus the
+	// ABI (used for calldata/event decoding when the contract is verified), so
+	// project out the heavy verification blobs that aren't consumed here:
+	// full source, constructor args, libraries, raw bytecode, AI explanation.
+	// The ABI itself is kept because the callers decode against it.
+	opts := options.Find().SetProjection(bson.D{
+		{Key: "sourceCode", Value: 0},
+		{Key: "constructorArguments", Value: 0},
+		{Key: "libraries", Value: 0},
+		{Key: "contractCode", Value: 0},
+		{Key: "aiExplanation", Value: 0},
+	})
 	cursor, err := configs.ContractInfoCollection.Find(ctx, bson.M{
 		"address": bson.M{"$in": normalized},
-	})
+	}, opts)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
 			return out, nil

--- a/backendAPI/db/stats.go
+++ b/backendAPI/db/stats.go
@@ -38,6 +38,32 @@ func getCoinGeckoData() (*models.CoinGecko, error) {
 	return &result, err
 }
 
+// MarketSnapshot bundles the three CoinGecko-derived values so a caller that
+// needs all of them (e.g. /overview) can fetch the single coingecko document
+// once instead of issuing three separate FindOne reads via GetMarketCap /
+// GetCurrentPrice / GetCurrentVolume.
+type MarketSnapshot struct {
+	MarketCapUSD float64
+	PriceUSD     float64
+	VolumeUSD    float64
+}
+
+// GetMarketSnapshot reads the coingecko document once and returns all three
+// values. On error it logs and returns a zero snapshot, matching the
+// individual getters' fallback behaviour.
+func GetMarketSnapshot() MarketSnapshot {
+	data, err := getCoinGeckoData()
+	if err != nil {
+		log.Printf("error fetching market snapshot: %v", err)
+		return MarketSnapshot{}
+	}
+	return MarketSnapshot{
+		MarketCapUSD: data.MarketCapUSD,
+		PriceUSD:     data.PriceUSD,
+		VolumeUSD:    data.VolumeUSD,
+	}
+}
+
 func GetMarketCap() float64 {
 	data, err := getCoinGeckoData()
 	if err != nil {

--- a/backendAPI/db/stats.go
+++ b/backendAPI/db/stats.go
@@ -95,7 +95,7 @@ func GetPriceHistory(interval string) ([]models.PriceHistory, error) {
 		limit = 1440 // ~30 min intervals for 30 days
 	case "all":
 		since = time.Time{} // Beginning of time
-		limit = 0           // No limit
+		limit = 5000        // Hard cap so an unbounded scan can't grow without limit
 	default:
 		// Default to 24h
 		since = now.Add(-24 * time.Hour)

--- a/backendAPI/db/token.go
+++ b/backendAPI/db/token.go
@@ -837,6 +837,11 @@ func GetNFTBalancesByAddress(address string, standardFilter *string) ([]models.N
 			{Key: "tokenIDLen", Value: 1},
 			{Key: "tokenID", Value: 1},
 		}},
+		// Bound the materialized result set. Without a cap a wallet holding
+		// thousands of NFT rows forces Mongo to sort + stream every row on
+		// each request. 500 covers any realistic single-wallet picker view;
+		// the route is not paginated so this is a hard ceiling, not a page.
+		{"$limit": 500},
 		{"$project": bson.M{"tokenIDLen": 0}},
 	}
 

--- a/backendAPI/db/token.go
+++ b/backendAPI/db/token.go
@@ -471,9 +471,11 @@ func GetTokenTransfers(contractAddress string, page, limit int) ([]models.TokenT
 		return nil, 0, err
 	}
 
-	// Find with pagination, sorted by block number descending (most recent first)
+	// Find with pagination, sorted by block number descending (most recent first).
+	// Sort on the numeric blockNumberInt field, not the hex string blockNumber,
+	// so ordering is true chain order rather than lexicographic.
 	opts := options.Find().
-		SetSort(bson.D{{Key: "blockNumber", Value: -1}}).
+		SetSort(bson.D{{Key: "blockNumberInt", Value: -1}}).
 		SetSkip(int64(page * limit)).
 		SetLimit(int64(limit))
 
@@ -499,7 +501,7 @@ func GetTokenTransfers(contractAddress string, page, limit int) ([]models.TokenT
 // holder address (either side: from or to), with pagination. Matches the
 // shape of GetTokenTransfers so the address-page consumer can render the
 // same row schema produced by /token/:address/transfers. Sorted by
-// blockNumber desc so the most recent transfer is first.
+// blockNumberInt desc so the most recent transfer is first.
 //
 // The address is normalised to the canonical Q-prefix lowercase form the
 // syncer writes; we don't expand to a multi-variant $in here because every
@@ -540,7 +542,7 @@ func GetTokenTransfersByAddress(address string, page, limit int) ([]models.Token
 	}
 
 	opts := options.Find().
-		SetSort(bson.D{{Key: "blockNumber", Value: -1}}).
+		SetSort(bson.D{{Key: "blockNumberInt", Value: -1}}).
 		SetSkip(int64(page * limit)).
 		SetLimit(int64(limit))
 

--- a/backendAPI/db/token.go
+++ b/backendAPI/db/token.go
@@ -126,9 +126,11 @@ func GetTokenBalancesByAddress(address string, standardFilter *string) ([]models
 	return results, nil
 }
 
-// normalizeAddress converts any address format to the canonical Q-prefix
+// NormalizeAddress converts any address format to the canonical Q-prefix
 // form that the syncer stores in MongoDB (uppercase Q + lowercase hex).
-func normalizeAddress(address string) string {
+// Exported so route handlers can reuse the exact same canonicalisation
+// when computing map keys instead of duplicating the logic.
+func NormalizeAddress(address string) string {
 	if strings.HasPrefix(address, "0x") || strings.HasPrefix(address, "0X") {
 		return "Q" + strings.ToLower(address[2:])
 	}
@@ -136,6 +138,12 @@ func normalizeAddress(address string) string {
 		return "Q" + strings.ToLower(address[1:])
 	}
 	return "Q" + strings.ToLower(address)
+}
+
+// normalizeAddress is the package-private alias kept so existing db callers
+// (and tests) read unchanged.
+func normalizeAddress(address string) string {
+	return NormalizeAddress(address)
 }
 
 // normalizeAddressBoth returns the canonical Q-prefix address as a slice.

--- a/backendAPI/db/validator.go
+++ b/backendAPI/db/validator.go
@@ -477,10 +477,14 @@ func GetValidatorStats() (*models.ValidatorStatsResponse, error) {
 		}, nil
 	}
 
-	// Use aggregation to compute per-status counts and total staked in one pass.
+	// Use a single aggregation to compute per-status counts and total staked.
 	// Status computation requires knowing currentEpoch, which MongoDB doesn't know,
 	// so we project the fields needed and compute buckets in a $group stage using
-	// $cond expressions that mirror getValidatorStatus logic.
+	// $cond expressions that mirror getValidatorStatus logic. A $facet then fans
+	// the same scanned documents into the status buckets and the balance sum so
+	// the whole thing is one cursor over the collection instead of two passes.
+	// $sum needs numeric input and balances are decimal strings, so the sum
+	// branch converts with $toLong inside the pipeline.
 	currentEpochStr := fmt.Sprintf("%d", currentEpoch)
 
 	pipeline := mongo.Pipeline{
@@ -512,11 +516,19 @@ func GetValidatorStats() (*models.ValidatorStatsResponse, error) {
 				},
 			},
 		}}},
-		bson.D{{Key: "$group", Value: bson.M{
-			"_id":   "$_computedStatus",
-			"count": bson.M{"$sum": 1},
-			// We sum effective balance as strings; MongoDB can't do numeric sum on
-			// decimal-string fields, so we fall back to a cursor scan for totalStaked.
+		bson.D{{Key: "$facet", Value: bson.M{
+			"statusCounts": []bson.M{
+				{"$group": bson.M{
+					"_id":   "$_computedStatus",
+					"count": bson.M{"$sum": 1},
+				}},
+			},
+			"totals": []bson.M{
+				{"$group": bson.M{
+					"_id":         nil,
+					"totalStaked": bson.M{"$sum": bson.M{"$toLong": "$effectiveBalance"}},
+				}},
+			},
 		}}},
 	}
 
@@ -526,15 +538,26 @@ func GetValidatorStats() (*models.ValidatorStatsResponse, error) {
 	}
 	defer cursor.Close(ctx)
 
-	var activeCount, pendingCount, exitedCount, slashedCount int
-	for cursor.Next(ctx) {
-		var row struct {
+	var facetResult struct {
+		StatusCounts []struct {
 			ID    string `bson:"_id"`
 			Count int    `bson:"count"`
+		} `bson:"statusCounts"`
+		Totals []struct {
+			TotalStaked int64 `bson:"totalStaked"`
+		} `bson:"totals"`
+	}
+	if cursor.Next(ctx) {
+		if err := cursor.Decode(&facetResult); err != nil {
+			return nil, fmt.Errorf("failed to decode validator stats: %v", err)
 		}
-		if err := cursor.Decode(&row); err != nil {
-			continue
-		}
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("cursor error while reading validator stats: %v", err)
+	}
+
+	var activeCount, pendingCount, exitedCount, slashedCount int
+	for _, row := range facetResult.StatusCounts {
 		switch row.ID {
 		case "active":
 			activeCount = row.Count
@@ -546,33 +569,10 @@ func GetValidatorStats() (*models.ValidatorStatsResponse, error) {
 			slashedCount = row.Count
 		}
 	}
-	if err := cursor.Err(); err != nil {
-		return nil, fmt.Errorf("cursor error while reading validator stats: %v", err)
-	}
-
-	// Compute total staked via a second aggregation (sum of effectiveBalance).
-	// MongoDB $sum works on numeric types; balances are stored as decimal strings,
-	// so we convert with $toLong inside the pipeline.
-	sumPipeline := mongo.Pipeline{
-		bson.D{{Key: "$group", Value: bson.M{
-			"_id":         nil,
-			"totalStaked": bson.M{"$sum": bson.M{"$toLong": "$effectiveBalance"}},
-		}}},
-	}
-	sumCursor, err := configs.ValidatorsCollections.Aggregate(ctx, sumPipeline)
-	if err != nil {
-		return nil, fmt.Errorf("failed to aggregate total staked: %v", err)
-	}
-	defer sumCursor.Close(ctx)
 
 	totalStaked := int64(0)
-	if sumCursor.Next(ctx) {
-		var sumRow struct {
-			TotalStaked int64 `bson:"totalStaked"`
-		}
-		if err := sumCursor.Decode(&sumRow); err == nil {
-			totalStaked = sumRow.TotalStaked
-		}
+	if len(facetResult.Totals) > 0 {
+		totalStaked = facetResult.Totals[0].TotalStaked
 	}
 
 	return &models.ValidatorStatsResponse{

--- a/backendAPI/db/validator.go
+++ b/backendAPI/db/validator.go
@@ -103,10 +103,20 @@ func CountValidators() (int64, error) {
 }
 
 // HexToInt converts a hex string (with or without 0x prefix) to int64.
+// Parses as unsigned first: ParseInt returns 0 for any value with the high
+// bit set (block numbers near 2^63), which would silently zero the epoch
+// math downstream. Values that overflow int64 are clamped to math.MaxInt64
+// so the result stays usable for the /128 epoch division callers perform.
 func HexToInt(hexStr string) int64 {
 	hexStr = strings.TrimPrefix(hexStr, "0x")
-	num, _ := strconv.ParseInt(hexStr, 16, 64)
-	return num
+	num, err := strconv.ParseUint(hexStr, 16, 64)
+	if err != nil {
+		return 0
+	}
+	if num > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(num)
 }
 
 // FAR_FUTURE_EPOCH represents a validator that hasn't exited.
@@ -386,7 +396,7 @@ func GetEpochDetail(epochId string) (*models.EpochDetailResponse, error) {
 	blockMap := make(map[int64]models.EpochDetailBlock)
 	for cursor.Next(ctx) {
 		var doc struct {
-			BlockNumberInt int64        `bson:"blockNumberInt"`
+			BlockNumberInt int64         `bson:"blockNumberInt"`
 			Result         models.Result `bson:"result"`
 		}
 		if err := cursor.Decode(&doc); err != nil {
@@ -481,8 +491,8 @@ func GetValidatorStats() (*models.ValidatorStatsResponse, error) {
 					"branches": []bson.M{
 						{
 							// slashed
-							"case":  bson.M{"$eq": []interface{}{"$slashed", true}},
-							"then":  "slashed",
+							"case": bson.M{"$eq": []interface{}{"$slashed", true}},
+							"then": "slashed",
 						},
 						{
 							// pending: activationEpoch > currentEpoch
@@ -503,8 +513,8 @@ func GetValidatorStats() (*models.ValidatorStatsResponse, error) {
 			},
 		}}},
 		bson.D{{Key: "$group", Value: bson.M{
-			"_id":          "$_computedStatus",
-			"count":        bson.M{"$sum": 1},
+			"_id":   "$_computedStatus",
+			"count": bson.M{"$sum": 1},
 			// We sum effective balance as strings; MongoDB can't do numeric sum on
 			// decimal-string fields, so we fall back to a cursor scan for totalStaked.
 		}}},
@@ -545,7 +555,7 @@ func GetValidatorStats() (*models.ValidatorStatsResponse, error) {
 	// so we convert with $toLong inside the pipeline.
 	sumPipeline := mongo.Pipeline{
 		bson.D{{Key: "$group", Value: bson.M{
-			"_id": nil,
+			"_id":         nil,
 			"totalStaked": bson.M{"$sum": bson.M{"$toLong": "$effectiveBalance"}},
 		}}},
 	}

--- a/backendAPI/db/validator.go
+++ b/backendAPI/db/validator.go
@@ -187,10 +187,16 @@ func GetValidatorHistory(limit int) (*models.ValidatorHistoryResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	findOpts := options.Find().SetSort(bson.D{{Key: "epoch", Value: -1}})
-	if limit > 0 {
-		findOpts.SetLimit(int64(limit))
+	// Cap an unbounded request so a limit=0 (or negative) caller can't force a
+	// full-collection scan of validator_history. Explicit small limits are
+	// honoured unchanged.
+	if limit <= 0 {
+		limit = 1000
 	}
+
+	findOpts := options.Find().
+		SetSort(bson.D{{Key: "epoch", Value: -1}}).
+		SetLimit(int64(limit))
 
 	cursor, err := configs.ValidatorHistoryCollection.Find(ctx, bson.M{}, findOpts)
 	if err != nil {

--- a/backendAPI/main.go
+++ b/backendAPI/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"backendAPI/configs"
 	"backendAPI/handler"
 	"fmt"
 	"io"
@@ -22,6 +23,11 @@ func main() {
 
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile)
 	log.Println("BackendAPI starting...")
+
+	// Fail fast on missing required config before serving. A missing MONGOURI
+	// would otherwise surface only as a late log.Fatal inside ConnectDB, and a
+	// missing NODE_URL would silently default to localhost in db.NodeRPC.
+	configs.ValidateEnv()
 
 	// Recover from panics
 	defer func() {

--- a/backendAPI/models/token_balance.go
+++ b/backendAPI/models/token_balance.go
@@ -42,6 +42,7 @@ type TokenTransfer struct {
 	To              string `json:"to" bson:"to"`
 	Amount          string `json:"amount" bson:"amount"`
 	BlockNumber     string `json:"blockNumber" bson:"blockNumber"`
+	BlockNumberInt  int64  `json:"blockNumberInt" bson:"blockNumberInt"`
 	TxHash          string `json:"txHash" bson:"txHash"`
 	LogIndex        string `json:"logIndex,omitempty" bson:"logIndex,omitempty"`
 	Timestamp       string `json:"timestamp" bson:"timestamp"`

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -399,8 +399,13 @@ func UserRoute(router *gin.Engine) {
 		// per request. Cache the assembled payload for 10 s so N concurrent
 		// pageviews fan into 1 backend computation.
 		v, err := routeCache.GetOrCompute("overview", 10*time.Second, func() (interface{}, error) {
-			marketCap := db.GetMarketCap()
-			currentPrice := db.GetCurrentPrice()
+			// GetMarketCap / GetCurrentPrice / GetCurrentVolume each issue their
+			// own FindOne against the single coingecko document. Fetch the
+			// snapshot once and reuse it so /overview makes one read instead of
+			// three for the same row.
+			market := db.GetMarketSnapshot()
+			marketCap := market.MarketCapUSD
+			currentPrice := market.PriceUSD
 			walletCount := db.GetWalletCount()
 
 			circulating := db.ReturnTotalCirculatingSupply()
@@ -420,7 +425,7 @@ func UserRoute(router *gin.Engine) {
 				contractCount = 0
 			}
 
-			tradingVolume := db.GetCurrentVolume()
+			tradingVolume := market.VolumeUSD
 
 			return gin.H{
 				"marketcap":      marketCap,

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -1566,6 +1566,13 @@ func UserRoute(router *gin.Engine) {
 			return
 		}
 
+		// Cap the length before SetString: a uint256 token ID is at most 78
+		// decimal digits, so anything longer is invalid and parsing an
+		// arbitrarily long string into big.Int is a CPU-DoS vector.
+		if len(tokenID) > 80 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "tokenID is too large"})
+			return
+		}
 		if _, ok := new(big.Int).SetString(tokenID, 10); !ok {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "tokenID must be a decimal integer"})
 			return

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -1060,7 +1060,15 @@ func UserRoute(router *gin.Engine) {
 
 	router.GET("/validators", func(c *gin.Context) {
 		pageToken := c.Query("page_token")
-		validatorResponse, err := db.ReturnValidators(pageToken)
+		// ReturnValidators fetches the full validator set (one doc per
+		// validator) and sums TotalStaked, an expensive unsegmented read.
+		// The set only shifts at epoch boundaries (~minutes), so a 30s TTL
+		// caches the full-collection fetch instead of running it per request.
+		// Keyed by page_token so future server-side pagination stays correct.
+		key := "validators:" + pageToken
+		v, err := routeCache.GetOrCompute(key, 30*time.Second, func() (interface{}, error) {
+			return db.ReturnValidators(pageToken)
+		})
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": fmt.Sprintf("Failed to fetch validators: %v", err),
@@ -1068,7 +1076,7 @@ func UserRoute(router *gin.Engine) {
 			return
 		}
 
-		c.JSON(http.StatusOK, validatorResponse)
+		c.JSON(http.StatusOK, v)
 	})
 
 	// Get epoch detail by ID

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"math/big"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -18,6 +19,64 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo"
 )
+
+// Path-param format guards. These reject malformed input at the route
+// boundary (HTTP 400) before it reaches the db layer, instead of letting
+// a junk string fan out into Mongo filters / RPC calls. The accepted
+// shapes mirror what the frontend search resolver emits (see
+// ExplorerFrontend/app/lib/searchResolver.ts).
+var (
+	// txHashRe matches a "0x"-prefixed 32-byte hash (the only tx/block
+	// hash form the explorer surfaces).
+	txHashRe = regexp.MustCompile(`^0x[0-9a-fA-F]{64}$`)
+	// addrParamRe matches both address forms the frontend forwards: the
+	// canonical "Q" + 40 hex (case-insensitive Q) and the "0x" + 40 hex
+	// contract form. db.normalizeAddress canonicalises both downstream.
+	addrParamRe = regexp.MustCompile(`^([Qq]|0x|0X)[0-9a-fA-F]{40}$`)
+	// validatorPubkeyRe matches a hex public-key lookup key (optional 0x
+	// prefix). Even-length and an upper bound are enforced in
+	// isValidValidatorID rather than the pattern, because Go's regexp
+	// rejects the nested-repeat form that would express "even, bounded"
+	// inline. The decimal-index form is handled separately so plain
+	// integers still resolve.
+	validatorPubkeyRe = regexp.MustCompile(`^(0x|0X)?[0-9a-fA-F]+$`)
+)
+
+// isValidTxHash reports whether s is a "0x"-prefixed 32-byte hash.
+func isValidTxHash(s string) bool {
+	return txHashRe.MatchString(s)
+}
+
+// isValidAddressParam reports whether s is one of the address forms a
+// route path param legitimately carries (Q + 40 hex or 0x + 40 hex).
+// Use this for :address / :query route guards; the stricter Q-only
+// isValidAddress stays reserved for the contract-write endpoints whose
+// inputs are never 0x-form.
+func isValidAddressParam(s string) bool {
+	return addrParamRe.MatchString(s)
+}
+
+// isValidValidatorID reports whether s is a decimal validator index or a
+// hex public-key key. GetValidatorByID looks up by _id (decimal index)
+// then falls back to publicKeyHex, so both shapes are legitimate.
+func isValidValidatorID(s string) bool {
+	if s == "" {
+		return false
+	}
+	if _, err := strconv.ParseUint(s, 10, 64); err == nil {
+		return true
+	}
+	if !validatorPubkeyRe.MatchString(s) {
+		return false
+	}
+	// Strip an optional 0x prefix, then require an even-length hex body of
+	// a sane size (1..2000 hex chars covers any real pubkey scheme).
+	body := s
+	if len(body) >= 2 && (body[:2] == "0x" || body[:2] == "0X") {
+		body = body[2:]
+	}
+	return len(body) > 0 && len(body)%2 == 0 && len(body) <= 2000
+}
 
 // normalizeContractAddr maps any input address form (0x-hex, q-lower, bare
 // hex, Q-canonical) to the canonical "Q" + lowercase hex shape the syncer
@@ -254,6 +313,10 @@ func UserRoute(router *gin.Engine) {
 	// Add endpoint for fetching a specific pending transaction
 	router.GET("/pending-transaction/:hash", func(c *gin.Context) {
 		hash := c.Param("hash")
+		if !isValidTxHash(hash) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid transaction hash; expected 0x + 64 hex chars"})
+			return
+		}
 		transaction, err := db.GetPendingTransactionByHash(hash)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -495,6 +558,10 @@ func UserRoute(router *gin.Engine) {
 
 	router.GET("/address/aggregate/:query", func(c *gin.Context) {
 		param := c.Param("query")
+		if !isValidAddressParam(param) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		// db functions normalize the address to canonical q-prefix internally.
 
 		// Pagination for the tx-list aggregations. Defaults match the old
@@ -589,6 +656,10 @@ func UserRoute(router *gin.Engine) {
 
 	router.GET("/tx/:query", func(c *gin.Context) {
 		value := c.Param("query")
+		if !isValidTxHash(value) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid transaction hash; expected 0x + 64 hex chars"})
+			return
+		}
 		query, err := db.ReturnSingleTransfer(value)
 		if err != nil {
 			log.Printf("error fetching transfer %s: %v", value, err)
@@ -840,6 +911,10 @@ func UserRoute(router *gin.Engine) {
 
 	router.GET("/coinbase/:query", func(c *gin.Context) {
 		value := c.Param("query")
+		if !isValidTxHash(value) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid transaction hash; expected 0x + 64 hex chars"})
+			return
+		}
 		query, err := db.ReturnSingleTransfer(value)
 		// A missing tx is not a server fault: keep the historical 200-with-empty
 		// behavior for not-found. Any other DB error becomes a 500 instead of a
@@ -1054,6 +1129,10 @@ func UserRoute(router *gin.Engine) {
 	// Get individual validator details
 	router.GET("/validator/:id", func(c *gin.Context) {
 		id := c.Param("id")
+		if !isValidValidatorID(id) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid validator id; expected a decimal index or hex public key"})
+			return
+		}
 		validator, err := db.GetValidatorByID(id)
 		if err != nil {
 			c.JSON(http.StatusNotFound, gin.H{
@@ -1230,6 +1309,10 @@ func UserRoute(router *gin.Engine) {
 	// Add a new endpoint to get limited non-zero transactions for an address
 	router.GET("/address/:address/transactions", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		page, limit := getPaginationParams(c, 1, 5)
 
 		transactions, err := db.ReturnNonZeroTransactions(address, page, limit)
@@ -1268,6 +1351,10 @@ func UserRoute(router *gin.Engine) {
 	// by contract not by holder. Paginated like /address/:addr/transactions.
 	router.GET("/address/:address/token-transfers", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		// Match the address-page Transactions table's 5-rows-per-page default
 		// (paginated server-side, page-1-indexed). Cap matches the DB layer.
 		page, limit := getPaginationParams(c, 1, 5)
@@ -1304,6 +1391,10 @@ func UserRoute(router *gin.Engine) {
 	// fungibles.
 	router.GET("/address/:address/tokens", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 
 		var standardFilter *string
 		if s := c.Query("standard"); s != "" {
@@ -1343,6 +1434,10 @@ func UserRoute(router *gin.Engine) {
 	// on the sibling /tokens?standard=ERC-20.
 	router.GET("/address/:address/nfts", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 
 		var standardFilter *string
 		if s := c.Query("standard"); s != "" {
@@ -1376,6 +1471,10 @@ func UserRoute(router *gin.Engine) {
 	// Get token info (summary stats for a token contract)
 	router.GET("/token/:address/info", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 
 		info, err := db.GetTokenInfo(address)
 		if err != nil {
@@ -1395,6 +1494,10 @@ func UserRoute(router *gin.Engine) {
 	// holder, balance is the cross-id total). ERC-20 behaviour unchanged.
 	router.GET("/token/:address/holders", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		tokenID := c.Query("tokenID")
 		page, limit := getPaginationParams(c, 0, 25)
 
@@ -1423,6 +1526,10 @@ func UserRoute(router *gin.Engine) {
 	// when off-chain metadata has been fetched.
 	router.GET("/token/:address/tokens", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		page, limit := getPaginationParams(c, 0, 25)
 
 		tokens, totalCount, err := db.GetTokenIDs(address, page, limit)
@@ -1454,6 +1561,11 @@ func UserRoute(router *gin.Engine) {
 		address := c.Param("address")
 		tokenID := c.Param("id")
 
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
+
 		if _, ok := new(big.Int).SetString(tokenID, 10); !ok {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "tokenID must be a decimal integer"})
 			return
@@ -1475,6 +1587,10 @@ func UserRoute(router *gin.Engine) {
 	// Get token transfers with pagination
 	router.GET("/token/:address/transfers", func(c *gin.Context) {
 		address := c.Param("address")
+		if !isValidAddressParam(address) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid address; expected Q or 0x followed by 40 hex chars"})
+			return
+		}
 		page, limit := getPaginationParams(c, 0, 25)
 
 		transfers, totalCount, err := db.GetTokenTransfers(address, page, limit)
@@ -1503,6 +1619,10 @@ func UserRoute(router *gin.Engine) {
 	// db/gas.go; the route just plumbs it together.
 	router.GET("/pending-tx-eta/:hash", func(c *gin.Context) {
 		hash := c.Param("hash")
+		if !isValidTxHash(hash) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid transaction hash; expected 0x + 64 hex chars"})
+			return
+		}
 		v, err := routeCache.GetOrCompute("eta:"+hash, 5*time.Second, func() (interface{}, error) {
 			tx, err := db.GetPendingTransactionByHash(hash)
 			if err != nil {

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -87,13 +87,7 @@ func normalizeContractAddr(addr string) string {
 	if addr == "" {
 		return ""
 	}
-	if strings.HasPrefix(addr, "0x") || strings.HasPrefix(addr, "0X") {
-		return "Q" + strings.ToLower(addr[2:])
-	}
-	if strings.HasPrefix(addr, "Q") || strings.HasPrefix(addr, "q") {
-		return "Q" + strings.ToLower(addr[1:])
-	}
-	return "Q" + strings.ToLower(addr)
+	return db.NormalizeAddress(addr)
 }
 
 // receiptLog mirrors the subset of qrl_getTransactionReceipt.logs[] the tx

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -304,7 +304,7 @@ func UserRoute(router *gin.Engine) {
 		})
 		if err != nil {
 			log.Printf("Error fetching pending transactions: %v", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -319,7 +319,8 @@ func UserRoute(router *gin.Engine) {
 		}
 		transaction, err := db.GetPendingTransactionByHash(hash)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error fetching pending transaction %s: %v", hash, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 
@@ -327,7 +328,8 @@ func UserRoute(router *gin.Engine) {
 		if transaction == nil {
 			tx, err := db.GetTransactionByHash(hash)
 			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				log.Printf("error fetching transaction %s: %v", hash, err)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 				return
 			}
 
@@ -442,7 +444,8 @@ func UserRoute(router *gin.Engine) {
 			}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error building overview: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -470,7 +473,7 @@ func UserRoute(router *gin.Engine) {
 		if err != nil {
 			log.Printf("Error fetching price history: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch price history: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -533,7 +536,8 @@ func UserRoute(router *gin.Engine) {
 			}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error fetching transactions: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -648,7 +652,8 @@ func UserRoute(router *gin.Engine) {
 			}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error aggregating address %s: %v", param, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -665,18 +670,30 @@ func UserRoute(router *gin.Engine) {
 			log.Printf("error fetching transfer %s: %v", value, err)
 		}
 
+		// ReturnSingleTransfer returns a zero-value Transfer (no error path
+		// distinguishes "found" from "missing" for the transfers-collection
+		// fallback), so detect not-found via an empty TxHash and return 404
+		// instead of a misleading 200 with empty fields. The frontend tx page
+		// maps 404 to notFound().
+		if query.TxHash == "" {
+			c.JSON(http.StatusNotFound, gin.H{"error": "transaction not found"})
+			return
+		}
+
 		latestBlockNumber, err := db.GetLatestBlockFromSyncState()
 		if err != nil {
+			log.Printf("error getting latest block: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to get latest block: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
 
 		latestBlockNum, err := parseHexBlockNumber(latestBlockNumber)
 		if err != nil {
+			log.Printf("error parsing latest block number %q: %v", latestBlockNumber, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to parse block number: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -903,7 +920,8 @@ func UserRoute(router *gin.Engine) {
 			}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error fetching latest block: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -933,7 +951,8 @@ func UserRoute(router *gin.Engine) {
 			return gin.H{"richlist": db.ReturnRichlist()}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error fetching richlist: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -1016,7 +1035,8 @@ func UserRoute(router *gin.Engine) {
 			return gin.H{"blocks": blocks, "total": countBlocks, "blockActivity": blockActivity}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error fetching blocks: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -1033,7 +1053,8 @@ func UserRoute(router *gin.Engine) {
 			return gin.H{"response": query}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error fetching block sizes: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -1045,8 +1066,9 @@ func UserRoute(router *gin.Engine) {
 
 		result, err := db.GetEpochs(page, limit)
 		if err != nil {
+			log.Printf("error fetching epochs: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch epochs: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1070,8 +1092,9 @@ func UserRoute(router *gin.Engine) {
 			return db.ReturnValidators(pageToken)
 		})
 		if err != nil {
+			log.Printf("error fetching validators: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch validators: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1088,8 +1111,9 @@ func UserRoute(router *gin.Engine) {
 				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 				return
 			}
+			log.Printf("error fetching epoch detail %s: %v", epochId, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch epoch detail: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1100,8 +1124,9 @@ func UserRoute(router *gin.Engine) {
 	router.GET("/epoch", func(c *gin.Context) {
 		epochInfo, err := db.GetEpochInfo()
 		if err != nil {
+			log.Printf("error fetching epoch info: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch epoch info: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1114,8 +1139,9 @@ func UserRoute(router *gin.Engine) {
 
 		history, err := db.GetValidatorHistory(limit)
 		if err != nil {
+			log.Printf("error fetching validator history: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch validator history: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1126,8 +1152,9 @@ func UserRoute(router *gin.Engine) {
 	router.GET("/validators/stats", func(c *gin.Context) {
 		stats, err := db.GetValidatorStats()
 		if err != nil {
+			log.Printf("error fetching validator stats: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch validator stats: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1167,7 +1194,8 @@ func UserRoute(router *gin.Engine) {
 			return gin.H{"response": query}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error fetching latest transactions: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -1185,7 +1213,8 @@ func UserRoute(router *gin.Engine) {
 			return counts, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error counting contracts by standard: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -1222,8 +1251,9 @@ func UserRoute(router *gin.Engine) {
 
 		query, total, err := db.ReturnContracts(page, limit, search, isTokenFilter, standardFilter)
 		if err != nil {
+			log.Printf("error fetching contracts: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch contracts: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1327,7 +1357,7 @@ func UserRoute(router *gin.Engine) {
 		if err != nil {
 			log.Printf("Error fetching non-zero transactions: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch transactions: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1372,7 +1402,7 @@ func UserRoute(router *gin.Engine) {
 		if err != nil {
 			log.Printf("Error fetching token transfers for %s: %v", address, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("Failed to fetch token transfers: %v", err),
+				"error": "internal server error",
 			})
 			return
 		}
@@ -1685,7 +1715,8 @@ func UserRoute(router *gin.Engine) {
 			}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error computing pending-tx eta %s: %v", hash, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		if v == nil {
@@ -1759,7 +1790,8 @@ func UserRoute(router *gin.Engine) {
 			}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error computing gas summary: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)
@@ -1792,7 +1824,8 @@ func UserRoute(router *gin.Engine) {
 			return gin.H{"range": rng, "data": rows}, nil
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Printf("error fetching gas history: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, v)

--- a/backendAPI/routes/routes_test.go
+++ b/backendAPI/routes/routes_test.go
@@ -1,0 +1,94 @@
+package routes
+
+import "testing"
+
+// These cover the path-param format guards added to reject malformed
+// input at the route boundary (HTTP 400) before it reaches the db layer.
+// The accepted shapes mirror the frontend search resolver
+// (ExplorerFrontend/app/lib/searchResolver.ts).
+
+func TestIsValidTxHash(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"canonical 0x + 64 hex", "0x" + repeat("a", 64), true},
+		{"uppercase hex body", "0x" + repeat("AB", 32), true},
+		{"missing 0x prefix", repeat("a", 64), false},
+		{"one char short", "0x" + repeat("a", 63), false},
+		{"one char too long", "0x" + repeat("a", 65), false},
+		{"non-hex char", "0x" + repeat("g", 64), false},
+		{"address mistaken for hash", "Q" + repeat("a", 40), false},
+		{"empty", "", false},
+		{"mongo-operator injection attempt", `0x"; return true; //`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidTxHash(tc.in); got != tc.want {
+				t.Errorf("isValidTxHash(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsValidAddressParam(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"Q + 40 hex", "Q" + repeat("a", 40), true},
+		{"lowercase q + 40 hex", "q" + repeat("a", 40), true},
+		{"0x + 40 hex contract form", "0x" + repeat("a", 40), true},
+		{"uppercase 0X prefix", "0X" + repeat("AB", 20), true},
+		{"bare 40 hex rejected", repeat("a", 40), false},
+		{"too short", "Q" + repeat("a", 39), false},
+		{"too long", "Q" + repeat("a", 41), false},
+		{"tx hash rejected", "0x" + repeat("a", 64), false},
+		{"non-hex body", "Q" + repeat("z", 40), false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidAddressParam(tc.in); got != tc.want {
+				t.Errorf("isValidAddressParam(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsValidValidatorID(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"decimal index", "1", true},
+		{"large decimal index", "1048576", true},
+		{"zero index", "0", true},
+		{"bare hex pubkey", repeat("ab", 48), true},
+		{"0x-prefixed hex pubkey", "0x" + repeat("ab", 48), true},
+		{"odd-length hex rejected", "abc", false},
+		{"non-hex rejected", "xyz", false},
+		{"empty", "", false},
+		{"injection attempt", `{"$ne":null}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidValidatorID(tc.in); got != tc.want {
+				t.Errorf("isValidValidatorID(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// repeat returns s concatenated n times. Local helper so the table cases
+// stay readable without importing strings.Repeat at every call site.
+func repeat(s string, n int) string {
+	out := make([]byte, 0, len(s)*n)
+	for i := 0; i < n; i++ {
+		out = append(out, s...)
+	}
+	return string(out)
+}

--- a/backendAPI/routes/verification_routes.go
+++ b/backendAPI/routes/verification_routes.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -113,7 +114,8 @@ func RegisterVerificationRoutes(router *gin.Engine) {
 			},
 		}
 		if err := db.CreateVerificationJob(job); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "create job: " + err.Error()})
+			log.Printf("create verification job %s: %v", jobID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 
@@ -130,7 +132,8 @@ func RegisterVerificationRoutes(router *gin.Engine) {
 		jobID := c.Param("jobId")
 		job, err := db.GetVerificationJob(jobID)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "lookup: " + err.Error()})
+			log.Printf("lookup verification job %s: %v", jobID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
 		if job == nil {


### PR DESCRIPTION
Batch 10. Stacked on #143 (base `fix/codebase-review-batch9`).

**Named finding:** `models.Address.Balance` was `float32`, truncating balances to ~7 significant digits on read (anything over ~7 digits lost its fractional QRL). The value is stored as a BSON double and the **backend model already uses float64**, so widening the syncer model is a lossless, zero-migration fix (storage unchanged, UpsertTransactions already writes float64).

**Discovered bug (fixed):** `circulating.go` decoded the same balance field into an `int64` local struct. The Mongo driver errors decoding a double into int64, so `UpdateTotalBalance` failed on every address and **circulating supply has been stuck at 0**. Now decodes as float64 and accumulates in a `big.Float` (precise over many addresses), emitting an integer-QRL string via `Text('f', 0)` to preserve the existing `circulating` string contract the backend reads.

**Deferred (genuinely needs operator/decision input):** full raw-wei integer precision would require re-querying every address balance from the node (the stored QRL-float already dropped sub-unit precision); ERC-20 amount hex-vs-decimal normalization; dependency-vuln bumps (elliptic / form-data) which need wallet-flow testing.

**Validation:** syncer build/vet/gofmt clean.