### PR TITLE
fix(syncer): head-path receipt status + surfaced trace RPC errors

### DIFF
--- a/QRL2MongoDB/db/transactions.go
+++ b/QRL2MongoDB/db/transactions.go
@@ -367,6 +367,10 @@ func processTransactionData(tx *models.Transaction, blockTimestamp string, to st
 	}
 
 	trace := rpc.CallDebugTraceTransaction(tx.Hash)
+	if trace.Err != nil {
+		configs.Logger.Warn("Debug trace failed; internal calls for this tx will be missing",
+			zap.String("txHash", txHash), zap.Error(trace.Err))
+	}
 	// Persist the nested (depth >= 1) call frames: value moved by contract
 	// code rather than by the outer transaction itself, e.g. an HTLC claim
 	// paying out contract-held funds. The top-level frame is intentionally

--- a/QRL2MongoDB/models/trace.go
+++ b/QRL2MongoDB/models/trace.go
@@ -4,6 +4,16 @@ type TraceResponse struct {
 	JsonRPC string      `json:"jsonrpc"`
 	ID      int         `json:"id"`
 	Result  TraceResult `json:"result"`
+	// Error is the JSON-RPC level error (e.g. "historical state not
+	// available in path scheme yet" on non-archive nodes). Without this
+	// field a failed trace unmarshals into a zero Result and reads as "no
+	// internal calls", which is silent data loss.
+	Error *TraceRPCError `json:"error"`
+}
+
+type TraceRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
 }
 
 type TraceResult struct {

--- a/QRL2MongoDB/rpc/calls.go
+++ b/QRL2MongoDB/rpc/calls.go
@@ -349,6 +349,15 @@ func CallDebugTraceTransaction(hash string) DebugTraceResult {
 		return emptyTrace(err)
 	}
 
+	// Surface JSON-RPC errors instead of treating them as an empty trace;
+	// a non-archive node cannot trace old transactions ("historical state
+	// not available") and callers must be able to tell that apart from a
+	// transaction that genuinely has no internal calls.
+	if tracerResponse.Error != nil {
+		return emptyTrace(fmt.Errorf("debug_traceTransaction failed for %s: %s (code %d)",
+			hash, tracerResponse.Error.Message, tracerResponse.Error.Code))
+	}
+
 	var res DebugTraceResult
 
 	// Flatten the nested call frames before the legacy top-level gate below:

--- a/QRL2MongoDB/synchroniser/sync.go
+++ b/QRL2MongoDB/synchroniser/sync.go
@@ -454,7 +454,11 @@ func processSubsequentBlocks(currentBlock string) string {
 		return utils.AddHexNumbers(currentBlock, "0x1")
 	}
 
-	// Process the block
+	// Process the block. UpdateTransactionStatuses fetches each receipt and
+	// fills tx.Status before persistence; the batch (producer_consumer) and
+	// gap-repair paths already do this, but this head-following path never
+	// did, so live-synced transactions were stored with an empty status.
+	db.UpdateTransactionStatuses(blockData)
 	db.InsertBlockDocument(*blockData)
 	db.ProcessTransactions(*blockData)
 


### PR DESCRIPTION
Two blindspots found while shipping #162/#163:

## Empty transaction status on live-synced blocks

processContracts takes status from tx.Status for non-creation transactions, but only the batch (producer_consumer) and gap-repair paths call UpdateTransactionStatuses to fill it from receipts. The head-following path (synchroniser/sync.go processSubsequentBlocks) never did, so every transaction synced at the chain head landed in mongo with status "". On prod that is 75 of 1090 transfer docs, and it is why the first backfill run (filtering status == 0x1) skipped the HTLC claim. Fix: call UpdateTransactionStatuses before insert on the head path, same as the other two paths.

## Swallowed debug_traceTransaction errors

models.TraceResponse had no JSON-RPC error field, so a failed trace (non-archive node: "historical state not available in path scheme yet") unmarshaled into a zero Result and was indistinguishable from a transaction with no internal calls. The backfill reported 1076 clean scans when ~1000 of them actually failed server-side. TraceResponse now carries the error object; CallDebugTraceTransaction returns it as Err, the backfill counts them, and the live sync path logs a warning.

## Validation

- go build, go vet clean; go test ./... green
- Existing transfer docs with empty status are repaired separately (one-off receipt re-fetch on the box); this PR stops new ones appearing.