### PR TITLE
fix(faucet): indicate the claimed tx is pending, not confirmed

### DIFF
--- a/ExplorerFrontend/app/faucet/faucet-client.tsx
+++ b/ExplorerFrontend/app/faucet/faucet-client.tsx
@@ -251,13 +251,18 @@ export default function FaucetClient(): JSX.Element {
 
               {result && (
                 <div role="status" className="w-full p-4 bg-background rounded-lg border border-green-500/40">
-                  <div className="text-sm text-gray-400">Sent {result.amount} QRL</div>
+                  <div className="text-sm text-gray-400">
+                    {result.amount} QRL broadcast to your address
+                  </div>
                   <Link
                     href={result.explorerUrl}
                     className="text-accent font-semibold break-all hover:underline"
                   >
                     {result.txHash}
                   </Link>
+                  <div className="mt-1 text-xs text-yellow-300/80">
+                    Transaction is pending: it should confirm within a minute.
+                  </div>
                 </div>
               )}
 

--- a/ExplorerFrontend/app/faucet/faucet-client.tsx
+++ b/ExplorerFrontend/app/faucet/faucet-client.tsx
@@ -260,7 +260,7 @@ export default function FaucetClient(): JSX.Element {
                   >
                     {result.txHash}
                   </Link>
-                  <div className="mt-1 text-xs text-yellow-300/80">
+                  <div className="mt-1 text-xs text-gray-400">
                     Transaction is pending: it should confirm within a minute.
                   </div>
                 </div>


### PR DESCRIPTION
The success card said "Sent 10 QRL", implying the transfer was complete, when the claim resolves as soon as the node accepts the broadcast. Reword to "broadcast" and add a small pending note so users know to expect a short confirmation delay before the balance updates.

No logic changes. Lint and build green.