### PR TITLE
fix(monitor): remove MongoDB wipe from sync-complete hook

### DIFF
--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -115,26 +115,22 @@ else
         fi
     fi
 
-    # --- One-shot sync completion: notify + deploy zondscan ---
+    # --- One-shot sync completion: notify + restart zondscan ---
     # Persist outside /tmp: a reboot wipes /tmp, and the node is already synced
-    # post-reboot, so a /tmp-based flag would re-trigger the DB wipe every time.
+    # post-reboot, so a /tmp-based flag would re-trigger this every time.
+    # Deliberately does NOT touch MongoDB. A monitoring script should never
+    # have destructive DB access; if a clean re-index is ever needed, that's
+    # a manual, explicit operation, not something a cron job can misfire into.
     SYNC_DONE_FLAG="$HOME/.monitor-sync-complete"
     if [ ! -f "$SYNC_DONE_FLAG" ]; then
         # Node is synced (qrl_syncing returns false) and has enough blocks
         if [ "$SYNC_RESULT" = "False" ] && [ "$NODE_BLOCK" -gt 100 ]; then
             touch "$SYNC_DONE_FLAG"
-            # Wipe old data and start zondscan
-            if mongosh --quiet --eval "db.getSiblingDB('qrldata-z').dropDatabase()" >/dev/null 2>&1; then
-                pm2 restart synchroniser handler frontend >/dev/null 2>&1
-                pm2 save >/dev/null 2>&1
-                curl -s -H "Content-Type: application/json" \
-                    -d "{\"content\":\"🎉 **Sync Complete** ($(hostname))\\nNode fully synced on chain ID 1337 (block $NODE_BLOCK).\\nZondscan deployed, syncer, handler, frontend started. MongoDB wiped for clean re-index.\"}" \
-                    "$WEBHOOK" >/dev/null
-            else
-                curl -s -H "Content-Type: application/json" \
-                    -d "{\"content\":\"⚠️ **Sync Complete (wipe failed)** ($(hostname))\\nNode fully synced (block $NODE_BLOCK), but MongoDB dropDatabase failed. Services NOT restarted.\"}" \
-                    "$WEBHOOK" >/dev/null
-            fi
+            pm2 restart synchroniser handler frontend >/dev/null 2>&1
+            pm2 save >/dev/null 2>&1
+            curl -s -H "Content-Type: application/json" \
+                -d "{\"content\":\"🎉 **Sync Complete** ($(hostname))\\nNode fully synced on chain ID 1337 (block $NODE_BLOCK).\\nZondscan restarted: syncer, handler, frontend.\"}" \
+                "$WEBHOOK" >/dev/null
         fi
     fi
 fi


### PR DESCRIPTION
## Summary
- Follow-up to #145. The sync-complete one-shot in `scripts/monitor.sh` ran `dropDatabase()` before restarting zondscan on a fresh sync. A cron-driven monitoring script should not have destructive DB access at all, if the sync detection ever misfires (stale RPC read, race on `SYNC_RESULT`), it should restart services, not wipe data.
- Removed the `dropDatabase()` call. The one-shot now only restarts `synchroniser`/`handler`/`frontend` and notifies. A clean re-index after a genuine resync is a manual, explicit step going forward.

## Test plan
- [x] `bash -n scripts/monitor.sh`
- [x] Applied the same change to the live script on `78.47.166.153` and dry-ran it; no MongoDB calls fire from the sync-complete branch anymore.