### PR TITLE
fix: address page shows full transaction history (server-side pagination)

### DIFF
--- a/ExplorerFrontend/app/address/[query]/address-tabs.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-tabs.tsx
@@ -74,6 +74,9 @@ interface AddressTabsProps {
    *  on the backend), independent of the paginated array length. */
   transactionsCount: number;
   internalt: InternalTransaction[];
+  /** True total from `addressData.internal_transactions_count`; undefined
+   *  on handlers predating the field. */
+  internalTransactionsCount?: number;
 }
 
 /** Subset of the `/address/aggregate` payload this component consumes. The
@@ -83,6 +86,7 @@ interface AddressAggregateResponse {
   transactions_by_address?: Transaction[];
   transactions_count?: number;
   internal_transactions_by_address?: InternalTransaction[];
+  internal_transactions_count?: number;
 }
 
 export default function AddressTabs({
@@ -90,6 +94,7 @@ export default function AddressTabs({
   transactions: initialTransactions,
   transactionsCount: initialTransactionsCount,
   internalt: initialInternalt,
+  internalTransactionsCount: initialInternalTransactionsCount,
 }: AddressTabsProps): JSX.Element {
   const router = useRouter();
   const pathname = usePathname();
@@ -125,6 +130,7 @@ export default function AddressTabs({
       transactions_by_address: initialTransactions,
       transactions_count: initialTransactionsCount,
       internal_transactions_by_address: initialInternalt,
+      internal_transactions_count: initialInternalTransactionsCount,
     },
     refetchInterval: 15000,
     refetchIntervalInBackground: false,
@@ -147,6 +153,7 @@ export default function AddressTabs({
   );
   const transactionsCount = data?.transactions_count ?? 0;
   const internalt = data?.internal_transactions_by_address ?? [];
+  const internalTransactionsCount = data?.internal_transactions_count;
 
   const activeTab = parseTabKey(searchParams?.get('tab') ?? null);
 
@@ -189,10 +196,11 @@ export default function AddressTabs({
       case 'transactions':
         return transactionsCount.toLocaleString('en-US');
       case 'internal':
-        // Aggregate doesn't return a true count for internal txns and
-        // there's no dedicated endpoint. Leave unbadged rather than show
-        // a clipped .length.
-        return null;
+        // Honest server-side count when the handler provides it; unbadged
+        // (rather than a clipped .length) against older handlers.
+        return typeof internalTransactionsCount === 'number'
+          ? internalTransactionsCount.toLocaleString('en-US')
+          : null;
       case 'token-transfers':
         return tokenTransfersTotal === null
           ? null
@@ -233,7 +241,11 @@ export default function AddressTabs({
             aria-labelledby="tab-transactions"
             hidden={activeTab !== 'transactions'}
           >
-            <TransactionsPanel transactions={transactions} />
+            <TransactionsPanel
+              address={address}
+              transactions={transactions}
+              total={transactionsCount}
+            />
           </div>
         )}
         {isPanelMounted('internal') && (
@@ -243,7 +255,11 @@ export default function AddressTabs({
             aria-labelledby="tab-internal"
             hidden={activeTab !== 'internal'}
           >
-            <InternalPanel internalt={internalt} />
+            <InternalPanel
+              address={address}
+              internalt={internalt}
+              total={internalTransactionsCount}
+            />
           </div>
         )}
         {isPanelMounted('token-transfers') && (

--- a/ExplorerFrontend/app/address/[query]/address-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-view.tsx
@@ -29,10 +29,14 @@ export default function AddressView({ addressData, addressSegment }: AddressView
     const { balance } = addressData.address;
     const { rank } = addressData;
 
-    let firstSeen = 0;
-    let lastSeen = 0;
-    if (addressData.transactions_by_address && Array.isArray(addressData.transactions_by_address) && addressData.transactions_by_address.length > 0) {
-        const timestamps = addressData.transactions_by_address.map(tx => tx.TimeStamp);
+    // Prefer the server-computed activity range: the tx list is paginated,
+    // so deriving the range from the loaded page reports the oldest row of
+    // the newest page as "First Activity". Fall back to the page-derived
+    // range against handlers predating first_seen/last_seen.
+    let firstSeen = addressData.first_seen ?? 0;
+    let lastSeen = addressData.last_seen ?? 0;
+    if (!firstSeen && addressData.transactions_by_address && Array.isArray(addressData.transactions_by_address) && addressData.transactions_by_address.length > 0) {
+        const timestamps = addressData.transactions_by_address.map(tx => Number(tx.TimeStamp));
         firstSeen = Math.min(...timestamps);
         lastSeen = Math.max(...timestamps);
     }
@@ -270,6 +274,7 @@ export default function AddressView({ addressData, addressSegment }: AddressView
                         : (addressData.transactions_by_address?.length ?? 0)
                 }
                 internalt={addressData.internal_transactions_by_address || []}
+                internalTransactionsCount={addressData.internal_transactions_count}
             />
         </main>
     );

--- a/ExplorerFrontend/app/address/[query]/address-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-view.tsx
@@ -36,9 +36,13 @@ export default function AddressView({ addressData, addressSegment }: AddressView
     let firstSeen = addressData.first_seen ?? 0;
     let lastSeen = addressData.last_seen ?? 0;
     if (!firstSeen && addressData.transactions_by_address && Array.isArray(addressData.transactions_by_address) && addressData.transactions_by_address.length > 0) {
-        const timestamps = addressData.transactions_by_address.map(tx => Number(tx.TimeStamp));
-        firstSeen = Math.min(...timestamps);
-        lastSeen = Math.max(...timestamps);
+        const timestamps = addressData.transactions_by_address
+            .map(tx => Number(tx.TimeStamp))
+            .filter(ts => !Number.isNaN(ts));
+        if (timestamps.length > 0) {
+            firstSeen = Math.min(...timestamps);
+            lastSeen = Math.max(...timestamps);
+        }
     }
 
     let addressType = "";

--- a/ExplorerFrontend/app/address/[query]/panels/internal-panel.tsx
+++ b/ExplorerFrontend/app/address/[query]/panels/internal-panel.tsx
@@ -6,7 +6,6 @@ import {
   createColumnHelper,
   getCoreRowModel,
   getFilteredRowModel,
-  getPaginationRowModel,
   useReactTable,
 } from '@tanstack/react-table';
 import type { ColumnDef, Row } from '@tanstack/react-table';
@@ -29,15 +28,22 @@ import {
   truncateMiddle,
   useIsMobile,
 } from './_table-utils';
+import {
+  PAGE_LIMIT,
+  fetchAllAggregateRows,
+  useAggregatePage,
+} from './use-aggregate-page';
 
 /**
  * Internal-transactions panel. Sub-frame calls emitted by contract
- * interactions (CALL / DELEGATECALL / CREATE). Rows come from the
- * `/address/aggregate/:addr` response that the parent already fetched.
+ * interactions (CALL / DELEGATECALL / CREATE). Server-side paginated the
+ * same way as the Transactions panel: page 1 comes from the parent's live
+ * aggregate poll, pages > 1 through useAggregatePage.
  *
- * No `total` count badge: the aggregate doesn't return one for internal
- * transactions, and a dedicated endpoint doesn't exist today. Adding
- * either is out of scope for this refactor.
+ * `total` is the aggregate's internal_transactions_count. Handlers
+ * predating that field leave it undefined; the panel then degrades to
+ * sequential paging (Next enabled while pages come back full) instead of
+ * pretending the loaded rows are the whole history.
  */
 
 const columnHelper = createColumnHelper<
