### PR TITLE
fix(syncer): load .env before validateEnv reads NODE_URLS

### DIFF
--- a/QRL2MongoDB/cmd/backfill-internal/main.go
+++ b/QRL2MongoDB/cmd/backfill-internal/main.go
@@ -28,6 +28,10 @@ type transferRow struct {
 }
 
 func main() {
+	// Load .env before the env checks below: nothing loads it at import
+	// time anymore.
+	configs.LoadEnv()
+
 	if os.Getenv("ENABLE_DEBUG_TRACE") != "true" {
 		log.Fatal("ENABLE_DEBUG_TRACE=true is required; without it every trace call silently no-ops and the backfill would do nothing")
 	}

--- a/QRL2MongoDB/configs/env.go
+++ b/QRL2MongoDB/configs/env.go
@@ -3,9 +3,24 @@ package configs
 import (
 	"log"
 	"os"
+	"sync"
 
 	"github.com/joho/godotenv"
 )
+
+var loadEnvOnce sync.Once
+
+// LoadEnv loads .env into the process environment (idempotent). Entrypoints
+// must call it before reading any config from os.Getenv: since ConnectDB
+// stopped running at package init, nothing loads .env implicitly anymore.
+// Missing .env is fine: real environment variables take precedence anyway.
+func LoadEnv() {
+	loadEnvOnce.Do(func() {
+		if err := godotenv.Load(); err != nil {
+			log.Println("Warning: .env file not found, using environment variables")
+		}
+	})
+}
 
 func EnvMongoURI() string {
 	// If MONGOURI is already set (e.g., via Docker), use it directly
@@ -14,10 +29,7 @@ func EnvMongoURI() string {
 	}
 
 	// Otherwise, try to load from .env file
-	err := godotenv.Load()
-	if err != nil {
-		log.Println("Warning: .env file not found, using environment variables")
-	}
+	LoadEnv()
 
 	return os.Getenv("MONGOURI")
 }

--- a/QRL2MongoDB/main.go
+++ b/QRL2MongoDB/main.go
@@ -31,6 +31,11 @@ func validateEnv() {
 }
 
 func main() {
+	// Load .env before anything reads os.Getenv. The old import-time
+	// ConnectDB loaded it as a side effect; validateEnv below fatals on a
+	// missing NODE_URLS if this doesn't run first (2026-07-11 prod incident).
+	configs.LoadEnv()
+
 	// Ensure logger resources are properly released
 	defer configs.Logger.Sync()
 


### PR DESCRIPTION
Regression from #165: ConnectDB no longer runs at package init, so nothing loaded .env before main's validateEnv, and a syncer configured purely via .env crash-looped on NODE_URLS at startup. Prod was recovered by injecting the env into pm2; this makes the binary self-sufficient again.

- configs.LoadEnv(): idempotent godotenv.Load, called first in main() and cmd/backfill-internal
- EnvMongoURI delegates to LoadEnv
- Verified locally: .env-only startup now passes validateEnv and proceeds to Mongo connect; hermetic tests still green (LoadEnv only warns when .env is absent)