### PR TITLE
feat(frontend): display native amounts as Quanta

### DIFF
--- a/ExplorerFrontend/app/address/[query]/panels/transactions-panel.tsx
+++ b/ExplorerFrontend/app/address/[query]/panels/transactions-panel.tsx
@@ -14,6 +14,7 @@ import {
   formatAmount,
   formatTimestamp,
   normalizeHexString,
+  NATIVE_UNIT,
 } from '../../../lib/helpers';
 import CopyButton from '../../../components/CopyButton';
 import DebouncedInput from '../../../components/DebouncedInput';
@@ -56,7 +57,7 @@ import {
  *     expected, so the cell rendered empty for every row. Removed rather
  *     than translated because the value adds no information the In/Out
  *     column doesn't already convey.
- *   - "Paid Fees" renders in QRL with up to 8 decimals; the wire value is
+ *   - "Paid Fees" renders in Quanta with up to 8 decimals; the wire value is
  *     a decimal-Quanta string like "0.000078750000357000" the old
  *     calculateFees treated as 0.
  */
@@ -103,8 +104,8 @@ export default function TransactionsPanel({
       rows.map((tx) => {
         const [amount, amountUnit] = formatAmount(tx.Amount);
         // PaidFees comes off the wire as a decimal-Quanta string
-        // ("0.0000787..."). Render in QRL with up to 8 decimals,
-        // Etherscan-style ("0.00428184 QRL"). Cast via unknown because
+        // ("0.0000787..."). Render in Quanta with up to 8 decimals,
+        // Etherscan-style ("0.00428184 Quanta"). Cast via unknown because
         // the type still says `number?` even though the wire shape is
         // a string. Trailing zeros trim out via parseFloat round-trip
         // so 0.10000000 displays as 0.1, not 0.10000000.
@@ -114,8 +115,8 @@ export default function TransactionsPanel({
             ? parseFloat(String(rawFees))
             : 0;
         const formattedFees = Number.isFinite(feeQuanta)
-          ? `${parseFloat(feeQuanta.toFixed(8))} Quanta`
-          : '0 Quanta';
+          ? `${parseFloat(feeQuanta.toFixed(8))} ${NATIVE_UNIT}`
+          : `0 ${NATIVE_UNIT}`;
         return {
           ...tx,
           formattedAmount: `${amount} ${amountUnit}`,

--- a/ExplorerFrontend/app/address/[query]/panels/transactions-panel.tsx
+++ b/ExplorerFrontend/app/address/[query]/panels/transactions-panel.tsx
@@ -114,8 +114,8 @@ export default function TransactionsPanel({
             ? parseFloat(String(rawFees))
             : 0;
         const formattedFees = Number.isFinite(feeQuanta)
-          ? `${parseFloat(feeQuanta.toFixed(8))} QRL`
-          : '0 QRL';
+          ? `${parseFloat(feeQuanta.toFixed(8))} Quanta`
+          : '0 Quanta';
         return {
           ...tx,
           formattedAmount: `${amount} ${amountUnit}`,

--- a/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
@@ -10,7 +10,7 @@ import ContractTabs from "../../components/ContractTabs";
 import TabPillBar from "../../components/TabPillBar";
 import VerifiedBadge from "../../components/VerifiedBadge";
 import type { ContractData } from "../../types/address";
-import { compactTokenIDLabel, formatAmount } from "../../lib/helpers";
+import { compactTokenIDLabel, formatAmount, NATIVE_UNIT } from "../../lib/helpers";
 import Breadcrumbs from "../../components/Breadcrumbs";
 
 interface TokenInfo {
@@ -594,8 +594,8 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                         <div className="text-sm text-text-secondary">
                                             {(() => {
                                                 if (!creationTx?.GasUsed || !creationTx?.GasPrice) return '-';
-                                                const [formattedFee] = formatAmount(`0x${(BigInt(creationTx.GasUsed) * BigInt(creationTx.GasPrice)).toString(16)}`);
-                                                return `${formattedFee} Quanta`;
+                                                const [formattedFee, feeUnit] = formatAmount(`0x${(BigInt(creationTx.GasUsed) * BigInt(creationTx.GasPrice)).toString(16)}`);
+                                                return `${formattedFee} ${feeUnit}`;
                                             })()}
                                         </div>
                                     </div>
@@ -604,9 +604,9 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                         <div className="text-xs md:text-sm text-text-secondary">Value</div>
                                         <div className="text-sm text-text-secondary">
                                             {(() => {
-                                                if (!creationTx?.Value) return '0 Quanta';
-                                                const [formattedValue] = formatAmount(creationTx.Value);
-                                                return `${formattedValue} Quanta`;
+                                                if (!creationTx?.Value) return `0 ${NATIVE_UNIT}`;
+                                                const [formattedValue, valueUnit] = formatAmount(creationTx.Value);
+                                                return `${formattedValue} ${valueUnit}`;
                                             })()}
                                         </div>
                                     </div>

--- a/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
@@ -595,7 +595,7 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                             {(() => {
                                                 if (!creationTx?.GasUsed || !creationTx?.GasPrice) return '-';
                                                 const [formattedFee] = formatAmount(`0x${(BigInt(creationTx.GasUsed) * BigInt(creationTx.GasPrice)).toString(16)}`);
-                                                return `${formattedFee} QRL`;
+                                                return `${formattedFee} Quanta`;
                                             })()}
                                         </div>
                                     </div>
@@ -604,9 +604,9 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                         <div className="text-xs md:text-sm text-text-secondary">Value</div>
                                         <div className="text-sm text-text-secondary">
                                             {(() => {
-                                                if (!creationTx?.Value) return '0 QRL';
+                                                if (!creationTx?.Value) return '0 Quanta';
                                                 const [formattedValue] = formatAmount(creationTx.Value);
-                                                return `${formattedValue} QRL`;
+                                                return `${formattedValue} Quanta`;
                                             })()}
                                         </div>
                                     </div>

--- a/ExplorerFrontend/app/checker/page.tsx
+++ b/ExplorerFrontend/app/checker/page.tsx
@@ -31,7 +31,7 @@ export const metadata: Metadata = {
 export default function BalanceChecker(): JSX.Element {
   return (
     <main aria-labelledby="checker-heading">
-      <h1 id="checker-heading" className="sr-only">QRL Balance Checker</h1>
+      <h1 id="checker-heading" className="sr-only">Quanta Balance Checker</h1>
       <CheckerClient />
     </main>
   );

--- a/ExplorerFrontend/app/components/BalanceCheckTool.tsx
+++ b/ExplorerFrontend/app/components/BalanceCheckTool.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import type { FormEvent, ChangeEvent } from 'react';
 import axios, { AxiosError } from 'axios';
 import config from '../../config';
-import { toFixed } from '../lib/helpers';
+import { NATIVE_UNIT, toFixed } from '../lib/helpers';
 
 interface BalanceResponse {
   balance: string;
@@ -36,7 +36,7 @@ export default function BalanceCheckTool(): JSX.Element {
             );
 
             if (response.data.balance !== "header not found") {
-                setBalance(`${toFixed(response.data.balance)} Quanta`);
+                setBalance(`${toFixed(response.data.balance)} ${NATIVE_UNIT}`);
                 setError(null);
             } else {
                 setBalance(null);

--- a/ExplorerFrontend/app/components/BalanceCheckTool.tsx
+++ b/ExplorerFrontend/app/components/BalanceCheckTool.tsx
@@ -36,7 +36,7 @@ export default function BalanceCheckTool(): JSX.Element {
             );
 
             if (response.data.balance !== "header not found") {
-                setBalance(`${toFixed(response.data.balance)} QRL`);
+                setBalance(`${toFixed(response.data.balance)} Quanta`);
                 setError(null);
             } else {
                 setBalance(null);

--- a/ExplorerFrontend/app/components/WriteContract.tsx
+++ b/ExplorerFrontend/app/components/WriteContract.tsx
@@ -197,7 +197,7 @@ function WriteFunctionCard({
           {fn.stateMutability === 'payable' && (
             <div>
               <div className="text-xs text-text-secondary mb-1">
-                value <span className="font-mono text-text-muted">(QRL)</span>
+                value <span className="font-mono text-text-muted">(Quanta)</span>
               </div>
               <input
                 value={value}

--- a/ExplorerFrontend/app/converter/converter-client.tsx
+++ b/ExplorerFrontend/app/converter/converter-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { smallestUnitToDecimal, decimalToSmallestUnit } from '../lib/helpers';
+import { smallestUnitToDecimal, decimalToSmallestUnit, NATIVE_UNIT } from '../lib/helpers';
 
 function Converter(): JSX.Element {
   const [quanta, setQuanta] = useState("");
@@ -61,7 +61,7 @@ function Converter(): JSX.Element {
                   className="w-full px-4 py-3 bg-background text-text-primary rounded-lg border border-border focus:outline-none focus:border-accent transition-all duration-300"
                 />
                 <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                  <span className="text-text-secondary">Quanta</span>
+                  <span className="text-text-secondary">{NATIVE_UNIT}</span>
                 </div>
               </div>
             </div>
@@ -106,7 +106,7 @@ function Converter(): JSX.Element {
             {/* Info Box */}
             <div className="mt-6 p-4 bg-background rounded-lg border border-border">
               <p className="text-sm text-text-secondary">
-                1 Quanta = 1,000,000,000,000,000,000 Shor (10^18)
+                1 {NATIVE_UNIT} = 1,000,000,000,000,000,000 Shor (10^18)
               </p>
             </div>
           </div>

--- a/ExplorerFrontend/app/converter/converter-client.tsx
+++ b/ExplorerFrontend/app/converter/converter-client.tsx
@@ -50,7 +50,7 @@ function Converter(): JSX.Element {
           <div className="space-y-6">
             {/* Quanta Input */}
             <div>
-              <label htmlFor="quanta-input" className="block text-sm font-medium text-text-secondary mb-2">Quanta (QRL)</label>
+              <label htmlFor="quanta-input" className="block text-sm font-medium text-text-secondary mb-2">Quanta</label>
               <div className="relative">
                 <input
                   id="quanta-input"
@@ -61,7 +61,7 @@ function Converter(): JSX.Element {
                   className="w-full px-4 py-3 bg-background text-text-primary rounded-lg border border-border focus:outline-none focus:border-accent transition-all duration-300"
                 />
                 <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                  <span className="text-text-secondary">QRL</span>
+                  <span className="text-text-secondary">Quanta</span>
                 </div>
               </div>
             </div>
@@ -106,7 +106,7 @@ function Converter(): JSX.Element {
             {/* Info Box */}
             <div className="mt-6 p-4 bg-background rounded-lg border border-border">
               <p className="text-sm text-text-secondary">
-                1 QRL = 1,000,000,000,000,000,000 Shor (10^18)
+                1 Quanta = 1,000,000,000,000,000,000 Shor (10^18)
               </p>
             </div>
           </div>

--- a/ExplorerFrontend/app/faucet/faucet-client.tsx
+++ b/ExplorerFrontend/app/faucet/faucet-client.tsx
@@ -215,10 +215,10 @@ export default function FaucetClient(): JSX.Element {
       <div className="flex flex-col items-center justify-center">
         <h2 className="section-title mb-2">QRL 2.0 Testnet Faucet</h2>
         <p className="text-text-secondary mb-8 text-center max-w-md">
-          Get free testnet QRL to experiment with transactions, contracts, and tooling.
+          Get free testnet Quanta to experiment with transactions, contracts, and tooling.
           {status && (
             <>
-              {' '}Sends <span className="text-accent font-semibold">{status.dripQuanta} QRL</span> per
+              {' '}Sends <span className="text-accent font-semibold">{status.dripQuanta} Quanta</span> per
               address, once every {status.cooldownHours}h.
             </>
           )}
@@ -252,7 +252,7 @@ export default function FaucetClient(): JSX.Element {
               {result && (
                 <div role="status" className="w-full p-4 bg-background rounded-lg border border-green-500/40">
                   <div className="text-sm text-text-secondary">
-                    {result.amount} QRL broadcast to your address
+                    {result.amount} Quanta broadcast to your address
                   </div>
                   <Link
                     href={result.explorerUrl}

--- a/ExplorerFrontend/app/faucet/faucet-client.tsx
+++ b/ExplorerFrontend/app/faucet/faucet-client.tsx
@@ -5,7 +5,7 @@ import type { FormEvent, ChangeEvent } from 'react';
 import Link from 'next/link';
 import Script from 'next/script';
 
-import { formatDuration, isValidQrlAddressFormat } from '../lib/helpers';
+import { formatDuration, isValidQrlAddressFormat, NATIVE_UNIT } from '../lib/helpers';
 
 interface FaucetStatus {
   configured: boolean;
@@ -218,7 +218,7 @@ export default function FaucetClient(): JSX.Element {
           Get free testnet Quanta to experiment with transactions, contracts, and tooling.
           {status && (
             <>
-              {' '}Sends <span className="text-accent font-semibold">{status.dripQuanta} Quanta</span> per
+              {' '}Sends <span className="text-accent font-semibold">{status.dripQuanta} {NATIVE_UNIT}</span> per
               address, once every {status.cooldownHours}h.
             </>
           )}
@@ -252,7 +252,7 @@ export default function FaucetClient(): JSX.Element {
               {result && (
                 <div role="status" className="w-full p-4 bg-background rounded-lg border border-green-500/40">
                   <div className="text-sm text-text-secondary">
-                    {result.amount} Quanta broadcast to your address
+                    {result.amount} {NATIVE_UNIT} broadcast to your address
                   </div>
                   <Link
                     href={result.explorerUrl}

--- a/ExplorerFrontend/app/home-client.tsx
+++ b/ExplorerFrontend/app/home-client.tsx
@@ -5,7 +5,7 @@ import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import axios from 'axios';
 import { useQuery } from '@tanstack/react-query';
-import { formatNumberWithCommas, timeAgo, formatStaked, formatGasPrice, truncateHash, formatAmount, formatAddress } from './lib/helpers';
+import { formatNumberWithCommas, timeAgo, formatStaked, formatGasPrice, truncateHash, formatAmount, formatAddress, NATIVE_UNIT } from './lib/helpers';
 import type { EpochInfo } from './types';
 import config from '../config.js';
 import SearchBar from './components/SearchBar';
@@ -156,7 +156,7 @@ function StatBar({ data }: { data: HomeData }) {
     { label: 'Avg Gas Price', value: data.avgGasPriceHex ? `${formatGasPrice(data.avgGasPriceHex)} Shor` : '…', icon: icons.gas },
     { label: 'Block Height', value: formatNumberWithCommas(data.blockHeight.toString()), icon: icons.block, live: true },
     { label: 'Validators', value: formatNumberWithCommas(data.validatorCount.toString()), icon: icons.validators },
-    { label: 'Staked Quanta', value: data.totalStaked !== '0' ? formatStaked(data.totalStaked) : '…', icon: icons.staked },
+    { label: `Staked ${NATIVE_UNIT}`, value: data.totalStaked !== '0' ? formatStaked(data.totalStaked) : '…', icon: icons.staked },
     { label: 'Transactions', value: formatNumberWithCommas(data.totalTransactions.toString()), icon: icons.transactions },
     { label: 'Market Cap', value: data.marketCap > 0 ? '$' + formatNumberWithCommas(data.marketCap.toString()) : '…', icon: icons.marketCap },
   ];

--- a/ExplorerFrontend/app/home-client.tsx
+++ b/ExplorerFrontend/app/home-client.tsx
@@ -156,7 +156,7 @@ function StatBar({ data }: { data: HomeData }) {
     { label: 'Avg Gas Price', value: data.avgGasPriceHex ? `${formatGasPrice(data.avgGasPriceHex)} Shor` : '…', icon: icons.gas },
     { label: 'Block Height', value: formatNumberWithCommas(data.blockHeight.toString()), icon: icons.block, live: true },
     { label: 'Validators', value: formatNumberWithCommas(data.validatorCount.toString()), icon: icons.validators },
-    { label: 'Staked QRL', value: data.totalStaked !== '0' ? formatStaked(data.totalStaked) : '…', icon: icons.staked },
+    { label: 'Staked Quanta', value: data.totalStaked !== '0' ? formatStaked(data.totalStaked) : '…', icon: icons.staked },
     { label: 'Transactions', value: formatNumberWithCommas(data.totalTransactions.toString()), icon: icons.transactions },
     { label: 'Market Cap', value: data.marketCap > 0 ? '$' + formatNumberWithCommas(data.marketCap.toString()) : '…', icon: icons.marketCap },
   ];

--- a/ExplorerFrontend/app/lib/formatters.test.ts
+++ b/ExplorerFrontend/app/lib/formatters.test.ts
@@ -79,18 +79,18 @@ describe('formatBigGas', () => {
 });
 
 describe('formatStaked', () => {
-  it('converts Shor (1e9) to QRL with trailing zeros stripped', () => {
-    expect(formatStaked('1000000000')).toBe('1 QRL');
-    expect(formatStaked('1500000000')).toBe('1.5 QRL');
+  it('converts Shor (1e9) to Quanta with trailing zeros stripped', () => {
+    expect(formatStaked('1000000000')).toBe('1 Quanta');
+    expect(formatStaked('1500000000')).toBe('1.5 Quanta');
   });
 
   it('handles whole-billion balances cleanly', () => {
-    expect(formatStaked('32000000000')).toBe('32 QRL');
+    expect(formatStaked('32000000000')).toBe('32 Quanta');
   });
 
-  it('returns "0 QRL" for empty / malformed input', () => {
-    expect(formatStaked('')).toBe('0 QRL');
-    expect(formatStaked('not-a-number')).toBe('0 QRL');
+  it('returns "0 Quanta" for empty / malformed input', () => {
+    expect(formatStaked('')).toBe('0 Quanta');
+    expect(formatStaked('not-a-number')).toBe('0 Quanta');
   });
 });
 

--- a/ExplorerFrontend/app/lib/helpers.ts
+++ b/ExplorerFrontend/app/lib/helpers.ts
@@ -15,6 +15,10 @@ function keccakHex(sig: string): string {
 // the tx page, pending-tx page, and search resolver all validate identically.
 export const TX_HASH_RE = /^0x[0-9a-fA-F]{64}$/;
 
+// Display unit for whole-coin amounts. Ecosystem convention: amounts show
+// as "Quanta"; "QRL" is the project name and exchange-ticker only.
+export const NATIVE_UNIT = 'Quanta';
+
 /** True when `value` is a well-formed "0x"-prefixed 32-byte transaction hash. */
 export function isTxHash(value: string | undefined | null): boolean {
   return !!value && TX_HASH_RE.test(value);
@@ -31,7 +35,7 @@ export function timeAgo(unixSeconds: number): string {
 }
 
 // Validator effective balances on the QRL beacon chain are Shor-denominated
-// (10^-9 QRL / "Quanta"). Convert to whole-QRL display.
+// (10^-9 Quanta). Convert to whole-Quanta display.
 export function formatStaked(shor: string): string {
   try {
     const val = BigInt(shor || '0');
@@ -39,9 +43,25 @@ export function formatStaked(shor: string): string {
     const remainder = val % BigInt(1_000_000_000);
     const decimalStr = remainder.toString().padStart(9, '0').replace(/0+$/, '');
     const result = formatNumberWithCommas(qrlBase.toString());
-    return decimalStr.length > 0 ? `${result}.${decimalStr} QRL` : `${result} QRL`;
+    return decimalStr.length > 0 ? `${result}.${decimalStr} ${NATIVE_UNIT}` : `${result} ${NATIVE_UNIT}`;
   } catch {
-    return '0 QRL';
+    return `0 ${NATIVE_UNIT}`;
+  }
+}
+
+// Validator balances arrive Shor-denominated as decimal strings. Whole-coin
+// display with no fraction: stake magnitudes make sub-Quanta noise. Returns
+// [value, unit] like formatAmount so callers style the unit independently.
+// Consolidated here from two previously duplicated component-local copies.
+export function formatValidatorBalance(amount: string | undefined | null): [string, string] {
+  if (!amount || amount === '0') return ['0', NATIVE_UNIT];
+  try {
+    const value = BigInt(amount);
+    const divisor = BigInt('1000000000'); // 10^9 (Shor to whole coin)
+    const qrlValue = Number(value / divisor);
+    return [qrlValue.toLocaleString(undefined, { maximumFractionDigits: 0 }), NATIVE_UNIT];
+  } catch {
+    return ['0', NATIVE_UNIT];
   }
 }
 
@@ -182,12 +202,12 @@ export function formatPlanckAdaptive(planck: number | string | undefined | null)
 export function formatAmount(amount: number | string | undefined | null): [string, string] {
   // Handle undefined or null
   if (amount === undefined || amount === null) {
-    return ['0.00', 'QRL'];
+    return ['0.00', NATIVE_UNIT];
   }
 
   // Handle zero amount
   if (amount === 0 || amount === '0' || amount === '0x0') {
-    return ['0.00', 'QRL'];
+    return ['0.00', NATIVE_UNIT];
   }
 
   let totalNum: number;
@@ -219,24 +239,24 @@ export function formatAmount(amount: number | string | undefined | null): [strin
     }
   } catch (error) {
     console.error('Error converting amount:', error, amount);
-    return ['0.00', 'QRL'];
+    return ['0.00', NATIVE_UNIT];
   }
 
   // Format with appropriate decimal places, avoiding scientific notation
   if (totalNum === 0) {
-    return ['0.00', 'QRL'];
+    return ['0.00', NATIVE_UNIT];
   } else if (totalNum < 0.000001) {
     // For very small numbers, show all significant digits without trailing zeros
-    return [totalNum.toFixed(18).replace(/\.?0+$/, ''), 'QRL'];
+    return [totalNum.toFixed(18).replace(/\.?0+$/, ''), NATIVE_UNIT];
   } else if (totalNum < 1) {
     // For numbers less than 1, show up to 6 decimal places
-    return [totalNum.toFixed(6).replace(/\.?0+$/, ''), 'QRL'];
+    return [totalNum.toFixed(6).replace(/\.?0+$/, ''), NATIVE_UNIT];
   } else if (totalNum < 1000) {
     // For numbers between 1 and 999, show up to 4 decimal places
-    return [totalNum.toFixed(4).replace(/\.?0+$/, ''), 'QRL'];
+    return [totalNum.toFixed(4).replace(/\.?0+$/, ''), NATIVE_UNIT];
   } else {
     // For large numbers, show 2 decimal places
-    return [totalNum.toFixed(2).replace(/\.?0+$/, ''), 'QRL'];
+    return [totalNum.toFixed(2).replace(/\.?0+$/, ''), NATIVE_UNIT];
   }
 }
 

--- a/ExplorerFrontend/app/pending/[query]/PendingList.tsx
+++ b/ExplorerFrontend/app/pending/[query]/PendingList.tsx
@@ -6,7 +6,7 @@ import config from '../../../config';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { formatAmount, formatGasPrice, timeAgo, truncateHash } from '../../lib/helpers';
+import { formatAmount, formatGasPrice, NATIVE_UNIT, timeAgo, truncateHash } from '../../lib/helpers';
 import type { PendingTransaction } from '@/app/types';
 import Badge from '../../components/Badge';
 import Pagination from '../../components/Pagination';
@@ -154,7 +154,7 @@ export default function PendingList({ initialData, currentPage }: PendingListPro
                         </td>
                         <td className="px-4 py-3 text-text-secondary tabular-nums whitespace-nowrap">
                           {formattedValue}
-                          <span className="text-text-muted text-xs ml-1">Quanta</span>
+                          <span className="text-text-muted text-xs ml-1">{NATIVE_UNIT}</span>
                         </td>
                         <td className="px-4 py-3">
                           <Badge variant={statusVariant(tx.status)} dot>

--- a/ExplorerFrontend/app/pending/[query]/PendingList.tsx
+++ b/ExplorerFrontend/app/pending/[query]/PendingList.tsx
@@ -154,7 +154,7 @@ export default function PendingList({ initialData, currentPage }: PendingListPro
                         </td>
                         <td className="px-4 py-3 text-text-secondary tabular-nums whitespace-nowrap">
                           {formattedValue}
-                          <span className="text-text-muted text-xs ml-1">QRL</span>
+                          <span className="text-text-muted text-xs ml-1">Quanta</span>
                         </td>
                         <td className="px-4 py-3">
                           <Badge variant={statusVariant(tx.status)} dot>

--- a/ExplorerFrontend/app/richlist/loading.tsx
+++ b/ExplorerFrontend/app/richlist/loading.tsx
@@ -13,7 +13,7 @@ export default function Loading(): JSX.Element {
         <div className="mb-6 md:mb-8">
           <h1 className="section-title">Richlist</h1>
           <p className="text-sm md:text-base text-text-secondary mt-2">
-            Top 50 QRL holders by balance
+            Top 50 Quanta holders by balance
           </p>
         </div>
 

--- a/ExplorerFrontend/app/richlist/loading.tsx
+++ b/ExplorerFrontend/app/richlist/loading.tsx
@@ -6,6 +6,8 @@
  * Shape mirrors RichlistClient: header + subtitle and the three-column
  * (rank / address / balance) table card.
  */
+import { NATIVE_UNIT } from '../lib/helpers';
+
 export default function Loading(): JSX.Element {
   return (
     <div role="status" aria-label="Loading rich list" className="min-h-screen">
@@ -13,7 +15,7 @@ export default function Loading(): JSX.Element {
         <div className="mb-6 md:mb-8">
           <h1 className="section-title">Richlist</h1>
           <p className="text-sm md:text-base text-text-secondary mt-2">
-            Top 50 Quanta holders by balance
+            Top 50 {NATIVE_UNIT} holders by balance
           </p>
         </div>
 

--- a/ExplorerFrontend/app/richlist/richlist-client.tsx
+++ b/ExplorerFrontend/app/richlist/richlist-client.tsx
@@ -68,7 +68,7 @@ export default function RichlistClient({ richlist }: RichlistProps): JSX.Element
             <div>
               <span className="text-accent text-sm">Balance:</span>
               <span className="ml-2 text-text-primary text-sm">
-                {toFixed(item.balance)} QRL
+                {toFixed(item.balance)} Quanta
               </span>
             </div>
           </div>
@@ -129,7 +129,7 @@ export default function RichlistClient({ richlist }: RichlistProps): JSX.Element
                 </Link>
               </td>
               <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap text-right text-text-secondary text-sm">
-                {toFixed(item.balance)} QRL
+                {toFixed(item.balance)} Quanta
               </td>
             </tr>
           ))}
@@ -144,7 +144,7 @@ export default function RichlistClient({ richlist }: RichlistProps): JSX.Element
         <div className="mb-6 md:mb-8">
           <h1 className="section-title">Richlist</h1>
           <p className="text-sm md:text-base text-text-secondary mt-2">
-            Top 50 QRL holders by balance
+            Top 50 Quanta holders by balance
           </p>
         </div>
 

--- a/ExplorerFrontend/app/richlist/richlist-client.tsx
+++ b/ExplorerFrontend/app/richlist/richlist-client.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import Link from "next/link";
-import { toFixed } from "../lib/helpers";
+import { NATIVE_UNIT, toFixed } from "../lib/helpers";
 
 interface RichlistEntry {
   id: string;
@@ -68,7 +68,7 @@ export default function RichlistClient({ richlist }: RichlistProps): JSX.Element
             <div>
               <span className="text-accent text-sm">Balance:</span>
               <span className="ml-2 text-text-primary text-sm">
-                {toFixed(item.balance)} Quanta
+                {toFixed(item.balance)} {NATIVE_UNIT}
               </span>
             </div>
           </div>
@@ -129,7 +129,7 @@ export default function RichlistClient({ richlist }: RichlistProps): JSX.Element
                 </Link>
               </td>
               <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap text-right text-text-secondary text-sm">
-                {toFixed(item.balance)} Quanta
+                {toFixed(item.balance)} {NATIVE_UNIT}
               </td>
             </tr>
           ))}
@@ -144,7 +144,7 @@ export default function RichlistClient({ richlist }: RichlistProps): JSX.Element
         <div className="mb-6 md:mb-8">
           <h1 className="section-title">Richlist</h1>
           <p className="text-sm md:text-base text-text-secondary mt-2">
-            Top 50 Quanta holders by balance
+            Top 50 {NATIVE_UNIT} holders by balance
           </p>
         </div>
 

--- a/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
+++ b/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import axios from 'axios';
 import { useQuery } from '@tanstack/react-query';
 import { type TransactionDetails, getConfirmations, getTransactionStatus } from '@/app/types';
-import { formatAmount, formatTokenAmount, decodeEventLog, decodeTokenTransferInput, decodeContractCall } from '../../lib/helpers';
+import { formatAmount, formatTokenAmount, decodeEventLog, decodeTokenTransferInput, decodeContractCall, NATIVE_UNIT } from '../../lib/helpers';
 import { useIsMobile } from '../../lib/hooks';
 import config from '../../../config';
 import CopyButton from '../../components/CopyButton';
@@ -280,7 +280,7 @@ export default function TransactionView({ transaction }: TransactionViewProps): 
           {(transaction.gasUsed || transaction.gasPrice) && (
             <DetailRow label="Transaction Fee">
               {paidFees}
-              <span className="text-text-muted ml-1">Quanta</span>
+              <span className="text-text-muted ml-1">{NATIVE_UNIT}</span>
               {(() => {
                 // USD conversion is opt-in: requires both a fee > 0 and a
                 // price from the polled /latestblock response. Skips the
@@ -606,7 +606,7 @@ export default function TransactionView({ transaction }: TransactionViewProps): 
                       </Badge>
                     )}
                     {itx.value > 0 && (
-                      <Badge variant="warning">{itx.value} Quanta</Badge>
+                      <Badge variant="warning">{itx.value} {NATIVE_UNIT}</Badge>
                     )}
                   </div>
                   <div className="space-y-1 text-xs">

--- a/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
+++ b/ExplorerFrontend/app/tx/[query]/transaction-view.tsx
@@ -280,7 +280,7 @@ export default function TransactionView({ transaction }: TransactionViewProps): 
           {(transaction.gasUsed || transaction.gasPrice) && (
             <DetailRow label="Transaction Fee">
               {paidFees}
-              <span className="text-text-muted ml-1">QRL</span>
+              <span className="text-text-muted ml-1">Quanta</span>
               {(() => {
                 // USD conversion is opt-in: requires both a fee > 0 and a
                 // price from the polled /latestblock response. Skips the
@@ -606,7 +606,7 @@ export default function TransactionView({ transaction }: TransactionViewProps): 
                       </Badge>
                     )}
                     {itx.value > 0 && (
-                      <Badge variant="warning">{itx.value} QRL</Badge>
+                      <Badge variant="warning">{itx.value} Quanta</Badge>
                     )}
                   </div>
                   <div className="space-y-1 text-xs">

--- a/ExplorerFrontend/app/validators/[id]/validator-detail-client.tsx
+++ b/ExplorerFrontend/app/validators/[id]/validator-detail-client.tsx
@@ -5,23 +5,10 @@ import { useRouter } from 'next/navigation';
 import axios from 'axios';
 import Link from 'next/link';
 import config from '../../../config';
-import { epochsToDays } from '../../lib/helpers';
+import { epochsToDays, formatValidatorBalance } from '../../lib/helpers';
 import Badge from '../../components/Badge';
 import CopyButton from '../../components/CopyButton';
 import EmptyState from '../../components/EmptyState';
-
-// Format staked amount (beacon chain stores effective balance in Shor, 1 QRL = 10^9 Shor)
-function formatValidatorBalance(amount: string): [string, string] {
-  if (!amount || amount === '0') return ['0', 'QRL'];
-  try {
-    const value = BigInt(amount);
-    const divisor = BigInt('1000000000'); // 10^9 (Shor to QRL)
-    const qrlValue = Number(value / divisor);
-    return [qrlValue.toLocaleString(undefined, { maximumFractionDigits: 0 }), 'QRL'];
-  } catch {
-    return ['0', 'QRL'];
-  }
-}
 
 interface ValidatorDetail {
   index: string;

--- a/ExplorerFrontend/app/validators/components/ValidatorHistoryChart.tsx
+++ b/ExplorerFrontend/app/validators/components/ValidatorHistoryChart.tsx
@@ -122,7 +122,7 @@ export default function ValidatorHistoryChart({
   const formatTooltipValue = (d: HistoryRecord) => {
     if (type === 'staked') {
       const val = getStaked(d);
-      return `${val.toLocaleString(undefined, { maximumFractionDigits: 2 })} QRL`;
+      return `${val.toLocaleString(undefined, { maximumFractionDigits: 2 })} Quanta`;
     }
     return d.validatorsCount.toLocaleString();
   };

--- a/ExplorerFrontend/app/validators/components/ValidatorHistoryChart.tsx
+++ b/ExplorerFrontend/app/validators/components/ValidatorHistoryChart.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
+import { NATIVE_UNIT } from '../../lib/helpers';
 import { Group } from '@visx/group';
 import { LinePath, AreaClosed } from '@visx/shape';
 import { AxisLeft, AxisBottom } from '@visx/axis';
@@ -122,7 +123,7 @@ export default function ValidatorHistoryChart({
   const formatTooltipValue = (d: HistoryRecord) => {
     if (type === 'staked') {
       const val = getStaked(d);
-      return `${val.toLocaleString(undefined, { maximumFractionDigits: 2 })} Quanta`;
+      return `${val.toLocaleString(undefined, { maximumFractionDigits: 2 })} ${NATIVE_UNIT}`;
     }
     return d.validatorsCount.toLocaleString();
   };

--- a/ExplorerFrontend/app/validators/components/ValidatorStatsCards.tsx
+++ b/ExplorerFrontend/app/validators/components/ValidatorStatsCards.tsx
@@ -83,7 +83,7 @@ export default function ValidatorStatsCards({ stats, loading }: ValidatorStatsCa
     },
     {
       label: 'Total Staked',
-      value: `${formattedStake} QRL`,
+      value: `${formattedStake} Quanta`,
       color: 'text-accent',
     },
   ];

--- a/ExplorerFrontend/app/validators/components/ValidatorStatsCards.tsx
+++ b/ExplorerFrontend/app/validators/components/ValidatorStatsCards.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { NATIVE_UNIT } from '../../lib/helpers';
+
 interface ValidatorStats {
   totalValidators: number;
   activeCount: number;
@@ -83,7 +85,7 @@ export default function ValidatorStatsCards({ stats, loading }: ValidatorStatsCa
     },
     {
       label: 'Total Staked',
-      value: `${formattedStake} Quanta`,
+      value: `${formattedStake} ${NATIVE_UNIT}`,
       color: 'text-accent',
     },
   ];

--- a/ExplorerFrontend/app/validators/components/ValidatorTable.tsx
+++ b/ExplorerFrontend/app/validators/components/ValidatorTable.tsx
@@ -2,21 +2,8 @@
 
 import { useState, useMemo } from 'react';
 import Link from 'next/link';
-import { epochsToDays } from '../../lib/helpers';
+import { epochsToDays, formatValidatorBalance } from '../../lib/helpers';
 import Badge from '../../components/Badge';
-
-// Format staked amount (beacon chain stores effective balance in Shor, 1 QRL = 10^9 Shor)
-function formatValidatorStake(amount: string): [string, string] {
-  if (!amount || amount === '0') return ['0', 'QRL'];
-  try {
-    const value = BigInt(amount);
-    const divisor = BigInt('1000000000'); // 10^9 (Shor to QRL)
-    const qrlValue = Number(value / divisor);
-    return [qrlValue.toLocaleString(undefined, { maximumFractionDigits: 0 }), 'QRL'];
-  } catch {
-    return ['0', 'QRL'];
-  }
-}
 
 interface Validator {
   index: string;
@@ -229,7 +216,7 @@ export default function ValidatorTable({ validators, loading }: ValidatorTablePr
           </thead>
           <tbody className="divide-y divide-border">
             {currentValidators.map((validator) => {
-              const [stakeValue, stakeUnit] = formatValidatorStake(validator.stakedAmount);
+              const [stakeValue, stakeUnit] = formatValidatorBalance(validator.stakedAmount);
               return (
               <tr
                 key={validator.index}

--- a/QRL2MongoDB/metadata/metadata_service_test.go
+++ b/QRL2MongoDB/metadata/metadata_service_test.go
@@ -350,7 +350,7 @@ func TestIsForbiddenIP(t *testing.T) {
 		{"8.8.8.8", false},
 		{"1.1.1.1", false},
 		{"209.250.255.226", false},      // QRL Foundation public RPC
-		{"9.9.9.9", false},        // Quad9 public DNS
+		{"9.9.9.9", false},              // Quad9 public DNS
 		{"2606:4700:4700::1111", false}, // Cloudflare DNS over IPv6
 
 		// Loopback


### PR DESCRIPTION
## Summary
Ecosystem consensus (Discord, 2026-07-20): native tools display coin amounts as **Quanta**; QRL stays the project name and exchange ticker. Zondscan was showing "10 QRL".

- New `NATIVE_UNIT` constant in `app/lib/helpers.ts`; `formatAmount()` and `formatStaked()` now emit it, which flips every render site consuming their `[value, unit]` tuple (balances, tx values, staked stats, blocks, pending).
- Consolidated the two duplicated component-local validator balance formatters (`validator-detail-client.tsx`, `ValidatorTable.tsx`) into a shared `formatValidatorBalance()` in helpers.
- Flipped remaining hardcoded literals: richlist, faucet copy, converter, tx fee rows, internal-tx badge, balance checker, validator stats/chart, token contract views, payable value label, home "Staked Quanta" stat.
- Test expectations updated (`formatters.test.ts`).

Kept as QRL: network/project references ("QRL 2.0"), address labels, the MEXC `QRLUSDT` TradingView widget, and the `USD/QRL` rate tooltip (ticker contexts).

## Gates
- `npm run lint`: 0 errors (17 pre-existing warnings)
- `npm test`: 114/114 pass
- `npm run build`: pass

## Risks
Display-only change, no data or API shape touched. Sub-unit (Shor/Planck) displays unchanged.