@@ -45,22 +51,43 @@ const columnHelper = createColumnHelper<
 >();
 
 interface InternalPanelProps {
+  address: string;
+  /** Page-1 rows from the parent's live aggregate poll. */
   internalt: InternalTransaction[];
+  /** True total when the handler provides it; undefined = unknown. */
+  total?: number;
 }
 
 export default function InternalPanel({
+  address,
   internalt,
+  total,
 }: InternalPanelProps): JSX.Element {
   const [filter, setFilter] = useState('');
+  const [page, setPage] = useState(1);
   const isMobile = useIsMobile();
+
+  const pageQuery = useAggregatePage(address, page);
+  const pageRows = pageQuery.data?.internal_transactions_by_address;
+  const rows = useMemo(
+    () => (page === 1 ? internalt : pageRows ?? []),
+    [page, internalt, pageRows],
+  );
+
+  const knownTotal = typeof total === 'number' && total > 0 ? total : undefined;
+  // Unknown total: assume one more page whenever the current page is full.
+  const hasMore = rows.length === PAGE_LIMIT;
+  const pageCount = knownTotal
+    ? Math.max(1, Math.ceil(knownTotal / PAGE_LIMIT))
+    : page + (hasMore ? 1 : 0);
 
   const data = useMemo(
     () =>
-      internalt.map((tx) => {
+      rows.map((tx) => {
         const [value, valueUnit] = formatAmount(tx.Value);
         return { ...tx, formattedValue: `${value} ${valueUnit}` };
       }),
-    [internalt],
+    [rows],
   );
 
   const columns = useMemo(
@@ -68,7 +95,15 @@ export default function InternalPanel({
       columnHelper.accessor(() => '', {
         id: 'Number',
         header: 'Number',
-        cell: (info) => <span>{internalt.length - info.row.index}</span>,
+        // Descending position within the full history when the total is
+        // known; page-local numbering otherwise (pre-count handlers).
+        cell: (info) => (
+          <span>
+            {knownTotal
+              ? knownTotal - ((page - 1) * PAGE_LIMIT + info.row.index)
+              : rows.length - info.row.index}
+          </span>
+        ),
       }),
       columnHelper.accessor('Type', {
         header: 'Type',
@@ -131,7 +166,7 @@ export default function InternalPanel({
         cell: (info) => <span>{formatTimestamp(info.getValue())}</span>,
       }),
     ],
-    [internalt.length],
+    [knownTotal, page, rows.length],
   );
 
   const table = useReactTable({
@@ -142,10 +177,9 @@ export default function InternalPanel({
     onGlobalFilterChange: setFilter,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
   });
 
-  if (internalt.length === 0) {
+  if (rows.length === 0 && page === 1) {
     return (
       <EmptyState
         title="No internal transactions"
@@ -237,22 +271,52 @@ export default function InternalPanel({
       <div className="p-4 border-b border-[#3d3d3d]">
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
           <div className="text-sm text-gray-400">
-            {internalt.length} internal call{internalt.length === 1 ? '' : 's'} loaded
+            {knownTotal
+              ? `${knownTotal.toLocaleString('en-US')} internal call${knownTotal === 1 ? '' : 's'}`
+              : `${rows.length} internal call${rows.length === 1 ? '' : 's'} loaded`}
           </div>
           <div className="flex items-center space-x-4">
             <DebouncedInput
               value={filter}
               onChange={(v) => setFilter(String(v))}
               className="px-4 py-2 text-sm bg-[#1a1a1a] border border-[#3d3d3d] rounded-lg focus:outline-none focus:border-[#ffa729] text-white w-full md:w-auto"
-              placeholder="Search internal transactions..."
+              placeholder="Search this page..."
             />
-            <DownloadBtnInternal data={internalt} />
+            <DownloadBtnInternal
+              data={rows}
+              fileName={`internal-transactions-${address}`}
+              getData={() =>
+                fetchAllAggregateRows(address, (p) => p.internal_transactions_by_address)
+              }
+            />
           </div>
         </div>
       </div>
 
-      <div className="overflow-x-auto">
-        {isMobile ? (
+      {pageQuery.isError && page > 1 && (
+        <div className="p-4 text-sm text-red-400 border-b border-[#3d3d3d]">
+          Failed to load page {page}.{' '}
+          <button
+            type="button"
+            className="underline hover:text-red-300"
+            onClick={() => { void pageQuery.refetch(); }}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      <div
+        className={`overflow-x-auto${
+          pageQuery.isFetching && page > 1 ? ' opacity-60' : ''
+        }`}
+      >
+        {rows.length === 0 && pageQuery.isFetching ? (
+          // First visit to a page > 1 has no previous query data to hold
+          // on screen (page 1 lives in the parent poll), so show an
+          // explicit loading state instead of an empty table.
+          <div className="p-8 text-center text-gray-400">Loading internal transactions...</div>
+        ) : isMobile ? (
           <div className="overflow-hidden">
             {table.getRowModel().rows.map((row) => renderCard(row))}
           </div>
@@ -265,14 +329,14 @@ export default function InternalPanel({
       </div>
 
       <Paginator
-        pageIndex={table.getState().pagination.pageIndex}
-        pageCount={table.getPageCount()}
-        canPrev={table.getCanPreviousPage()}
-        canNext={table.getCanNextPage()}
-        goFirst={() => table.setPageIndex(0)}
-        goPrev={() => table.previousPage()}
-        goNext={() => table.nextPage()}
-        goLast={() => table.setPageIndex(table.getPageCount() - 1)}
+        pageIndex={page - 1}
+        pageCount={pageCount}
+        canPrev={page > 1}
+        canNext={page < pageCount}
+        goFirst={() => setPage(1)}
+        goPrev={() => setPage((p) => Math.max(1, p - 1))}
+        goNext={() => setPage((p) => Math.min(pageCount, p + 1))}
+        goLast={() => setPage(pageCount)}
       />
     </div>
   );

--- a/ExplorerFrontend/app/address/[query]/panels/transactions-panel.tsx
+++ b/ExplorerFrontend/app/address/[query]/panels/transactions-panel.tsx
@@ -6,7 +6,6 @@ import {
   createColumnHelper,
   getCoreRowModel,
   getFilteredRowModel,
-  getPaginationRowModel,
   useReactTable,
 } from '@tanstack/react-table';
 import type { ColumnDef, Row } from '@tanstack/react-table';
@@ -28,10 +27,28 @@ import {
   truncateMiddle,
   useIsMobile,
 } from './_table-utils';
+import {
+  PAGE_LIMIT,
+  fetchAllAggregateRows,
+  useAggregatePage,
+} from './use-aggregate-page';
 
 /**
- * Native transactions panel. Renders the rows the parent address-view
- * already received from `/address/aggregate/:addr` (no fetch here).
+ * Native transactions panel with server-side pagination.
+ *
+ * The parent address-view seeds page 1 from `/address/aggregate/:addr`
+ * (kept live by the AddressTabs 15s poll); pages > 1 are fetched on demand
+ * through useAggregatePage. The old TanStack client pagination only ever
+ * paged the single server page it was handed, so any address with more
+ * than one page of history rendered as "Page 1 of 1" with its 10 newest
+ * rows and no way to reach the rest.
+ *
+ * Consequences of paging server-side:
+ *   - The search box filters the page on screen, not the whole history.
+ *   - Download exports the full history (fetchAllAggregateRows), not just
+ *     the loaded rows.
+ *   - The Number column counts down from the true total, so row numbers
+ *     stay stable across pages.
  *
  * Notable departures from the pre-refactor TanStackTable Transactions tab:
  *   - "Transaction Type" column dropped. The syncer writes TxType as a hex
@@ -39,12 +56,9 @@ import {
  *     expected, so the cell rendered empty for every row. Removed rather
  *     than translated because the value adds no information the In/Out
  *     column doesn't already convey.
- *   - "Paid Fees" now renders in Shor (10^-9 QRL / "Quanta") with a
- *     thousands-separator. The wire value is a decimal-Quanta string like
- *     "0.000078750000357000"; the old calculateFees only accepted a
- *     numeric type and fell back to 0 when handed the string, which is
- *     why the column showed "0.00 QRL" for every native tx. Multiplied
- *     by 1e9 to land in the Shor / Gwei range users actually read.
+ *   - "Paid Fees" renders in QRL with up to 8 decimals; the wire value is
+ *     a decimal-Quanta string like "0.000078750000357000" the old
+ *     calculateFees treated as 0.
  */
 
 const IN_OUT_MAP = ['Out', 'In'] as const;
@@ -55,18 +69,38 @@ const columnHelper = createColumnHelper<
 
 
 interface TransactionsPanelProps {
+  address: string;
+  /** Page-1 rows from the parent's live aggregate poll. */
   transactions: Transaction[];
+  /** True total from transactions_count, drives the page count. */
+  total: number;
 }
 
 export default function TransactionsPanel({
+  address,
   transactions,
+  total,
 }: TransactionsPanelProps): JSX.Element {
   const [filter, setFilter] = useState('');
+  const [page, setPage] = useState(1);
   const isMobile = useIsMobile();
+
+  const pageQuery = useAggregatePage(address, page);
+  const pageRows = pageQuery.data?.transactions_by_address;
+  const rows = useMemo(
+    () => (page === 1 ? transactions : pageRows ?? []),
+    [page, transactions, pageRows],
+  );
+
+  // Guard against a zero/absent total (e.g. count query failed server-side)
+  // so the Number column and page count still make sense for the rows we
+  // actually have.
+  const effectiveTotal = total > 0 ? total : rows.length;
+  const pageCount = Math.max(1, Math.ceil(effectiveTotal / PAGE_LIMIT));
 
   const data = useMemo(
     () =>
-      transactions.map((tx) => {
+      rows.map((tx) => {
         const [amount, amountUnit] = formatAmount(tx.Amount);
         // PaidFees comes off the wire as a decimal-Quanta string
         // ("0.0000787..."). Render in QRL with up to 8 decimals,
@@ -88,7 +122,7 @@ export default function TransactionsPanel({
           formattedFees,
         };
       }),
-    [transactions],
+    [rows],
   );
 
   const columns = useMemo(
@@ -96,7 +130,12 @@ export default function TransactionsPanel({
       columnHelper.accessor(() => '', {
         id: 'Number',
         header: 'Number',
-        cell: (info) => <span>{transactions.length - info.row.index}</span>,
+        // Descending position within the full history, newest = total.
+        // row.index is the position in this page's data array, stable
+        // under the in-page search filter.
+        cell: (info) => (
+          <span>{effectiveTotal - ((page - 1) * PAGE_LIMIT + info.row.index)}</span>
+        ),
       }),
       columnHelper.accessor('InOut', {
         header: 'In/Out',
@@ -162,7 +201,7 @@ export default function TransactionsPanel({
         cell: (info) => <span>{info.getValue()}</span>,
       }),
     ],
-    [transactions.length],
+    [effectiveTotal, page],
   );
 
   const table = useReactTable({
@@ -173,10 +212,9 @@ export default function TransactionsPanel({
     onGlobalFilterChange: setFilter,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
   });
 
-  if (transactions.length === 0) {
+  if (effectiveTotal === 0 && page === 1) {
     return (
       <EmptyState
         title="No transactions yet"
@@ -267,22 +305,51 @@ export default function TransactionsPanel({
       <div className="p-4 border-b border-[#3d3d3d]">
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
           <div className="text-sm text-gray-400">
-            {transactions.length} transaction{transactions.length === 1 ? '' : 's'} loaded
+            {effectiveTotal.toLocaleString('en-US')} transaction
+            {effectiveTotal === 1 ? '' : 's'}
           </div>
           <div className="flex items-center space-x-4">
             <DebouncedInput
               value={filter}
               onChange={(v) => setFilter(String(v))}
               className="px-4 py-2 text-sm bg-[#1a1a1a] border border-[#3d3d3d] rounded-lg focus:outline-none focus:border-[#ffa729] text-white w-full md:w-auto"
-              placeholder="Search transactions..."
+              placeholder="Search this page..."
             />
-            <DownloadBtn data={transactions} />
+            <DownloadBtn
+              data={rows}
+              fileName={`transactions-${address}`}
+              getData={() =>
+                fetchAllAggregateRows(address, (p) => p.transactions_by_address)
+              }
+            />
           </div>
         </div>
       </div>
 
-      <div className="overflow-x-auto">
-        {isMobile ? (
+      {pageQuery.isError && page > 1 && (
+        <div className="p-4 text-sm text-red-400 border-b border-[#3d3d3d]">
+          Failed to load page {page}.{' '}
+          <button
+            type="button"
+            className="underline hover:text-red-300"
+            onClick={() => { void pageQuery.refetch(); }}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      <div
+        className={`overflow-x-auto${
+          pageQuery.isFetching && page > 1 ? ' opacity-60' : ''
+        }`}
+      >
+        {rows.length === 0 && pageQuery.isFetching ? (
+          // First visit to a page > 1 has no previous query data to hold
+          // on screen (page 1 lives in the parent poll), so show an
+          // explicit loading state instead of an empty table.
+          <div className="p-8 text-center text-gray-400">Loading transactions...</div>
+        ) : isMobile ? (
           <div className="overflow-hidden">
             {table.getRowModel().rows.map((row) => renderCard(row))}
           </div>
@@ -295,14 +362,14 @@ export default function TransactionsPanel({
       </div>
 
       <Paginator
-        pageIndex={table.getState().pagination.pageIndex}
-        pageCount={table.getPageCount()}
-        canPrev={table.getCanPreviousPage()}
-        canNext={table.getCanNextPage()}
-        goFirst={() => table.setPageIndex(0)}
-        goPrev={() => table.previousPage()}
-        goNext={() => table.nextPage()}
-        goLast={() => table.setPageIndex(table.getPageCount() - 1)}
+        pageIndex={page - 1}
+        pageCount={pageCount}
+        canPrev={page > 1}
+        canNext={page < pageCount}
+        goFirst={() => setPage(1)}
+        goPrev={() => setPage((p) => Math.max(1, p - 1))}
+        goNext={() => setPage((p) => Math.min(pageCount, p + 1))}
+        goLast={() => setPage(pageCount)}
       />
     </div>
   );

--- a/ExplorerFrontend/app/address/[query]/panels/use-aggregate-page.ts
+++ b/ExplorerFrontend/app/address/[query]/panels/use-aggregate-page.ts
@@ -1,0 +1,87 @@
+'use client';
+
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import type { UseQueryResult } from '@tanstack/react-query';
+import axios from 'axios';
+import type { InternalTransaction, Transaction } from '@/app/types';
+import config from '../../../../config';
+
+/**
+ * Paged access to `/address/aggregate/:addr` for the Transactions and
+ * Internal Txns panels.
+ *
+ * The backend paginates both tx lists in the aggregate (default 10/page,
+ * DB-layer cap 50) since the hot-address timeout fix, but the panels used
+ * to client-paginate whatever single page the server component fetched,
+ * silently clipping every address to its 10 most recent rows ("84
+ * transactions" badge, one page of 10 rows). These helpers give the panels
+ * real server-side paging.
+ *
+ * Page 1 stays owned by the parent AddressTabs poll (live 15s refresh);
+ * this hook only fetches pages > 1, so the two panels share one cache
+ * entry per (address, page) and switching back to page 1 is instant.
+ */
+
+/** Rows per page in the panels. Matches the backend default so page 1 from
+ *  the parent poll and pages > 1 from this hook tile seamlessly. */
+export const PAGE_LIMIT = 10;
+
+/** Per-request row cap for full-history export; the aggregate's DB layer
+ *  clamps limit to 50, so asking for more just wastes nothing. */
+const EXPORT_PAGE_LIMIT = 50;
+
+/** Upper bound on exported rows (40 requests at 50/page) so Download on a
+ *  validator-grade address can't fan out unbounded requests. */
+export const MAX_EXPORT_ROWS = 2000;
+
+export interface AggregatePage {
+  transactions_by_address?: Transaction[];
+  internal_transactions_by_address?: InternalTransaction[];
+  transactions_count?: number;
+  internal_transactions_count?: number;
+}
+
+export async function fetchAggregatePage(
+  address: string,
+  page: number,
+  limit: number,
+): Promise<AggregatePage> {
+  const res = await axios.get<AggregatePage>(
+    `${config.handlerUrl}/address/aggregate/${address}`,
+    { params: { page, limit } },
+  );
+  return res.data ?? {};
+}
+
+/** Fetch one page of the aggregate. Disabled for page 1 (parent-owned).
+ *  keepPreviousData holds the prior page on screen while the next loads,
+ *  so paging doesn't flash an empty table. */
+export function useAggregatePage(
+  address: string,
+  page: number,
+): UseQueryResult<AggregatePage> {
+  return useQuery<AggregatePage>({
+    queryKey: ['address-aggregate-page', address, page],
+    queryFn: () => fetchAggregatePage(address, page, PAGE_LIMIT),
+    enabled: page > 1,
+    // Matches the backend's 10s route cache; refetching sooner can't
+    // observe anything fresher.
+    staleTime: 10_000,
+    placeholderData: keepPreviousData,
+  });
+}
+
+/** Walk every page of one of the aggregate's row lists (for CSV export).
+ *  Stops on the first short page or at MAX_EXPORT_ROWS. */
+export async function fetchAllAggregateRows<T>(
+  address: string,
+  select: (page: AggregatePage) => T[] | undefined,
+): Promise<T[]> {
+  const rows: T[] = [];
+  for (let page = 1; rows.length < MAX_EXPORT_ROWS; page++) {
+    const batch = select(await fetchAggregatePage(address, page, EXPORT_PAGE_LIMIT)) ?? [];
+    rows.push(...batch);
+    if (batch.length < EXPORT_PAGE_LIMIT) break;
+  }
+  return rows.slice(0, MAX_EXPORT_ROWS);
+}

--- a/ExplorerFrontend/app/components/DownloadBtn.tsx
+++ b/ExplorerFrontend/app/components/DownloadBtn.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useState } from 'react';
 import { formatTimestamp, normalizeHexString, formatAddress } from '../lib/helpers';
 import type { MouseEvent } from 'react';
 import type { DownloadBtnProps, DownloadBtnInternalProps } from '@/app/types';
@@ -27,10 +30,28 @@ function downloadCSV(data: Record<string, string | number>[], fileName: string):
   URL.revokeObjectURL(link.href);
 }
 
-export function DownloadBtn({ data = [], fileName }: DownloadBtnProps): JSX.Element {
-  const handleDownload = (e: MouseEvent<HTMLButtonElement>): void => {
+export function DownloadBtn({ data = [], fileName, getData }: DownloadBtnProps): JSX.Element {
+  // Guards double-clicks while a getData provider is fetching the full
+  // history; also swaps the label so the wait is visible.
+  const [busy, setBusy] = useState(false);
+
+  const handleDownload = async (e: MouseEvent<HTMLButtonElement>): Promise<void> => {
     e.preventDefault();
-    const datas = data?.length ? data : [];
+    if (busy) return;
+
+    let datas = data?.length ? data : [];
+    if (getData) {
+      setBusy(true);
+      try {
+        datas = await getData();
+      } catch (error) {
+        console.error('Failed to fetch rows for download:', error);
+        window.alert('Failed to download the full history. Please try again.');
+        return;
+      } finally {
+        setBusy(false);
+      }
+    }
 
     const convertedData = datas.map(item => {
       const convertedItem: Record<string, string | number> = {};
@@ -71,18 +92,35 @@ export function DownloadBtn({ data = [], fileName }: DownloadBtnProps): JSX.Elem
   return (
     <button
       type="button"
-      className="px-4 py-2 text-sm font-medium rounded-lg bg-[#2d2d2d] text-gray-300 border border-[#3d3d3d] hover:border-[#ffa729] hover:text-white transition-colors"
-      onClick={handleDownload}
+      className="px-4 py-2 text-sm font-medium rounded-lg bg-[#2d2d2d] text-gray-300 border border-[#3d3d3d] hover:border-[#ffa729] hover:text-white transition-colors disabled:opacity-60"
+      onClick={(e) => { void handleDownload(e); }}
+      disabled={busy}
     >
-      Download
+      {busy ? 'Preparing...' : 'Download'}
     </button>
   );
 }
 
-export function DownloadBtnInternal({ data = [], fileName }: DownloadBtnInternalProps): JSX.Element {
-  const handleDownload = (e: MouseEvent<HTMLButtonElement>): void => {
+export function DownloadBtnInternal({ data = [], fileName, getData }: DownloadBtnInternalProps): JSX.Element {
+  const [busy, setBusy] = useState(false);
+
+  const handleDownload = async (e: MouseEvent<HTMLButtonElement>): Promise<void> => {
     e.preventDefault();
-    const datas = data?.length ? data : [];
+    if (busy) return;
+
+    let datas = data?.length ? data : [];
+    if (getData) {
+      setBusy(true);
+      try {
+        datas = await getData();
+      } catch (error) {
+        console.error('Failed to fetch rows for download:', error);
+        window.alert('Failed to download the full history. Please try again.');
+        return;
+      } finally {
+        setBusy(false);
+      }
+    }
 
     const skipKeys = new Set([
       'ID', 'CallType', 'Calls', 'TraceAdd', 'Address',
@@ -127,10 +165,11 @@ export function DownloadBtnInternal({ data = [], fileName }: DownloadBtnInternal
   return (
     <button
       type="button"
-      className="px-4 py-2 text-sm font-medium rounded-lg bg-[#2d2d2d] text-gray-300 border border-[#3d3d3d] hover:border-[#ffa729] hover:text-white transition-colors"
-      onClick={handleDownload}
+      className="px-4 py-2 text-sm font-medium rounded-lg bg-[#2d2d2d] text-gray-300 border border-[#3d3d3d] hover:border-[#ffa729] hover:text-white transition-colors disabled:opacity-60"
+      onClick={(e) => { void handleDownload(e); }}
+      disabled={busy}
     >
-      Download
+      {busy ? 'Preparing...' : 'Download'}
     </button>
   );
 }

--- a/ExplorerFrontend/app/types/address.ts
+++ b/ExplorerFrontend/app/types/address.ts
@@ -74,6 +74,15 @@ export interface AddressData {
   // aggregate inlined into transactions_by_address (capped at limit=50).
   // Used by the address-page tab badge so the count is honest.
   transactions_count?: number;
+  // True total for the internal-transactions list, same contract as
+  // transactions_count. Optional: absent on handlers predating it.
+  internal_transactions_count?: number;
+  // Unix seconds of the oldest/newest native tx involving the address,
+  // computed server-side across the whole history. 0 = no activity.
+  // Optional: absent on handlers predating it, in which case the view
+  // falls back to deriving the range from the loaded page.
+  first_seen?: number;
+  last_seen?: number;
   transactions_by_address: Transaction[];
   internal_transactions_by_address: InternalTransaction[];
   contract_code: ContractData | null;

--- a/ExplorerFrontend/app/types/components.ts
+++ b/ExplorerFrontend/app/types/components.ts
@@ -6,6 +6,9 @@ import type { Transaction, InternalTransaction } from './transaction';
 export interface DownloadBtnProps {
   data: Transaction[];
   fileName?: string;
+  /** When set, the button resolves the full row set through this instead
+   *  of exporting `data` (which may be just the currently loaded page). */
+  getData?: () => Promise<Transaction[]>;
 }
 
 /**
@@ -14,6 +17,8 @@ export interface DownloadBtnProps {
 export interface DownloadBtnInternalProps {
   data: InternalTransaction[];
   fileName?: string;
+  /** Same contract as DownloadBtnProps.getData. */
+  getData?: () => Promise<InternalTransaction[]>;
 }
 
 /**

--- a/backendAPI/db/transaction.go
+++ b/backendAPI/db/transaction.go
@@ -305,6 +305,87 @@ func CountTransactions(address string) (int, error) {
 	return int(count), nil
 }
 
+// CountInternalTransactionsByAddress mirrors CountTransactions for the
+// internalTransactionByAddress collection, so the address page can size
+// the Internal Txns pagination honestly instead of guessing from the
+// clipped page it received.
+func CountInternalTransactionsByAddress(address string) (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Normalize to canonical Q-prefix, matches syncer write format.
+	normalizedAddress := normalizeAddress(address)
+
+	filter := primitive.D{{Key: "$or", Value: []primitive.D{
+		{{Key: "from", Value: normalizedAddress}},
+		{{Key: "to", Value: normalizedAddress}},
+	}}}
+
+	count, err := configs.InternalTransactionByAddressCollection.CountDocuments(ctx, filter)
+	if err != nil {
+		log.Printf("error counting internal transactions: %v", err)
+		return 0, err
+	}
+
+	return int(count), nil
+}
+
+// ReturnAddressActivityRange returns the unix timestamps (seconds) of the
+// oldest and newest native transactions involving the address, or (0, 0)
+// when it has none. The address page's Activity card needs the true range;
+// deriving it from whichever page of transactions happens to be loaded
+// shows the oldest row of the newest page as "First Activity".
+//
+// timeStamp is persisted as a fixed-width "0x" + 8-hex-digit string, so a
+// lexicographic sort orders it numerically (until 2106), the same
+// assumption every timeStamp sort in this file already makes.
+func ReturnAddressActivityRange(address string) (int64, int64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	normalizedAddress := normalizeAddress(address)
+
+	filter := primitive.D{{Key: "$or", Value: []primitive.D{
+		{{Key: "from", Value: normalizedAddress}},
+		{{Key: "to", Value: normalizedAddress}},
+	}}}
+
+	fetchBoundary := func(order int) (int64, error) {
+		var doc struct {
+			TimeStamp string `bson:"timeStamp"`
+		}
+		opts := options.FindOne().
+			SetProjection(primitive.D{{Key: "timeStamp", Value: 1}}).
+			SetSort(primitive.D{{Key: "timeStamp", Value: order}})
+		err := configs.TransactionByAddressCollection.FindOne(ctx, filter, opts).Decode(&doc)
+		if err != nil {
+			return 0, err
+		}
+		ts, err := strconv.ParseInt(strings.TrimPrefix(doc.TimeStamp, "0x"), 16, 64)
+		if err != nil {
+			return 0, fmt.Errorf("malformed timeStamp %q: %w", doc.TimeStamp, err)
+		}
+		return ts, nil
+	}
+
+	first, err := fetchBoundary(1)
+	if err == mongo.ErrNoDocuments {
+		return 0, 0, nil
+	}
+	if err != nil {
+		log.Printf("error fetching first activity: %v", err)
+		return 0, 0, err
+	}
+
+	last, err := fetchBoundary(-1)
+	if err != nil {
+		log.Printf("error fetching last activity: %v", err)
+		return 0, 0, err
+	}
+
+	return first, last, nil
+}
+
 func ReturnSingleTransfer(query string) (models.Transfer, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/backendAPI/routes/routes.go
+++ b/backendAPI/routes/routes.go
@@ -584,6 +584,19 @@ func UserRoute(router *gin.Engine) {
 				log.Printf("error counting transactions: %v", err)
 			}
 
+			countInternalTransactions, err := db.CountInternalTransactionsByAddress(param)
+			if err != nil {
+				log.Printf("error counting internal transactions: %v", err)
+			}
+
+			// True activity range across the whole history; the paginated
+			// tx list only covers one page, so deriving first/last seen
+			// from it is wrong for any address with more than one page.
+			firstSeen, lastSeen, err := db.ReturnAddressActivityRange(param)
+			if err != nil {
+				log.Printf("error fetching activity range: %v", err)
+			}
+
 			rank, err := db.ReturnRankAddress(param)
 			if err != nil {
 				log.Printf("error getting rank: %v", err)
@@ -641,6 +654,9 @@ func UserRoute(router *gin.Engine) {
 			return gin.H{
 				"address":                          addressData,
 				"transactions_count":               countTransactions,
+				"internal_transactions_count":      countInternalTransactions,
+				"first_seen":                       firstSeen,
+				"last_seen":                        lastSeen,
 				"rank":                             rank,
 				"transactions_by_address":          transactionsByAddress,
 				"internal_transactions_by_address": internalTransactionsByAddress,


### PR DESCRIPTION
## Problem

The address page clips every transaction history to its 10 newest rows. Example: `Q6153d37Fa...905b1` shows the badge "Transactions (84)" but the table renders "10 transactions loaded", "Page 1 of 1". The Activity card is wrong for the same reason: "First Activity 2026-07-09" is just the oldest row of the newest page; the address has been active since 2026-04-17 (block 24232).

## Cause

`/address/aggregate/:addr` gained server-side pagination (default 10/page, DB cap 50) with the hot-address timeout fix, but the frontend was never taught to page: the server component fetches the default first page and the panels run TanStack client pagination over those same 10 rows.

## Changes

Backend (additive, no behavior change to existing fields):
- `internal_transactions_count`: CountDocuments mirror for the internal list
- `first_seen` / `last_seen`: unix seconds of the oldest/newest tx involving the address (FindOne asc/desc on `timeStamp`; fixed-width hex strings sort numerically, same assumption as the existing sorts)

Frontend:
- Transactions + Internal Txns panels page through `/address/aggregate?page=N&limit=10` via a shared react-query hook (`use-aggregate-page.ts`). Page 1 stays owned by the parent AddressTabs 15s live poll; pages > 1 fetch on demand with `keepPreviousData`, retry banner on failure
- Page count + descending Number column derive from the true totals
- Activity card prefers server-computed `first_seen`/`last_seen`, falls back to the old page-derived range against older handlers
- Internal Txns tab badge shows the true count when the handler provides it
- Download now exports the full history via a paged walk (limit 50/request, 2000-row cap) with a busy state on the button, instead of silently exporting the loaded page
- Search placeholder renamed to "Search this page..." to match its actual scope (it filters the rows on screen, as before)

## Verification

- backendAPI: `go build`, `go vet ./...`, `go test ./...` green; touched files gofmt-clean
- ExplorerFrontend: `eslint` 0 errors, `jest` 114/114, `next build` compiles
- Prod API already serves paged aggregates (`?page=2&limit=10` verified against zondscan.com), so the frontend change is compatible with the currently deployed handler; deploying the handler additionally lights up the new count/activity fields

## Deploy notes

Handler first (`go build` + `pm2 restart handler`), then frontend (`npm run build` + `pm2 restart frontend`). The frontend degrades gracefully against the old handler (no internal badge, page-derived activity range).