### PR TITLE
fix(search): /search redirected to localhost:3000 behind the nginx proxy

### DIFF
--- a/ExplorerFrontend/app/search/route.ts
+++ b/ExplorerFrontend/app/search/route.ts
@@ -11,6 +11,11 @@ import { resolveSearchPath } from '../lib/searchResolver';
  * also makes bookmarkable search URLs work. Unresolvable queries fall
  * back to the homepage.
  */
+// Behind the nginx proxy request.nextUrl.origin is the internal
+// localhost:3000, so anchor redirects to the canonical public origin
+// (same hardcode as metadataBase in lib/seo/metaData.ts).
+const CANONICAL_ORIGIN = 'https://zondscan.com';
+
 export function GET(request: NextRequest): NextResponse {
   try {
     const query = request.nextUrl.searchParams.get('q') ?? '';
@@ -20,8 +25,8 @@ export function GET(request: NextRequest): NextResponse {
     if (!destination.startsWith('/') || destination.startsWith('//')) {
       destination = '/';
     }
-    return NextResponse.redirect(new URL(destination, request.nextUrl.origin), 302);
+    return NextResponse.redirect(new URL(destination, CANONICAL_ORIGIN), 302);
   } catch {
-    return NextResponse.redirect(new URL('/', request.nextUrl.origin), 302);
+    return NextResponse.redirect(new URL('/', CANONICAL_ORIGIN), 302);
   }
 }


### PR DESCRIPTION
## Summary
Live verification after PR #158 deploy showed GET /search?q=12345 issuing a 302 to https://localhost:3000/block/12345: behind nginx, request.nextUrl.origin is the internal server origin. Redirects are now anchored to the canonical https://zondscan.com (same hardcode pattern as metadataBase).

## Validation
- npm run lint: 0 errors
- npm test: 114/114