### PR TITLE
fix(monitor): scope fail-count dir to uid

### DIFF
--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -37,7 +37,7 @@ resolve() {
 # Debounced check: requires $threshold consecutive failing ticks before
 # alerting, so a single transient blip (a deploy restart, a GC pause) doesn't
 # page anyone. Passes reset the streak and resolve immediately.
-FAIL_COUNT_DIR="/tmp/monitor-fail-counts"
+FAIL_COUNT_DIR="/tmp/monitor-fail-counts-$(id -u)"
 mkdir -p "$FAIL_COUNT_DIR"
 
 check_debounced() {


### PR DESCRIPTION
## Summary
Follow-up to Gemini's review on #147. Two comments came in:

1. **Claimed HIGH**: an empty fail-count file would cause an arithmetic syntax error in `check_debounced()`. Verified this empirically (`set -uo pipefail`, `local`, both empty and nonexistent files) and it does not reproduce, bash treats an empty command substitution before `+` as a valid unary-plus operand and evaluates to the expected value. Not applying this one, false positive.
2. **Valid MEDIUM**: `FAIL_COUNT_DIR=/tmp/monitor-fail-counts` is a single shared directory with no per-user scoping. If anyone other than the cron user runs the script manually, ownership conflicts could silently break writes for the other user. Fixed by suffixing the dir with `$(id -u)`.

## Test plan
- [x] `bash -n scripts/monitor.sh`
- [x] Confirmed empty/nonexistent fail-count file does not error in bash (tested standalone against the exact code pattern)