### PR TITLE
feat(api): add priceChange24h to /overview

### DIFF
--- a/backendAPI/db/stats.go
+++ b/backendAPI/db/stats.go
@@ -4,12 +4,14 @@ import (
 	"backendAPI/configs"
 	"backendAPI/models"
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -112,7 +114,15 @@ func GetPriceChange24h(currentPrice float64) float64 {
 	var then models.PriceHistory
 	err := configs.PriceHistoryCollection.FindOne(ctx,
 		bson.M{"timestamp": bson.M{"$gte": since}}, opts).Decode(&then)
-	if err != nil || then.PriceUSD <= 0 {
+	if err != nil {
+		// An empty window is expected on fresh deployments; anything else
+		// is a real database problem worth surfacing.
+		if !errors.Is(err, mongo.ErrNoDocuments) {
+			log.Printf("error fetching 24h price baseline: %v", err)
+		}
+		return 0
+	}
+	if then.PriceUSD <= 0 {
 		return 0
 	}
 

--- a/backendAPI/db/stats.go
+++ b/backendAPI/db/stats.go
@@ -92,6 +92,33 @@ func GetCurrentVolume() float64 {
 	return data.VolumeUSD
 }
 
+// GetPriceChange24h returns the percent change between the stored price
+// closest to 24 hours ago and the given current price. Returns 0 when the
+// current price is unknown or there is no history old enough to compare
+// against, callers treat 0 as "no change data".
+func GetPriceChange24h(currentPrice float64) float64 {
+	if currentPrice <= 0 {
+		return 0
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Snapshots are written every ~30 min, so the oldest document inside
+	// the trailing 24h window is the closest one to 24 hours ago.
+	since := time.Now().Add(-24 * time.Hour)
+	opts := options.FindOne().SetSort(bson.D{{Key: "timestamp", Value: 1}})
+
+	var then models.PriceHistory
+	err := configs.PriceHistoryCollection.FindOne(ctx,
+		bson.M{"timestamp": bson.M{"$gte": since}}, opts).Decode(&then)
+	if err != nil || then.PriceUSD <= 0 {
+		return 0
+	}
+
+	return (currentPrice - then.PriceUSD) / then.PriceUSD * 100
+}
+
 // GetPriceHistory returns historical price data for the given duration
 // interval can be: "4h", "12h", "24h", "7d", "30d", "all"
 func GetPriceHistory(interval string) ([]models.PriceHistory, error) {

--- a/backendAPI/routes/market_routes.go
+++ b/backendAPI/routes/market_routes.go
@@ -44,9 +44,12 @@ func handleOverview(c *gin.Context) {
 
 		tradingVolume := market.VolumeUSD
 
+		priceChange24h := db.GetPriceChange24h(currentPrice)
+
 		return gin.H{
 			"marketcap":      marketCap,
 			"currentPrice":   currentPrice,
+			"priceChange24h": priceChange24h,
 			"countwallets":   walletCount,
 			"circulating":    circulating,
 			"volume":         volume,


### PR DESCRIPTION
## Why
The wallet frontend renders a 24h price up/down indicator next to the USD balance and has read `priceChange24h` from `/overview` since its fee-selector PR, but the field was never produced anywhere in this repo, so the indicator has been silently hidden since it shipped.

## What
- `db.GetPriceChange24h(currentPrice)`: fetches the oldest `priceHistory` snapshot inside the trailing 24h window (snapshots are ~30 min apart, so that is the one closest to 24h ago) and returns the percent change vs the current price. Returns 0 on missing price or history, which consumers already treat as no-data.
- `/overview` now includes `priceChange24h` in its cached payload.

No syncer or schema changes: the computation reuses the existing `priceHistory` collection, which live-checks confirm holds a full trailing 24h of data.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` all green
- Live data check: `/api/price-history?interval=24h` returns 48 snapshots; current 0.9763 vs 0.9845 24h ago computes to about -0.83%, matching expectations