### PR TITLE
feat(syncer): persist nested internal call frames as internal transactions

### DIFF
--- a/QRL2MongoDB/cmd/backfill-internal/main.go
+++ b/QRL2MongoDB/cmd/backfill-internal/main.go
@@ -38,17 +38,28 @@ func main() {
 	ctx := context.Background()
 
 	// Hashes that already have internal rows: skip them so re-runs are
-	// idempotent and a partial run can resume where it stopped.
-	seenRaw, err := configs.InternalTransactionByAddressCollections.Distinct(ctx, "hash", bson.D{})
+	// idempotent and a partial run can resume where it stopped. Streamed
+	// through a cursor rather than Distinct, which returns one BSON array
+	// and hits the 16MB document cap on large collections.
+	seen := make(map[string]struct{})
+	seenCursor, err := configs.InternalTransactionByAddressCollections.Find(
+		ctx, bson.D{}, options.Find().SetProjection(bson.D{{Key: "hash", Value: 1}}))
 	if err != nil {
 		log.Fatalf("failed to load existing internal tx hashes: %v", err)
 	}
-	seen := make(map[string]struct{}, len(seenRaw))
-	for _, h := range seenRaw {
-		if s, ok := h.(string); ok {
-			seen[s] = struct{}{}
+	for seenCursor.Next(ctx) {
+		var doc struct {
+			Hash string `bson:"hash"`
+		}
+		if err := seenCursor.Decode(&doc); err == nil && doc.Hash != "" {
+			seen[doc.Hash] = struct{}{}
 		}
 	}
+	if err := seenCursor.Err(); err != nil {
+		seenCursor.Close(ctx)
+		log.Fatalf("failed to iterate existing internal tx hashes: %v", err)
+	}
+	seenCursor.Close(ctx)
 	log.Printf("%d transactions already have internal rows", len(seen))
 
 	// Only successful transactions can move value; reverted ones paid fees
@@ -72,7 +83,7 @@ func main() {
 	}
 	defer cursor.Close(ctx)
 
-	var scanned, skipped, traceErrs, txsWithCalls, rowsInserted int
+	var scanned, skipped, traceErrs, insertErrs, txsWithCalls, rowsInserted int
 	for cursor.Next(ctx) {
 		var row transferRow
 		if err := cursor.Decode(&row); err != nil {
@@ -99,7 +110,14 @@ func main() {
 			continue
 		}
 
-		db.StoreInternalCalls(trace.InternalCalls, row.TxHash, row.BlockTimestamp, row.BlockNumber)
+		// A failed insert may leave partial rows for this tx; the re-run
+		// skip is per-hash, so check the logged hashes manually if any
+		// insert errors show up in the summary.
+		if err := db.StoreInternalCalls(trace.InternalCalls, row.TxHash, row.BlockTimestamp, row.BlockNumber); err != nil {
+			insertErrs++
+			log.Printf("failed to store internal calls for %s: %v", row.TxHash, err)
+			continue
+		}
 		txsWithCalls++
 		rowsInserted += len(trace.InternalCalls)
 	}
@@ -107,6 +125,6 @@ func main() {
 		log.Fatalf("cursor error after %d rows: %v", scanned, err)
 	}
 
-	log.Printf("done: %d scanned, %d already indexed, %d trace errors, %d txs produced %d internal rows",
-		scanned, skipped, traceErrs, txsWithCalls, rowsInserted)
+	log.Printf("done: %d scanned, %d already indexed, %d trace errors, %d insert errors, %d txs produced %d internal rows",
+		scanned, skipped, traceErrs, insertErrs, txsWithCalls, rowsInserted)
 }

--- a/QRL2MongoDB/cmd/backfill-internal/main.go
+++ b/QRL2MongoDB/cmd/backfill-internal/main.go
@@ -1,0 +1,112 @@
+// backfill-internal re-traces already-synced transactions and persists their
+// nested call frames into internalTransactionByAddress. One-off maintenance
+// tool for chains synced before internal-transaction indexing was enabled
+// (the collection is append-only, so blocks synced with tracing disabled
+// never get their internal rows otherwise).
+//
+// Usage: build and run next to the synchroniser's .env (MONGOURI, NODE_URLS,
+// ENABLE_DEBUG_TRACE=true). Transactions that already have internal rows are
+// skipped, so re-running is safe.
+package main
+
+import (
+	"QRL2MongoDB/configs"
+	"QRL2MongoDB/db"
+	"QRL2MongoDB/rpc"
+	"context"
+	"log"
+	"os"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type transferRow struct {
+	TxHash         string `bson:"txHash"`
+	BlockNumber    string `bson:"blockNumber"`
+	BlockTimestamp string `bson:"blockTimestamp"`
+}
+
+func main() {
+	if os.Getenv("ENABLE_DEBUG_TRACE") != "true" {
+		log.Fatal("ENABLE_DEBUG_TRACE=true is required; without it every trace call silently no-ops and the backfill would do nothing")
+	}
+	if os.Getenv("NODE_URLS") == "" && os.Getenv("NODE_URL") == "" {
+		log.Fatal("Required environment variable NODE_URLS (or legacy NODE_URL) is not set")
+	}
+
+	ctx := context.Background()
+
+	// Hashes that already have internal rows: skip them so re-runs are
+	// idempotent and a partial run can resume where it stopped.
+	seenRaw, err := configs.InternalTransactionByAddressCollections.Distinct(ctx, "hash", bson.D{})
+	if err != nil {
+		log.Fatalf("failed to load existing internal tx hashes: %v", err)
+	}
+	seen := make(map[string]struct{}, len(seenRaw))
+	for _, h := range seenRaw {
+		if s, ok := h.(string); ok {
+			seen[s] = struct{}{}
+		}
+	}
+	log.Printf("%d transactions already have internal rows", len(seen))
+
+	// Only successful transactions can move value; reverted ones paid fees
+	// and did nothing else.
+	filter := bson.D{{Key: "status", Value: "0x1"}}
+	opts := options.Find().SetProjection(bson.D{
+		{Key: "txHash", Value: 1},
+		{Key: "blockNumber", Value: 1},
+		{Key: "blockTimestamp", Value: 1},
+	})
+
+	total, err := configs.TransferCollections.CountDocuments(ctx, filter)
+	if err != nil {
+		log.Fatalf("failed to count transfer docs: %v", err)
+	}
+	log.Printf("scanning %d successful transactions", total)
+
+	cursor, err := configs.TransferCollections.Find(ctx, filter, opts)
+	if err != nil {
+		log.Fatalf("failed to query transfer collection: %v", err)
+	}
+	defer cursor.Close(ctx)
+
+	var scanned, skipped, traceErrs, txsWithCalls, rowsInserted int
+	for cursor.Next(ctx) {
+		var row transferRow
+		if err := cursor.Decode(&row); err != nil {
+			log.Printf("decode error, skipping row: %v", err)
+			continue
+		}
+		scanned++
+		if scanned%500 == 0 {
+			log.Printf("progress: %d/%d scanned, %d txs with internal calls, %d rows inserted", scanned, total, txsWithCalls, rowsInserted)
+		}
+
+		if _, ok := seen[row.TxHash]; ok {
+			skipped++
+			continue
+		}
+
+		trace := rpc.CallDebugTraceTransaction(row.TxHash)
+		if trace.Err != nil {
+			traceErrs++
+			log.Printf("trace failed for %s: %v", row.TxHash, trace.Err)
+			continue
+		}
+		if len(trace.InternalCalls) == 0 {
+			continue
+		}
+
+		db.StoreInternalCalls(trace.InternalCalls, row.TxHash, row.BlockTimestamp, row.BlockNumber)
+		txsWithCalls++
+		rowsInserted += len(trace.InternalCalls)
+	}
+	if err := cursor.Err(); err != nil {
+		log.Fatalf("cursor error after %d rows: %v", scanned, err)
+	}
+
+	log.Printf("done: %d scanned, %d already indexed, %d trace errors, %d txs produced %d internal rows",
+		scanned, skipped, traceErrs, txsWithCalls, rowsInserted)
+}

--- a/QRL2MongoDB/db/transactions.go
+++ b/QRL2MongoDB/db/transactions.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -365,25 +366,11 @@ func processTransactionData(tx *models.Transaction, blockTimestamp string, to st
 	}
 
 	trace := rpc.CallDebugTraceTransaction(tx.Hash)
-	if trace.TransactionType == "CALL" || trace.TraceAddress != nil {
-		InternalTransactionByAddressCollection(
-			trace.TransactionType,
-			trace.CallType,
-			txHash,
-			trace.From,
-			trace.To,
-			fmt.Sprintf("0x%x", trace.Input),
-			fmt.Sprintf("0x%x", trace.Output),
-			trace.TraceAddress,
-			float64(trace.Value),
-			fmt.Sprintf("0x%x", trace.Gas),
-			fmt.Sprintf("0x%x", trace.GasUsed),
-			trace.AddressFunctionIdentifier,
-			fmt.Sprintf("0x%x", trace.AmountFunctionIdentifier),
-			blockTimestamp,
-			blockNumber,
-		)
-	}
+	// Persist the nested (depth >= 1) call frames: value moved by contract
+	// code rather than by the outer transaction itself, e.g. an HTLC claim
+	// paying out contract-held funds. The top-level frame is intentionally
+	// not stored; it would only duplicate the transactionByAddress row.
+	StoreInternalCalls(trace.InternalCalls, txHash, blockTimestamp, blockNumber)
 
 	// Calculate fees using hex strings. Guard against empty/short
 	// gasPrice, slicing [2:] on those panics; treat too-short as zero.
@@ -490,6 +477,31 @@ func TransferCollection(blockNumber string, blockTimestamp string, from string, 
 	}
 
 	return result, err
+}
+
+// StoreInternalCalls persists each flattened nested call frame of one
+// transaction as an internalTransactionByAddress row. Shared by the live
+// sync path (processTransactions) and the historical backfill command.
+func StoreInternalCalls(calls []rpc.InternalCall, txHash string, blockTimestamp string, blockNumber string) {
+	for _, call := range calls {
+		InternalTransactionByAddressCollection(
+			call.Type,
+			strings.ToLower(call.Type),
+			txHash,
+			call.From,
+			call.To,
+			call.Input,
+			call.Output,
+			call.TraceAddress,
+			call.Value,
+			call.Gas,
+			call.GasUsed,
+			"",
+			"0x0",
+			blockTimestamp,
+			blockNumber,
+		)
+	}
 }
 
 func InternalTransactionByAddressCollection(transactionType string, callType string, hash string, from string, to string, input string, output string, traceAddress []int, value float64, gas string, gasUsed string, addressFunctionIdentifier string, amountFunctionIdentifier string, blockTimestamp string, blockNumber string) (*mongo.InsertOneResult, error) {

--- a/QRL2MongoDB/db/transactions.go
+++ b/QRL2MongoDB/db/transactions.go
@@ -6,6 +6,7 @@ import (
 	"QRL2MongoDB/rpc"
 	"QRL2MongoDB/validation"
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -370,7 +371,10 @@ func processTransactionData(tx *models.Transaction, blockTimestamp string, to st
 	// code rather than by the outer transaction itself, e.g. an HTLC claim
 	// paying out contract-held funds. The top-level frame is intentionally
 	// not stored; it would only duplicate the transactionByAddress row.
-	StoreInternalCalls(trace.InternalCalls, txHash, blockTimestamp, blockNumber)
+	if err := StoreInternalCalls(trace.InternalCalls, txHash, blockTimestamp, blockNumber); err != nil {
+		configs.Logger.Error("Failed to store internal calls",
+			zap.String("txHash", txHash), zap.Error(err))
+	}
 
 	// Calculate fees using hex strings. Guard against empty/short
 	// gasPrice, slicing [2:] on those panics; treat too-short as zero.
@@ -482,9 +486,12 @@ func TransferCollection(blockNumber string, blockTimestamp string, from string, 
 // StoreInternalCalls persists each flattened nested call frame of one
 // transaction as an internalTransactionByAddress row. Shared by the live
 // sync path (processTransactions) and the historical backfill command.
-func StoreInternalCalls(calls []rpc.InternalCall, txHash string, blockTimestamp string, blockNumber string) {
+// A failed insert does not stop the remaining frames; all failures are
+// joined into the returned error.
+func StoreInternalCalls(calls []rpc.InternalCall, txHash string, blockTimestamp string, blockNumber string) error {
+	var errs []error
 	for _, call := range calls {
-		InternalTransactionByAddressCollection(
+		_, err := InternalTransactionByAddressCollection(
 			call.Type,
 			strings.ToLower(call.Type),
 			txHash,
@@ -501,7 +508,11 @@ func StoreInternalCalls(calls []rpc.InternalCall, txHash string, blockTimestamp 
 			blockTimestamp,
 			blockNumber,
 		)
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
+	return errors.Join(errs...)
 }
 
 func InternalTransactionByAddressCollection(transactionType string, callType string, hash string, from string, to string, input string, output string, traceAddress []int, value float64, gas string, gasUsed string, addressFunctionIdentifier string, amountFunctionIdentifier string, blockTimestamp string, blockNumber string) (*mongo.InsertOneResult, error) {

--- a/QRL2MongoDB/models/trace.go
+++ b/QRL2MongoDB/models/trace.go
@@ -18,15 +18,22 @@ type TraceResult struct {
 	Output       string `json:"output"`
 	Calls        []Call `json:"calls"`
 	Value        string `json:"value"`
+	Error        string `json:"error"`
 	TraceAddress []int  `json:"traceAddress"`
 }
 
+// Call is one frame of the callTracer call tree. Frames nest recursively
+// via Calls; a non-empty Error marks the frame (and its whole subtree)
+// as reverted.
 type Call struct {
 	From    string `json:"from"`
 	Gas     string `json:"gas"`
 	GasUsed string `json:"gasUsed"`
 	To      string `json:"to"`
 	Input   string `json:"input"`
+	Output  string `json:"output"`
 	Value   string `json:"value"`
 	Type    string `json:"type"`
+	Error   string `json:"error"`
+	Calls   []Call `json:"calls"`
 }

--- a/QRL2MongoDB/rpc/calls.go
+++ b/QRL2MongoDB/rpc/calls.go
@@ -177,9 +177,116 @@ type DebugTraceResult struct {
 	AddressFunctionIdentifier string
 	// AmountFunctionIdentifier is the transfer amount decoded from the transfer() input data.
 	AmountFunctionIdentifier uint64
+	// InternalCalls are the nested (depth >= 1) call frames worth persisting
+	// as internal transactions: value transfers executed by contract code and
+	// contract creations. The top-level frame is not included; it already
+	// exists as the outer transaction row.
+	InternalCalls []InternalCall
 	// Err is non-nil when the RPC call itself failed (network error, unmarshal error, etc.).
 	// A nil Err with empty TransactionType means the trace has no relevant call data.
 	Err error
+}
+
+// InternalCall is one nested callTracer frame, flattened for persistence in
+// the internalTransactionByAddress collection.
+type InternalCall struct {
+	// Type is the frame opcode (CALL, CALLCODE, CREATE, CREATE2, SELFDESTRUCT).
+	Type string
+	// From and To are Q-prefix addresses.
+	From string
+	To   string
+	// Input and Output are raw hex strings ("0x" when absent).
+	Input  string
+	Output string
+	// TraceAddress is the frame's position in the call tree, derived from
+	// child indices (callTracer itself does not emit it).
+	TraceAddress []int
+	// Value is the QRL amount moved by this frame (wei / QUANTA), matching
+	// the float schema of the existing collection.
+	Value float64
+	// Gas and GasUsed are raw hex strings ("0x0" when absent).
+	Gas     string
+	GasUsed string
+}
+
+// parseHexBig parses a 0x-prefixed hex quantity into a big.Int, or nil when
+// the input is empty or malformed.
+func parseHexBig(hexVal string) *big.Int {
+	if hexVal == "" || !validation.IsValidHexString(hexVal) {
+		return nil
+	}
+	v := new(big.Int)
+	if _, ok := v.SetString(strings.TrimPrefix(hexVal, "0x"), 16); !ok {
+		return nil
+	}
+	return v
+}
+
+// hexOrDefault returns the hex string unchanged, or def when empty.
+func hexOrDefault(hexVal string, def string) string {
+	if hexVal == "" {
+		return def
+	}
+	return hexVal
+}
+
+// flattenCalls walks a callTracer call tree depth-first and returns the
+// nested frames worth persisting as internal transactions: frames that move
+// value plus contract creations. Frames with a non-empty error are skipped
+// together with their whole subtree, a reverted frame's transfers never took
+// effect. path is the traceAddress prefix inherited from the parent frame.
+func flattenCalls(calls []models.Call, path []int) []InternalCall {
+	var out []InternalCall
+	for i, call := range calls {
+		if call.Error != "" {
+			continue
+		}
+
+		tracePath := make([]int, 0, len(path)+1)
+		tracePath = append(tracePath, path...)
+		tracePath = append(tracePath, i)
+
+		value := parseHexBig(call.Value)
+		hasValue := value != nil && value.Sign() > 0
+		if hasValue || strings.HasPrefix(call.Type, "CREATE") {
+			valueFloat := 0.0
+			if hasValue {
+				divisor := new(big.Float).SetFloat64(float64(configs.QUANTA))
+				quo := new(big.Float).Quo(new(big.Float).SetInt(value), divisor)
+				valueFloat, _ = quo.Float64()
+			}
+
+			from := call.From
+			if from != "" {
+				if err := validation.ValidateAddress(from); err != nil {
+					zap.L().Warn("Invalid from address in internal call frame", zap.Error(err))
+				}
+				from = validation.ConvertToQAddress(from)
+			}
+			to := call.To
+			if to != "" {
+				if err := validation.ValidateAddress(to); err != nil {
+					zap.L().Warn("Invalid to address in internal call frame", zap.Error(err))
+				}
+				to = validation.ConvertToQAddress(to)
+			}
+
+			out = append(out, InternalCall{
+				Type:         call.Type,
+				From:         from,
+				To:           to,
+				Input:        hexOrDefault(call.Input, "0x"),
+				Output:       hexOrDefault(call.Output, "0x"),
+				TraceAddress: tracePath,
+				Value:        valueFloat,
+				Gas:          hexOrDefault(call.Gas, "0x0"),
+				GasUsed:      hexOrDefault(call.GasUsed, "0x0"),
+			})
+		}
+
+		out = append(out, flattenCalls(call.Calls, tracePath)...)
+	}
+	return out
 }
 
 // emptyTrace returns a zero-value DebugTraceResult, optionally carrying an error.
@@ -244,6 +351,15 @@ func CallDebugTraceTransaction(hash string) DebugTraceResult {
 
 	var res DebugTraceResult
 
+	// Flatten the nested call frames before the legacy top-level gate below:
+	// a transaction whose top-level frame carries no interesting call data
+	// can still contain value-moving sub-frames (e.g. an HTLC claim paying
+	// out contract-held funds). A reverted top-level frame voids the whole
+	// tree, so nothing is collected in that case.
+	if tracerResponse.Result.Error == "" {
+		res.InternalCalls = flattenCalls(tracerResponse.Result.Calls, nil)
+	}
+
 	// Validate and parse gas values
 	if tracerResponse.Result.Gas != "" {
 		if !validation.IsValidHexString(tracerResponse.Result.Gas) {
@@ -294,7 +410,9 @@ func CallDebugTraceTransaction(hash string) DebugTraceResult {
 		tracerResponse.Result.Type == "CALL"
 
 	if !hasValidCallData {
-		return emptyTrace(nil)
+		// Keep the flattened sub-frames even when the legacy top-level
+		// fields stay empty; the caller persists them independently.
+		return DebugTraceResult{InternalCalls: res.InternalCalls}
 	}
 
 	// Validate addresses and convert to Q format

--- a/QRL2MongoDB/rpc/calls_internal_test.go
+++ b/QRL2MongoDB/rpc/calls_internal_test.go
@@ -1,0 +1,134 @@
+package rpc
+
+import (
+	"QRL2MongoDB/models"
+	"reflect"
+	"testing"
+)
+
+// Package configs connects to MongoDB at init, so this suite (like the
+// token tests) needs MONGOURI pointing at a reachable instance.
+
+// oneQRLWei is 1 QRL expressed as hex wei (1e18).
+const oneQRLWei = "0xde0b6b3a7640000"
+
+func TestFlattenCallsValueTransfer(t *testing.T) {
+	// HTLC-claim shape: outer 0-value CALL into the contract, one nested
+	// frame paying the recipient out of contract-held funds.
+	tree := []models.Call{
+		{
+			Type:  "CALL",
+			From:  "0x94cd8e406d2bb4ea251dce3f0558941f2ac056ee",
+			To:    "0x79b662ce3d663643df4454a8ba3f532c0de6887f",
+			Value: oneQRLWei,
+			Gas:   "0x2300",
+		},
+	}
+
+	got := flattenCalls(tree, nil)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 internal call, got %d", len(got))
+	}
+	ic := got[0]
+	if ic.From != "Q94cd8e406d2bb4ea251dce3f0558941f2ac056ee" {
+		t.Errorf("from not converted to Q-prefix: %s", ic.From)
+	}
+	if ic.To != "Q79b662ce3d663643df4454a8ba3f532c0de6887f" {
+		t.Errorf("to not converted to Q-prefix: %s", ic.To)
+	}
+	if ic.Value != 1.0 {
+		t.Errorf("expected value 1.0 QRL, got %v", ic.Value)
+	}
+	if !reflect.DeepEqual(ic.TraceAddress, []int{0}) {
+		t.Errorf("expected traceAddress [0], got %v", ic.TraceAddress)
+	}
+	if ic.Input != "0x" || ic.Output != "0x" {
+		t.Errorf("expected default input/output 0x, got %q / %q", ic.Input, ic.Output)
+	}
+	if ic.GasUsed != "0x0" {
+		t.Errorf("expected default gasUsed 0x0, got %q", ic.GasUsed)
+	}
+}
+
+func TestFlattenCallsSkipsZeroValueNoise(t *testing.T) {
+	tree := []models.Call{
+		{Type: "STATICCALL", From: "0x94cd8e406d2bb4ea251dce3f0558941f2ac056ee", To: "0x79b662ce3d663643df4454a8ba3f532c0de6887f"},
+		{Type: "DELEGATECALL", From: "0x94cd8e406d2bb4ea251dce3f0558941f2ac056ee", To: "0x79b662ce3d663643df4454a8ba3f532c0de6887f", Value: "0x0"},
+	}
+	if got := flattenCalls(tree, nil); len(got) != 0 {
+		t.Fatalf("expected no internal calls for 0-value frames, got %d", len(got))
+	}
+}
+
+func TestFlattenCallsKeepsCreate(t *testing.T) {
+	tree := []models.Call{
+		{Type: "CREATE2", From: "0x94cd8e406d2bb4ea251dce3f0558941f2ac056ee", To: "0x79b662ce3d663643df4454a8ba3f532c0de6887f", Value: "0x0"},
+	}
+	got := flattenCalls(tree, nil)
+	if len(got) != 1 || got[0].Type != "CREATE2" {
+		t.Fatalf("expected CREATE2 frame kept despite 0 value, got %v", got)
+	}
+	if got[0].Value != 0 {
+		t.Errorf("expected value 0, got %v", got[0].Value)
+	}
+}
+
+func TestFlattenCallsSkipsRevertedSubtree(t *testing.T) {
+	// The errored frame and its value-bearing child must both be dropped;
+	// the sibling after it keeps its own tree index.
+	tree := []models.Call{
+		{
+			Type:  "CALL",
+			Error: "execution reverted",
+			Value: oneQRLWei,
+			From:  "0x94cd8e406d2bb4ea251dce3f0558941f2ac056ee",
+			To:    "0x79b662ce3d663643df4454a8ba3f532c0de6887f",
+			Calls: []models.Call{
+				{Type: "CALL", Value: oneQRLWei, From: "0x94cd8e406d2bb4ea251dce3f0558941f2ac056ee", To: "0x79b662ce3d663643df4454a8ba3f532c0de6887f"},
+			},
+		},
+		{
+			Type:  "CALL",
+			Value: oneQRLWei,
+			From:  "0x94cd8e406d2bb4ea251dce3f0558941f2ac056ee",
+			To:    "0x79b662ce3d663643df4454a8ba3f532c0de6887f",
+		},
+	}
+
+	got := flattenCalls(tree, nil)
+	if len(got) != 1 {
+		t.Fatalf("expected only the healthy sibling, got %d frames", len(got))
+	}
+	if !reflect.DeepEqual(got[0].TraceAddress, []int{1}) {
+		t.Errorf("expected traceAddress [1], got %v", got[0].TraceAddress)
+	}
+}
+
+func TestFlattenCallsNestedPaths(t *testing.T) {
+	// A value transfer two levels deep: parent frame itself carries no
+	// value (not persisted) but the path indices must still accumulate.
+	tree := []models.Call{
+		{
+			Type: "CALL",
+			From: "0x94cd8e406d2bb4ea251dce3f0558941f2ac056ee",
+			To:   "0x79b662ce3d663643df4454a8ba3f532c0de6887f",
+			Calls: []models.Call{
+				{Type: "STATICCALL"},
+				{
+					Type:  "CALL",
+					Value: oneQRLWei,
+					From:  "0x94cd8e406d2bb4ea251dce3f0558941f2ac056ee",
+					To:    "0x79b662ce3d663643df4454a8ba3f532c0de6887f",
+				},
+			},
+		},
+	}
+
+	got := flattenCalls(tree, nil)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 internal call, got %d", len(got))
+	}
+	if !reflect.DeepEqual(got[0].TraceAddress, []int{0, 1}) {
+		t.Errorf("expected traceAddress [0 1], got %v", got[0].TraceAddress)
+	}
+}


### PR DESCRIPTION
## Problem

The Internal Txns tab is empty for every address (internal_transactions_count is 0 across the whole explorer). Two independent causes:

1. Prod never enables tracing: ENABLE_DEBUG_TRACE is unset and the node does not expose debug_traceTransaction (infra, fixed separately).
2. Even with tracing on, the syncer only stored the top-level callTracer frame. Value moved by contract code (HTLC claims, withdrawals, contracts paying EOAs) lives in the nested calls array, which was parsed into a non-recursive model and then discarded.

Concrete example: QuantaSwap claim 0x421b1d9d4c41a6f1d699621dbd4980c78386a51910853f9f90d10ffcb710d8da pays 43.05 QRL from the HTLC contract to the recipient. The outer tx has value 0, so nothing about the payout is visible anywhere on the explorer.

## Changes

- models: Call is now recursive (calls), gains output and error; TraceResult gains error.
- rpc: flattenCalls walks the call tree depth-first and returns frames worth persisting: value-bearing frames plus CREATE*/CREATE2. Reverted subtrees are dropped (their transfers never took effect). traceAddress is derived from tree position since callTracer does not emit it. Addresses converted to canonical Q-prefix.
- db: StoreInternalCalls persists each nested frame as its own internalTransactionByAddress row. The old behavior of storing the top-level frame is removed: it only duplicated the transactionByAddress row and would have counted every contract call as an internal tx.
- cmd/backfill-internal: standalone maintenance tool that re-traces already-synced successful transactions and backfills their internal rows. Idempotent (skips tx hashes that already have rows), so safe to re-run or resume.

No backendAPI or frontend changes needed: the read path (aggregate endpoint + Internal Txns panel) already renders this collection.

## Validation

- go build ./... and go vet ./... clean
- go test ./... green (includes 5 new flattenCalls unit tests: value transfer, zero-value noise skip, CREATE keep, reverted-subtree skip, nested traceAddress paths)
- Rollback compatibility: rows keep blockNumber as raw hex string, matching the reorg companionFilter in db/blocks.go

## Deploy notes

Requires ENABLE_DEBUG_TRACE=true in the syncer env and gqrl started with debug in --http.api. Backfill: build cmd/backfill-internal and run once next to the syncer .env.