### PR TITLE
fix(api): allow browser-extension origins through CORS

### DIFF
--- a/backendAPI/handler/handler.go
+++ b/backendAPI/handler/handler.go
@@ -103,7 +103,25 @@ func RequestHandler() {
 		}
 	}
 	router.Use(cors.New(cors.Config{
-		AllowOrigins:     allowOrigins,
+		AllowOrigins: allowOrigins,
+		// Browser extensions send Origin: chrome-extension://<install-id>;
+		// the id is per-install so it cannot be allowlisted by value. A
+		// scheme-level allowance adds no exposure beyond what a no-Origin
+		// client (curl) already gets: AllowCredentials stays false and the
+		// abuse-sensitive POST endpoints have their own rate limits.
+		AllowOriginFunc: func(origin string) bool {
+			lower := strings.ToLower(origin)
+			for _, scheme := range []string{
+				"chrome-extension://",
+				"moz-extension://",
+				"safari-web-extension://",
+			} {
+				if strings.HasPrefix(lower, scheme) {
+					return true
+				}
+			}
+			return false
+		},
 		AllowMethods:     []string{"GET", "POST"},
 		AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type", "Authorization"},
 		ExposeHeaders:    []string{"Content-Length"},


### PR DESCRIPTION
Extension pages send `Origin: chrome-extension://<install-id>`; gin-contrib/cors aborts unknown origins with 403, which silently broke the MyQRLWallet extension's token/NFT discovery and blocks its new on-chain transaction history.

- Adds an `AllowOriginFunc` (checked after the `AllowOrigins` list in v1.6.0) accepting `chrome-extension://`, `moz-extension://`, `safari-web-extension://` schemes, case-insensitive.
- Security-neutral: same access a no-Origin client (curl) already has. `AllowCredentials` stays false; billed/abuse-sensitive POST endpoints keep their rate limits.
- Mirrors the myqrlwallet-backend fix (PR #65 there), verified in prod for the RPC proxy.

Gate: `go build ./...` + `go vet ./handler/` clean.