### PR TITLE
feat: community feedback pass (richlist, contracts, converter, validators, genesis, URL state)

### DIFF
--- a/ExplorerFrontend/app/address/[query]/address-tabs.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-tabs.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useMemo, useState } from 'react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import type { InternalTransaction, Transaction } from '@/app/types';
@@ -12,6 +12,7 @@ import InternalPanel from './panels/internal-panel';
 import TokenTransfersPanel from './panels/token-transfers-panel';
 import TokensPanel from './panels/tokens-panel';
 import NftsPanel from './panels/nfts-panel';
+import { setUrlParams } from '../../lib/use-url-param';
 
 /**
  * Single unified tab bar that replaces the old stacked HoldingsDisplay +
@@ -23,9 +24,11 @@ import NftsPanel from './panels/nfts-panel';
  * Source-of-truth choices, deliberate:
  *   - activeTab is derived from useSearchParams every render; no local
  *     useState mirror to drift out of sync.
- *   - router.replace (not push) so tab clicks don't pollute browser
- *     history. Back-button returns to the previous page, not the previous
- *     tab. Matches the codebase pattern (TransactionsList, blocks-client).
+ *   - setUrlParams replace (not push) so tab clicks don't pollute browser
+ *     history: Back returns to the previous page, not the previous tab.
+ *     The shallow History-API write avoids the RSC refetch router.replace
+ *     caused and preserves the panels' page params (?txPage etc.) so Back
+ *     can restore them.
  *   - Per-address reset is delegated to the parent: address-view passes
  *     key={addressSegment} so React unmounts + remounts this whole
  *     component on address change. All internal state (mountedTabs,
@@ -96,8 +99,6 @@ export default function AddressTabs({
   internalt: initialInternalt,
   internalTransactionsCount: initialInternalTransactionsCount,
 }: AddressTabsProps): JSX.Element {
-  const router = useRouter();
-  const pathname = usePathname();
   const searchParams = useSearchParams();
 
   // Keep the native-tx feed + counts live by polling the same
@@ -168,13 +169,10 @@ export default function AddressTabs({
     () => new Set([activeTab]),
   );
 
-  const setTab = useCallback(
-    (key: TabKey) => {
-      setMountedTabs((prev) => (prev.has(key) ? prev : new Set(prev).add(key)));
-      router.replace(`${pathname}?tab=${key}`, { scroll: false });
-    },
-    [router, pathname],
-  );
+  const setTab = useCallback((key: TabKey) => {
+    setMountedTabs((prev) => (prev.has(key) ? prev : new Set(prev).add(key)));
+    setUrlParams({ tab: key }, 'replace');
+  }, []);
 
   // If the URL ever flips to a tab the click handler didn't go through
   // (theoretically possible on some external navigation), fall back to

--- a/ExplorerFrontend/app/address/[query]/address-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/address-view.tsx
@@ -156,11 +156,13 @@ export default function AddressView({ addressData, addressSegment }: AddressView
                                     <div>
                                         <div className="text-xs md:text-sm text-text-secondary mb-1">Creator Address</div>
                                         <div className="flex items-center space-x-2">
-                                            <AddressDisplay
-                                                address={contractData.creatorAddress || 'Unknown'}
-                                            />
-                                            {contractData.creatorAddress && (
-                                                <CopyButton value={contractData.creatorAddress} label="Copy address" />
+                                            {contractData.creatorAddress ? (
+                                                <>
+                                                    <AddressDisplay address={contractData.creatorAddress} />
+                                                    <CopyButton value={contractData.creatorAddress} label="Copy address" />
+                                                </>
+                                            ) : (
+                                                <span className="text-xs md:text-sm text-text-secondary">Unknown</span>
                                             )}
                                         </div>
                                     </div>

--- a/ExplorerFrontend/app/address/[query]/panels/internal-panel.tsx
+++ b/ExplorerFrontend/app/address/[query]/panels/internal-panel.tsx
@@ -33,6 +33,7 @@ import {
   fetchAllAggregateRows,
   useAggregatePage,
 } from './use-aggregate-page';
+import { useUrlIntParam } from '../../../lib/use-url-param';
 
 /**
  * Internal-transactions panel. Sub-frame calls emitted by contract
@@ -64,7 +65,11 @@ export default function InternalPanel({
   total,
 }: InternalPanelProps): JSX.Element {
   const [filter, setFilter] = useState('');
-  const [page, setPage] = useState(1);
+  // URL-backed page (?itxPage) so browser Back restores it; read during
+  // render, so a lazy-mounted panel hydrates the page before its first
+  // fetch. replace (the hook default) keeps tab-internal paging out of
+  // browser history.
+  const [page, setPage] = useUrlIntParam('itxPage', 1);
   const isMobile = useIsMobile();
 
   const pageQuery = useAggregatePage(address, page);
@@ -334,8 +339,8 @@ export default function InternalPanel({
         canPrev={page > 1}
         canNext={page < pageCount}
         goFirst={() => setPage(1)}
-        goPrev={() => setPage((p) => Math.max(1, p - 1))}
-        goNext={() => setPage((p) => Math.min(pageCount, p + 1))}
+        goPrev={() => setPage(Math.max(1, page - 1))}
+        goNext={() => setPage(Math.min(pageCount, page + 1))}
         goLast={() => setPage(pageCount)}
       />
     </div>

--- a/ExplorerFrontend/app/address/[query]/panels/nfts-panel.tsx
+++ b/ExplorerFrontend/app/address/[query]/panels/nfts-panel.tsx
@@ -20,6 +20,7 @@ import {
   renderTableBody,
   renderTableHeader,
 } from './_table-utils';
+import { useUrlIntParam } from '../../../lib/use-url-param';
 
 /**
  * NFT holdings panel (QRC-721 + QRC-1155). Lazy-fetches `/address/:addr/nfts`
@@ -54,6 +55,12 @@ export default function NftsPanel({ address, onLoaded }: NftsPanelProps): JSX.El
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState('');
+  // URL-backed page (?nftPage, 1-based) so browser Back restores it. Read
+  // during render, so a lazy-mounted panel hydrates its page before the
+  // rows arrive; autoResetPageIndex is off below because the post-mount
+  // fetch swapping `data` in would otherwise clobber the restored page.
+  const [pageParam, setPageParam] = useUrlIntParam('nftPage', 1);
+  const pagination = { pageIndex: pageParam - 1, pageSize: PAGE_SIZE };
 
   useEffect(() => {
     let cancelled = false;
@@ -169,12 +176,16 @@ export default function NftsPanel({ address, onLoaded }: NftsPanelProps): JSX.El
   const table = useReactTable({
     data: rows,
     columns,
-    state: { globalFilter: filter },
+    state: { globalFilter: filter, pagination },
     onGlobalFilterChange: setFilter,
+    onPaginationChange: (updater) => {
+      const next = typeof updater === 'function' ? updater(pagination) : updater;
+      setPageParam(next.pageIndex + 1);
+    },
+    autoResetPageIndex: false,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
-    initialState: { pagination: { pageIndex: 0, pageSize: PAGE_SIZE } },
   });
 
   if (loading && !loaded) {
@@ -196,7 +207,12 @@ export default function NftsPanel({ address, onLoaded }: NftsPanelProps): JSX.El
           </div>
           <DebouncedInput
             value={filter}
-            onChange={(v) => setFilter(String(v))}
+            onChange={(v) => {
+              setFilter(String(v));
+              // Manual reset since autoResetPageIndex is off: a new search
+              // starts from page 1.
+              setPageParam(1);
+            }}
             className="px-4 py-2 text-sm bg-background border border-border rounded-lg focus:outline-none focus:border-accent text-text-primary w-full md:w-auto"
             placeholder="Search by collection, tokenID, address"
           />

--- a/ExplorerFrontend/app/address/[query]/panels/token-transfers-panel.tsx
+++ b/ExplorerFrontend/app/address/[query]/panels/token-transfers-panel.tsx
@@ -22,6 +22,7 @@ import {
   truncateMiddle,
   useIsMobile,
 } from './_table-utils';
+import { useUrlIntParam } from '../../../lib/use-url-param';
 
 /**
  * Token Transfers panel for the address page. Lazy-fetches up to 250 rows
@@ -54,6 +55,10 @@ interface TokenTransferRow {
   tokenID?: string;
 }
 
+// TanStack's default 10/page, made explicit now that pagination state is
+// controlled (URL-backed ?ttPage).
+const TRANSFERS_PAGE_SIZE = 10;
+
 const columnHelper = createColumnHelper<
   TokenTransferRow & { formattedAmount: string; tsSeconds: number }
 >();
@@ -75,6 +80,12 @@ export default function TokenTransfersPanel({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState('');
+  // URL-backed page (?ttPage, 1-based) so browser Back restores it. Read
+  // during render, so a lazy-mounted panel hydrates its page before the
+  // rows arrive; autoResetPageIndex is off below because the post-mount
+  // fetch swapping `data` in would otherwise clobber the restored page.
+  const [pageParam, setPageParam] = useUrlIntParam('ttPage', 1);
+  const pagination = { pageIndex: pageParam - 1, pageSize: TRANSFERS_PAGE_SIZE };
   const isMobile = useIsMobile();
 
   useEffect(() => {
@@ -258,8 +269,13 @@ export default function TokenTransfersPanel({
     columns: columns as ColumnDef<
       TokenTransferRow & { formattedAmount: string; tsSeconds: number }
     >[],
-    state: { globalFilter: filter },
+    state: { globalFilter: filter, pagination },
     onGlobalFilterChange: setFilter,
+    onPaginationChange: (updater) => {
+      const next = typeof updater === 'function' ? updater(pagination) : updater;
+      setPageParam(next.pageIndex + 1);
+    },
+    autoResetPageIndex: false,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
@@ -370,7 +386,12 @@ export default function TokenTransfersPanel({
           </div>
           <DebouncedInput
             value={filter}
-            onChange={(v) => setFilter(String(v))}
+            onChange={(v) => {
+              setFilter(String(v));
+              // Manual reset since autoResetPageIndex is off: a new search
+              // starts from page 1.
+              setPageParam(1);
+            }}
             className="px-4 py-2 text-sm bg-background border border-border rounded-lg focus:outline-none focus:border-accent text-text-primary w-full md:w-auto"
             placeholder="Search token transfers..."
           />

--- a/ExplorerFrontend/app/address/[query]/panels/tokens-panel.tsx
+++ b/ExplorerFrontend/app/address/[query]/panels/tokens-panel.tsx
@@ -19,6 +19,7 @@ import {
   renderTableBody,
   renderTableHeader,
 } from './_table-utils';
+import { useUrlIntParam } from '../../../lib/use-url-param';
 
 /**
  * QRC-20 holdings panel. Lazy-fetches `/address/:addr/tokens` on first
@@ -52,6 +53,12 @@ export default function TokensPanel({ address, onLoaded }: TokensPanelProps): JS
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState('');
+  // URL-backed page (?tokPage, 1-based) so browser Back restores it. Read
+  // during render, so a lazy-mounted panel hydrates its page before the
+  // rows arrive; autoResetPageIndex is off below because the post-mount
+  // fetch swapping `data` in would otherwise clobber the restored page.
+  const [pageParam, setPageParam] = useUrlIntParam('tokPage', 1);
+  const pagination = { pageIndex: pageParam - 1, pageSize: PAGE_SIZE };
 
   useEffect(() => {
     let cancelled = false;
@@ -130,12 +137,16 @@ export default function TokensPanel({ address, onLoaded }: TokensPanelProps): JS
   const table = useReactTable({
     data: rows,
     columns,
-    state: { globalFilter: filter },
+    state: { globalFilter: filter, pagination },
     onGlobalFilterChange: setFilter,
+    onPaginationChange: (updater) => {
+      const next = typeof updater === 'function' ? updater(pagination) : updater;
+      setPageParam(next.pageIndex + 1);
+    },
+    autoResetPageIndex: false,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
-    initialState: { pagination: { pageIndex: 0, pageSize: PAGE_SIZE } },
   });
 
   if (loading && !loaded) {
@@ -157,7 +168,12 @@ export default function TokensPanel({ address, onLoaded }: TokensPanelProps): JS
           </div>
           <DebouncedInput
             value={filter}
-            onChange={(v) => setFilter(String(v))}
+            onChange={(v) => {
+              setFilter(String(v));
+              // Manual reset since autoResetPageIndex is off: a new search
+              // starts from page 1.
+              setPageParam(1);
+            }}
             className="px-4 py-2 text-sm bg-background border border-border rounded-lg focus:outline-none focus:border-accent text-text-primary w-full md:w-auto"
             placeholder="Search by name, symbol, address"
           />

--- a/ExplorerFrontend/app/address/[query]/panels/transactions-panel.tsx
+++ b/ExplorerFrontend/app/address/[query]/panels/transactions-panel.tsx
@@ -33,6 +33,7 @@ import {
   fetchAllAggregateRows,
   useAggregatePage,
 } from './use-aggregate-page';
+import { useUrlIntParam } from '../../../lib/use-url-param';
 
 /**
  * Native transactions panel with server-side pagination.
@@ -83,7 +84,11 @@ export default function TransactionsPanel({
   total,
 }: TransactionsPanelProps): JSX.Element {
   const [filter, setFilter] = useState('');
-  const [page, setPage] = useState(1);
+  // URL-backed page (?txPage) so browser Back restores it; read during
+  // render, so a lazy-mounted panel hydrates the page before its first
+  // fetch. replace (the hook default) keeps tab-internal paging out of
+  // browser history.
+  const [page, setPage] = useUrlIntParam('txPage', 1);
   const isMobile = useIsMobile();
 
   const pageQuery = useAggregatePage(address, page);
@@ -368,8 +373,8 @@ export default function TransactionsPanel({
         canPrev={page > 1}
         canNext={page < pageCount}
         goFirst={() => setPage(1)}
-        goPrev={() => setPage((p) => Math.max(1, p - 1))}
-        goNext={() => setPage((p) => Math.min(pageCount, p + 1))}
+        goPrev={() => setPage(Math.max(1, page - 1))}
+        goNext={() => setPage(Math.min(pageCount, page + 1))}
         goLast={() => setPage(pageCount)}
       />
     </div>

--- a/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
+++ b/ExplorerFrontend/app/address/[query]/token-contract-view.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import Image from 'next/image';
+import { useState, useEffect, useCallback } from 'react';
 import ImageWithFallback from '../../components/ImageWithFallback';
 import Link from 'next/link';
 import CopyButton from "../../components/CopyButton";
@@ -12,6 +11,17 @@ import VerifiedBadge from "../../components/VerifiedBadge";
 import type { ContractData } from "../../types/address";
 import { compactTokenIDLabel, formatAmount, NATIVE_UNIT } from "../../lib/helpers";
 import Breadcrumbs from "../../components/Breadcrumbs";
+import { setUrlParams, useUrlIntParam, useUrlParam } from "../../lib/use-url-param";
+
+// Tab set for the pill bar below. ?tab values outside this list (hand-edited
+// URLs) fall back to the overview pane.
+const TOKEN_TABS = ['overview', 'holders', 'transfers', 'tokens'] as const;
+type TokenTab = (typeof TOKEN_TABS)[number];
+function parseTokenTab(raw: string): TokenTab {
+    return (TOKEN_TABS as readonly string[]).includes(raw)
+        ? (raw as TokenTab)
+        : 'overview';
+}
 
 interface TokenInfo {
     contractAddress: string;
@@ -24,6 +34,9 @@ interface TokenInfo {
     creatorAddress: string;
     creationTxHash: string;
     creationBlock: string;
+    // Optional backend flag for contracts baked into the chain at genesis
+    // (no deployment tx). Absent on handlers predating it.
+    genesisContract?: boolean;
 }
 
 interface TokenHolder {
@@ -90,6 +103,10 @@ interface TokenContractViewProps {
         decimals?: number;
         totalSupply?: string;
         status?: string;
+        creationBlockNumber?: string;
+        // Optional genesis flag mirrored from the contract-info payload;
+        // treat absence as "deployed normally".
+        genesisContract?: boolean;
     };
     handlerUrl: string;
 }
@@ -154,23 +171,56 @@ const formatTimestamp = (timestamp: string): string => {
 };
 
 export default function TokenContractView({ address, contractData, handlerUrl }: TokenContractViewProps) {
-    const [activeTab, setActiveTab] = useState<'overview' | 'holders' | 'transfers' | 'tokens'>('overview');
+    const tokenStandard = contractData.tokenStandard;
+    const isNFT = tokenStandard === 'ERC-721' || tokenStandard === 'ERC-1155';
+    // URL-backed tab + per-tab pages + tokenID filter so the browser Back
+    // button restores the exact view instead of resetting to Overview. All
+    // writes use replace (shallow History-API, no RSC refetch); pages are
+    // 1-based in the URL for readability and converted to the 0-based
+    // values the fetches use.
+    const [rawTab, setRawTab] = useUrlParam('tab', 'overview');
+    const parsedTab = parseTokenTab(rawTab);
+    // Non-NFT contracts have no Tokens tab; clamp a stray ?tab=tokens.
+    const activeTab = parsedTab === 'tokens' && !isNFT ? 'overview' : parsedTab;
     const [tokenInfo, setTokenInfo] = useState<TokenInfo | null>(null);
     const [holders, setHolders] = useState<TokenHolder[]>([]);
     const [transfers, setTransfers] = useState<TokenTransfer[]>([]);
     const [holdersTotal, setHoldersTotal] = useState(0);
     const [transfersTotal, setTransfersTotal] = useState(0);
-    const [holdersPage, setHoldersPage] = useState(0);
-    const [transfersPage, setTransfersPage] = useState(0);
+    const [holdersPageParam, setHoldersPageParam] = useUrlIntParam('hp', 1);
+    const [transfersPageParam, setTransfersPageParam] = useUrlIntParam('tp', 1);
+    const holdersPage = holdersPageParam - 1;
+    const transfersPage = transfersPageParam - 1;
+    const setHoldersPage = useCallback(
+        (p: number) => setHoldersPageParam(p + 1),
+        [setHoldersPageParam],
+    );
+    const setTransfersPage = useCallback(
+        (p: number) => setTransfersPageParam(p + 1),
+        [setTransfersPageParam],
+    );
     const [loading, setLoading] = useState(true);
     const [creationTx, setCreationTx] = useState<CreationTxData | null>(null);
     // Phase 2: NFT-specific state. holderTokenIDFilter narrows /holders to
     // a single tokenID; tokensList drives the new "Tokens" tab listing.
-    const [holderTokenIDFilter, setHolderTokenIDFilter] = useState<string>('');
-    const [holderTokenIDInput, setHolderTokenIDInput] = useState<string>('');
+    const [holderTokenIDFilter] = useUrlParam('tokenId', '');
+    const [holderTokenIDInput, setHolderTokenIDInput] = useState<string>(holderTokenIDFilter);
+    // Keep the filter input display in sync when ?tokenId changes from
+    // outside the input (Back/Forward, Tokens-tab row click), adjusting
+    // state during render via a prev-value tracker instead of an effect.
+    const [prevTokenIDFilter, setPrevTokenIDFilter] = useState(holderTokenIDFilter);
+    if (holderTokenIDFilter !== prevTokenIDFilter) {
+        setPrevTokenIDFilter(holderTokenIDFilter);
+        setHolderTokenIDInput(holderTokenIDFilter);
+    }
     const [tokensList, setTokensList] = useState<TokenIDSummary[]>([]);
     const [tokensTotal, setTokensTotal] = useState(0);
-    const [tokensPage, setTokensPage] = useState(0);
+    const [tokensPageParam, setTokensPageParam] = useUrlIntParam('kp', 1);
+    const tokensPage = tokensPageParam - 1;
+    const setTokensPage = useCallback(
+        (p: number) => setTokensPageParam(p + 1),
+        [setTokensPageParam],
+    );
     const limit = 25;
 
     // Fetch token info
@@ -298,8 +348,14 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
     const totalSupply = tokenInfo?.totalSupply ?? contractData.totalSupply ?? '0';
     const creatorAddress = creationTx?.From || tokenInfo?.creatorAddress || contractData.creatorAddress || '';
     const creationTxHash = tokenInfo?.creationTxHash || contractData.creationTransaction || '';
-    const tokenStandard = contractData.tokenStandard;
-    const isNFT = tokenStandard === 'ERC-721' || tokenStandard === 'ERC-1155';
+    // Genesis contracts are baked into the chain at block 0 and have no
+    // deployment transaction; the backend flags them via the optional
+    // genesisContract boolean, with a '0x0' creation block as the same
+    // signal on payloads carrying the block but not the flag.
+    const isGenesisContract =
+        tokenInfo?.genesisContract === true ||
+        contractData.genesisContract === true ||
+        contractData.creationBlockNumber === '0x0';
     const badgeLabel =
         tokenStandard === 'ERC-721'
             ? 'QRC-721 NFT'
@@ -458,7 +514,7 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                 <TabPillBar
                     ariaLabel="Token contract sections"
                     activeKey={activeTab}
-                    onSelect={setActiveTab}
+                    onSelect={setRawTab}
                     tabs={tabs.map((tab) => ({ key: tab.id, label: tab.label }))}
                 />
             </div>
@@ -533,14 +589,20 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                 <div className="flex flex-col md:flex-row md:items-center justify-between gap-2">
                                     <div className="text-xs md:text-sm text-text-secondary">Transaction Hash</div>
                                     <div className="flex items-center gap-2 min-w-0">
-                                        <Link
-                                            href={`/tx/${creationTxHash}`}
-                                            className="text-accent hover:text-accent-hover font-mono text-xs md:text-sm break-all"
-                                        >
-                                            {creationTxHash || 'Unknown'}
-                                        </Link>
-                                        {creationTxHash && (
-                                            <CopyButton value={creationTxHash} label="Copy transaction hash" />
+                                        {creationTxHash ? (
+                                            <>
+                                                <Link
+                                                    href={`/tx/${creationTxHash}`}
+                                                    className="text-accent hover:text-accent-hover font-mono text-xs md:text-sm break-all"
+                                                >
+                                                    {creationTxHash}
+                                                </Link>
+                                                <CopyButton value={creationTxHash} label="Copy transaction hash" />
+                                            </>
+                                        ) : (
+                                            <span className="text-xs md:text-sm text-text-secondary">
+                                                {isGenesisContract ? 'Genesis contract' : 'Unknown'}
+                                            </span>
                                         )}
                                     </div>
                                 </div>
@@ -550,16 +612,26 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                 <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                                     <div className="flex justify-between md:flex-col">
                                         <div className="text-xs md:text-sm text-text-secondary">Block</div>
-                                        <Link
-                                            href={`/block/${creationTx?.BlockNumber || tokenInfo?.creationBlock || ''}`}
-                                            className="text-accent hover:text-accent-hover text-sm"
-                                        >
-                                            {creationTx?.BlockNumber
-                                                ? parseInt(creationTx.BlockNumber, 16).toLocaleString()
-                                                : tokenInfo?.creationBlock
-                                                    ? parseInt(tokenInfo.creationBlock, 16).toLocaleString()
-                                                    : '-'}
-                                        </Link>
+                                        {(() => {
+                                            // Only link when a block is actually known; a bare
+                                            // /block/ href renders as a broken link.
+                                            const creationBlock = creationTx?.BlockNumber || tokenInfo?.creationBlock || '';
+                                            if (!creationBlock) {
+                                                return (
+                                                    <span className="text-sm text-text-secondary">
+                                                        {isGenesisContract ? 'Genesis' : '-'}
+                                                    </span>
+                                                );
+                                            }
+                                            return (
+                                                <Link
+                                                    href={`/block/${creationBlock}`}
+                                                    className="text-accent hover:text-accent-hover text-sm"
+                                                >
+                                                    {parseInt(creationBlock, 16).toLocaleString()}
+                                                </Link>
+                                            );
+                                        })()}
                                     </div>
 
                                     <div className="flex justify-between md:flex-col">
@@ -636,16 +708,16 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                     onChange={(e) => setHolderTokenIDInput(e.target.value.replace(/[^0-9]/g, ''))}
                                     onKeyDown={(e) => {
                                         if (e.key === 'Enter') {
-                                            setHoldersPage(0);
-                                            setHolderTokenIDFilter(holderTokenIDInput.trim());
+                                            // Filter + page reset in one URL write so Back
+                                            // restores both atomically.
+                                            setUrlParams({ tokenId: holderTokenIDInput.trim() || null, hp: null }, 'replace');
                                         }
                                     }}
                                     className="px-2 py-1 rounded bg-black/40 border border-border text-sm text-text-primary font-mono w-32"
                                 />
                                 <button
                                     onClick={() => {
-                                        setHoldersPage(0);
-                                        setHolderTokenIDFilter(holderTokenIDInput.trim());
+                                        setUrlParams({ tokenId: holderTokenIDInput.trim() || null, hp: null }, 'replace');
                                     }}
                                     className="px-3 py-1 rounded bg-accent/20 text-accent text-sm hover:bg-accent/30"
                                 >
@@ -655,8 +727,7 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                     <button
                                         onClick={() => {
                                             setHolderTokenIDInput('');
-                                            setHolderTokenIDFilter('');
-                                            setHoldersPage(0);
+                                            setUrlParams({ tokenId: null, hp: null }, 'replace');
                                         }}
                                         className="px-3 py-1 rounded bg-surface-2 text-sm hover:bg-surface-3"
                                     >
@@ -763,7 +834,7 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                         <div className="flex gap-2">
                                             <button
                                                 aria-label="Go to previous page"
-                                                onClick={() => setHoldersPage(p => Math.max(0, p - 1))}
+                                                onClick={() => setHoldersPage(Math.max(0, holdersPage - 1))}
                                                 disabled={holdersPage === 0}
                                                 className="px-3 py-1 rounded bg-surface-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-3"
                                             >
@@ -771,7 +842,7 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                             </button>
                                             <button
                                                 aria-label="Go to next page"
-                                                onClick={() => setHoldersPage(p => p + 1)}
+                                                onClick={() => setHoldersPage(holdersPage + 1)}
                                                 disabled={(holdersPage + 1) * limit >= holdersTotal}
                                                 className="px-3 py-1 rounded bg-surface-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-3"
                                             >
@@ -819,10 +890,10 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                                         key={t.tokenID}
                                                         className="hover:bg-white/5 cursor-pointer"
                                                         onClick={() => {
-                                                            setHolderTokenIDInput(t.tokenID);
-                                                            setHolderTokenIDFilter(t.tokenID);
-                                                            setHoldersPage(0);
-                                                            setActiveTab('holders');
+                                                            // Tab + filter + page in ONE URL write so Back
+                                                            // undoes the jump atomically; the filter input
+                                                            // syncs from ?tokenId via the render tracker.
+                                                            setUrlParams({ tab: 'holders', tokenId: t.tokenID, hp: null }, 'replace');
                                                         }}
                                                     >
                                                         <td className="px-4 py-3">
@@ -874,7 +945,7 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                         <div className="flex gap-2">
                                             <button
                                                 aria-label="Go to previous page"
-                                                onClick={() => setTokensPage(p => Math.max(0, p - 1))}
+                                                onClick={() => setTokensPage(Math.max(0, tokensPage - 1))}
                                                 disabled={tokensPage === 0}
                                                 className="px-3 py-1 rounded bg-surface-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-3"
                                             >
@@ -882,7 +953,7 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                             </button>
                                             <button
                                                 aria-label="Go to next page"
-                                                onClick={() => setTokensPage(p => p + 1)}
+                                                onClick={() => setTokensPage(tokensPage + 1)}
                                                 disabled={(tokensPage + 1) * limit >= tokensTotal}
                                                 className="px-3 py-1 rounded bg-surface-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-3"
                                             >
@@ -954,7 +1025,7 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                         <div className="flex gap-2">
                                             <button
                                                 aria-label="Go to previous page"
-                                                onClick={() => setTransfersPage(p => Math.max(0, p - 1))}
+                                                onClick={() => setTransfersPage(Math.max(0, transfersPage - 1))}
                                                 disabled={transfersPage === 0}
                                                 className="px-3 py-1 rounded bg-surface-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-3"
                                             >
@@ -962,7 +1033,7 @@ export default function TokenContractView({ address, contractData, handlerUrl }:
                                             </button>
                                             <button
                                                 aria-label="Go to next page"
-                                                onClick={() => setTransfersPage(p => p + 1)}
+                                                onClick={() => setTransfersPage(transfersPage + 1)}
                                                 disabled={(transfersPage + 1) * limit >= transfersTotal}
                                                 className="px-3 py-1 rounded bg-surface-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-3"
                                             >

--- a/ExplorerFrontend/app/block/[query]/block-detail-client.tsx
+++ b/ExplorerFrontend/app/block/[query]/block-detail-client.tsx
@@ -258,6 +258,11 @@ export default function BlockDetailClient({ blockNumber }: BlockDetailClientProp
               <path strokeLinecap="round" strokeLinejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
             </svg>
             <h1 id="block-heading" className="section-title">Block #{formatNumberWithCommas(hexToNumber(blockData.number).toString())}</h1>
+            {/* Block 0 is the chain's genesis block: flag it so the all-zero
+                parent hash below reads as expected rather than broken. */}
+            {blockNum === 0 && (
+              <Badge variant="brand">Genesis</Badge>
+            )}
             {/* Live depth: surfaces how settled this block is. "Latest"
                 when we're looking at the head, otherwise "N
                 confirmations". Hidden until the first /latestblock
@@ -297,12 +302,18 @@ export default function BlockDetailClient({ blockNumber }: BlockDetailClientProp
             </div>
           </DetailRow>
           <DetailRow label="Parent Hash" mono>
-            <Link
-              href={`/block/${blockNum - 1}`}
-              className="text-text-secondary hover:text-accent transition-colors break-all"
-            >
-              {blockData.parentHash}
-            </Link>
+            {/* Genesis has no parent: same guard as the prev-block arrow
+                above, an unlinked all-zero hash beats a link to block -1. */}
+            {blockNum > 0 ? (
+              <Link
+                href={`/block/${blockNum - 1}`}
+                className="text-text-secondary hover:text-accent transition-colors break-all"
+              >
+                {blockData.parentHash}
+              </Link>
+            ) : (
+              <span className="break-all">{blockData.parentHash}</span>
+            )}
           </DetailRow>
           <DetailRow label="Timestamp">
             {timeAgo(tsNum)}

--- a/ExplorerFrontend/app/components/CollapsibleHex.tsx
+++ b/ExplorerFrontend/app/components/CollapsibleHex.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState } from 'react';
+import CopyButton from './CopyButton';
+
+interface CollapsibleHexProps {
+    label: string;
+    hex: string;
+    copyLabel?: string;
+}
+
+// Generic expand/collapse viewer for large hex blobs (contract bytecode,
+// validator public keys). Takes already-decoded hex, with or without a
+// leading 0x, and renders/copies it 0x-prefixed to match the explorer's
+// hex display convention. Extracted from ContractBytecode.
+export default function CollapsibleHex({ label, hex, copyLabel = 'Copy hex' }: CollapsibleHexProps): JSX.Element | null {
+    const [expanded, setExpanded] = useState(false);
+
+    const normalized = hex.startsWith('0x') ? hex.slice(2) : hex;
+    if (!normalized) return null;
+
+    const prefixed = `0x${normalized}`;
+    const byteLength = normalized.length / 2;
+
+    return (
+        <div>
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-2">
+                <div className="text-xs md:text-sm text-text-secondary">
+                    {label} <span className="text-text-muted">({byteLength.toLocaleString()} bytes)</span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <button
+                        type="button"
+                        onClick={() => setExpanded(e => !e)}
+                        aria-expanded={expanded}
+                        className="inline-flex items-center px-3 py-1.5 rounded-lg
+                                   bg-card-gradient border border-border hover:border-accent
+                                   text-sm text-text-secondary hover:text-accent transition-colors"
+                    >
+                        {expanded ? 'Collapse' : 'Expand'}
+                    </button>
+                    <CopyButton value={prefixed} label={copyLabel} />
+                </div>
+            </div>
+            <div
+                className={`rounded-lg bg-black/40 border border-border p-3 font-mono text-xs text-text-secondary
+                            break-all overflow-y-auto transition-[max-height] duration-200
+                            ${expanded ? 'max-h-[32rem]' : 'max-h-24'}`}
+            >
+                {prefixed}
+            </div>
+        </div>
+    );
+}

--- a/ExplorerFrontend/app/components/ContractBytecode.tsx
+++ b/ExplorerFrontend/app/components/ContractBytecode.tsx
@@ -1,50 +1,19 @@
 'use client';
 
-import { useMemo, useState } from 'react';
-import CopyButton from './CopyButton';
+import { useMemo } from 'react';
+import CollapsibleHex from './CollapsibleHex';
 import { decodeToHex } from '../lib/helpers';
 
 interface ContractBytecodeProps {
     contractCode: string;
 }
 
+// Thin wrapper: decodes the base64-encoded contract code from the API and
+// hands the resulting hex to the shared CollapsibleHex viewer.
 export default function ContractBytecode({ contractCode }: ContractBytecodeProps): JSX.Element | null {
-    const [expanded, setExpanded] = useState(false);
-
     const hex = useMemo(() => decodeToHex(contractCode), [contractCode]);
 
     if (!hex) return null;
 
-    const prefixed = `0x${hex}`;
-    const byteLength = hex.length / 2;
-
-    return (
-        <div>
-            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-2">
-                <div className="text-xs md:text-sm text-text-secondary">
-                    Contract Bytecode <span className="text-text-muted">({byteLength.toLocaleString()} bytes)</span>
-                </div>
-                <div className="flex items-center gap-2">
-                    <button
-                        type="button"
-                        onClick={() => setExpanded(e => !e)}
-                        aria-expanded={expanded}
-                        className="inline-flex items-center px-3 py-1.5 rounded-lg
-                                   bg-card-gradient border border-border hover:border-accent
-                                   text-sm text-text-secondary hover:text-accent transition-colors"
-                    >
-                        {expanded ? 'Collapse' : 'Expand'}
-                    </button>
-                    <CopyButton value={prefixed} label="Copy bytecode" />
-                </div>
-            </div>
-            <div
-                className={`rounded-lg bg-black/40 border border-border p-3 font-mono text-xs text-text-secondary
-                            break-all overflow-y-auto transition-[max-height] duration-200
-                            ${expanded ? 'max-h-[32rem]' : 'max-h-24'}`}
-            >
-                {prefixed}
-            </div>
-        </div>
-    );
+    return <CollapsibleHex label="Contract Bytecode" hex={hex} copyLabel="Copy bytecode" />;
 }

--- a/ExplorerFrontend/app/components/ContractTabs.tsx
+++ b/ExplorerFrontend/app/components/ContractTabs.tsx
@@ -8,12 +8,20 @@ import ReadContract from './ReadContract';
 import WriteContract from './WriteContract';
 import AiExplainCard from './AiExplainCard';
 import type { ContractData } from '../types/address';
+import { useUrlParam } from '../lib/use-url-param';
 
 interface ContractTabsProps {
   contractData: ContractData;
 }
 
-type TabKey = 'code' | 'read' | 'write';
+const TAB_KEYS = ['code', 'read', 'write'] as const;
+type TabKey = (typeof TAB_KEYS)[number];
+
+// ?ctab values outside the known set (hand-edited URLs) fall back to the
+// first tab.
+function parseTab(raw: string): TabKey {
+  return (TAB_KEYS as readonly string[]).includes(raw) ? (raw as TabKey) : 'code';
+}
 
 /**
  * Replacement for the old standalone ContractBytecode block on the address
@@ -27,7 +35,11 @@ type TabKey = 'code' | 'read' | 'write';
  *            session (M5).
  */
 export default function ContractTabs({ contractData }: ContractTabsProps): JSX.Element {
-  const [tab, setTab] = useState<TabKey>('code');
+  // URL-backed (?ctab) so browser Back restores the selected sub-tab.
+  // Distinct param from the page-level ?tab since both live on address
+  // pages; replace keeps in-page tab clicks out of browser history.
+  const [rawTab, setTab] = useUrlParam('ctab', 'code');
+  const tab = parseTab(rawTab);
 
   const parsedAbi = useMemo(() => {
     if (!contractData.abi) return null;

--- a/ExplorerFrontend/app/components/DebouncedInput.tsx
+++ b/ExplorerFrontend/app/components/DebouncedInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ChangeEvent, InputHTMLAttributes } from "react";
 
 interface DebouncedInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
@@ -26,13 +26,26 @@ export default function DebouncedInput({
     setValue(initialValue);
   }
 
+  // Keep the latest onChange out of the effect deps: consumers pass inline
+  // closures, and a fresh identity per parent render must not re-arm the
+  // timer (it would re-emit the unchanged value, e.g. resetting a consumer's
+  // page param on every poll re-render).
+  const onChangeRef = useRef(onChange);
   useEffect(() => {
+    onChangeRef.current = onChange;
+  });
+
+  useEffect(() => {
+    // Only emit when the user's edit actually diverges from the parent's
+    // value: no mount fire (a deep-linked page param would be wiped by an
+    // initial onChange), no echo after the parent adopts the emitted value.
+    if (value === initialValue) return;
     const timeout = setTimeout(() => {
-      onChange(value);
+      onChangeRef.current(value);
     }, debounce);
 
     return () => clearTimeout(timeout);
-  }, [value, onChange, debounce]);
+  }, [value, initialValue, debounce]);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>): void => {
     setValue(e.target.value);

--- a/ExplorerFrontend/app/components/Sidebar.tsx
+++ b/ExplorerFrontend/app/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   QuestionMarkCircleIcon,
   ArrowTopRightOnSquareIcon,
   CodeBracketIcon,
+  HomeIcon,
   ArrowsRightLeftIcon,
   ClockIcon,
   CubeIcon,
@@ -41,6 +42,7 @@ const navGroups: NavGroup[] = [
   {
     label: 'Blockchain',
     items: [
+      { name: 'Overview', href: '/', icon: HomeIcon },
       { name: 'Transactions', href: '/transactions/1', icon: ArrowsRightLeftIcon },
       { name: 'Pending', href: '/pending/1', icon: ClockIcon },
       { name: 'Blocks', href: '/blocks/1', icon: CubeIcon },

--- a/ExplorerFrontend/app/contracts/contracts-client.tsx
+++ b/ExplorerFrontend/app/contracts/contracts-client.tsx
@@ -3,9 +3,9 @@
 import { useState, useEffect, useCallback } from 'react';
 import ImageWithFallback from '../components/ImageWithFallback';
 import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
 import axios from 'axios';
 import config from '../../config';
+import { setUrlParams, useUrlIntParam, useUrlParam } from '../lib/use-url-param';
 import Badge from '../components/Badge';
 import EmptyState from '../components/EmptyState';
 
@@ -153,33 +153,41 @@ function truncateAddress(addr: string, start = 8, end = 6): string {
 }
 
 export default function ContractsClient({ initialData, totalContracts }: ContractsClientProps) {
-  // URL-backed active tab so deep-links like /contracts?tab=erc1155 land on
-  // the right pane and breadcrumb back-steps from contract detail pages
-  // return the user to the section they came from. URL is the source of
-  // truth; clicking a tab pushes a replace() so the back button stays
-  // useful for in-page navigation.
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const urlTab = parseTab(searchParams.get('tab'));
-  const [activeTab, setActiveTabState] = useState<TabType>(urlTab);
+  // URL-backed tab / search / page so deep-links like
+  // /contracts?tab=erc1155&page=3 land on the right view and the browser
+  // Back button restores it instead of dumping the user on page 1. The URL
+  // is the single source of truth (no useState mirrors); tab and search
+  // write with replace (no history spam), page writes with push so Back
+  // walks pages the same way /blocks does. setUrlParams is a shallow
+  // History-API write, so none of these trigger an RSC refetch.
+  const [rawTab] = useUrlParam('tab', 'erc20');
+  const activeTab = parseTab(rawTab);
   const setActiveTab = useCallback((t: TabType) => {
-    setActiveTabState(t);
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('tab', t);
-    router.replace(`/contracts?${params.toString()}`, { scroll: false });
-  }, [router, searchParams]);
-  // Keep state in sync when the URL changes from outside (back/forward,
-  // breadcrumb click on a different tab). Adjusting state during render
-  // via a prev-value tracker, the React-recommended replacement for the
-  // set-state-in-effect anti-pattern. Matches the cadence used in
-  // pending-transaction-view.tsx for ETA resync.
-  const [prevUrlTab, setPrevUrlTab] = useState<TabType>(urlTab);
-  if (urlTab !== prevUrlTab) {
-    setPrevUrlTab(urlTab);
-    setActiveTabState(urlTab);
+    // Tab change resets pagination in the same URL write so Back restores
+    // tab + page atomically.
+    setUrlParams({ tab: t === 'erc20' ? null : t, page: null }, 'replace');
+  }, []);
+  const [pageParam, setPageParam] = useUrlIntParam('page', 1, { history: 'push' });
+  // 1-based in the URL for readability; 0-based for the fetch + render math.
+  const currentPage = pageParam - 1;
+  const setCurrentPage = useCallback(
+    (p: number) => setPageParam(p + 1),
+    [setPageParam],
+  );
+  // ?q is authoritative (mount, Back/Forward); the input keeps a local
+  // mirror so typing stays responsive while the URL write debounces.
+  const [searchQuery] = useUrlParam('q', '');
+  const [searchInput, setSearchInput] = useState(searchQuery);
+  // Re-sync the input when the URL changes from outside (back/forward),
+  // adjusting state during render via a prev-value tracker, the
+  // React-recommended replacement for the set-state-in-effect
+  // anti-pattern. Matches the cadence used in pending-transaction-view.tsx
+  // for ETA resync.
+  const [prevSearchQuery, setPrevSearchQuery] = useState(searchQuery);
+  if (searchQuery !== prevSearchQuery) {
+    setPrevSearchQuery(searchQuery);
+    setSearchInput(searchQuery);
   }
-  const [searchQuery, setSearchQuery] = useState('');
-  const [currentPage, setCurrentPage] = useState(0);
   const [contracts, setContracts] = useState<ContractData[]>(initialData);
   const [loading, setLoading] = useState(false);
   const [total, setTotal] = useState(totalContracts);
@@ -258,25 +266,40 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
     }
   }, []);
 
-  // Fetch when tab, search, or page changes
+  // Debounced search → URL. Writing ?q (and clearing ?page in the same
+  // call, so Back restores search + page atomically) is what triggers the
+  // fetch below; the 300ms wait keeps each keystroke from firing a request.
   useEffect(() => {
+    if (searchInput === searchQuery) return;
+    // During a route transition the old page can stay mounted after the URL
+    // has already flipped (popstate/Link commit lag); firing then would stamp
+    // ?q onto the destination's URL, so the write aborts if the path moved.
+    const scheduledPath = window.location.pathname;
     const timer = setTimeout(() => {
-      fetchContracts(currentPage, searchQuery, activeTab);
-    }, searchQuery ? 300 : 0);
-
+      if (window.location.pathname !== scheduledPath) return;
+      setUrlParams({ q: searchInput || null, page: null }, 'replace');
+    }, 300);
     return () => clearTimeout(timer);
-  }, [activeTab, searchQuery, currentPage, fetchContracts]);
-
-  // Reset page when tab or search changes, adjusting state on prop/state
-  // change instead of writing it in an effect (set-state-in-effect).
-  const [prevReset, setPrevReset] = useState<string>(`${activeTab}|${searchQuery}`);
-  const resetKey = `${activeTab}|${searchQuery}`;
-  if (prevReset !== resetKey) {
-    setPrevReset(resetKey);
-    if (currentPage !== 0) setCurrentPage(0);
-  }
+  }, [searchInput, searchQuery]);
 
   const totalPages = Math.max(1, Math.ceil(total / ITEMS_PER_PAGE));
+  // Deep-linked/stale ?page beyond the last page clamps to the last page
+  // instead of fetching an empty one ("Page 999 of 3" over a bogus empty
+  // state). The clamp tracks the freshest total, so a first fetch against a
+  // stale total self-corrects once the real total lands.
+  const safePage = Math.min(currentPage, totalPages - 1);
+
+  // Fetch when tab, search, or page changes. All three are URL-derived, so
+  // Back/Forward refetches exactly like the old setState-driven effect did.
+  // The zero-delay timer defers the setLoading call inside fetchContracts
+  // off the effect body (set-state-in-effect) and coalesces double flips
+  // within one commit, same shape as the old debounce timer.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      fetchContracts(safePage, searchQuery, activeTab);
+    }, 0);
+    return () => clearTimeout(timer);
+  }, [activeTab, searchQuery, safePage, fetchContracts]);
 
   return (
     <div className="py-4 sm:py-6 lg:py-8">
@@ -307,8 +330,8 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
             type="text"
             aria-label="Search contracts"
             placeholder={activeTab === 'contracts' ? 'Search by contract address...' : 'Search by token name or address...'}
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
             className="w-full p-3 pl-10 bg-surface-2 border border-border rounded-lg text-text-secondary placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
           />
         </div>
@@ -349,27 +372,27 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
         <div className="mt-6 flex flex-wrap justify-center items-center gap-2">
           <button
             aria-label="Go to previous page"
-            onClick={() => setCurrentPage((p) => Math.max(0, p - 1))}
-            disabled={currentPage === 0}
+            onClick={() => setCurrentPage(Math.max(0, safePage - 1))}
+            disabled={safePage === 0}
             className="px-3 py-1.5 rounded-lg bg-surface-2 text-text-secondary border border-border hover:border-accent disabled:opacity-50 disabled:hover:border-border text-sm"
           >
             Previous
           </button>
 
           <span className="text-sm text-text-secondary mx-2">
-            Page {currentPage + 1} of {totalPages}
+            Page {safePage + 1} of {totalPages}
           </span>
 
           {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
             let pageNum;
             if (totalPages <= 5) {
               pageNum = i;
-            } else if (currentPage <= 2) {
+            } else if (safePage <= 2) {
               pageNum = i;
-            } else if (currentPage >= totalPages - 3) {
+            } else if (safePage >= totalPages - 3) {
               pageNum = totalPages - 5 + i;
             } else {
-              pageNum = currentPage - 2 + i;
+              pageNum = safePage - 2 + i;
             }
 
             return (
@@ -378,7 +401,7 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
                 aria-label={`Go to page ${pageNum + 1}`}
                 onClick={() => setCurrentPage(pageNum)}
                 className={`w-8 h-8 rounded-lg text-sm ${
-                  currentPage === pageNum
+                  safePage === pageNum
                     ? 'bg-accent text-background font-semibold'
                     : 'bg-surface-2 text-text-secondary hover:bg-surface-3'
                 }`}
@@ -390,8 +413,8 @@ export default function ContractsClient({ initialData, totalContracts }: Contrac
 
           <button
             aria-label="Go to next page"
-            onClick={() => setCurrentPage((p) => Math.min(totalPages - 1, p + 1))}
-            disabled={currentPage >= totalPages - 1}
+            onClick={() => setCurrentPage(Math.min(totalPages - 1, safePage + 1))}
+            disabled={safePage >= totalPages - 1}
             className="px-3 py-1.5 rounded-lg bg-surface-2 text-text-secondary border border-border hover:border-accent disabled:opacity-50 disabled:hover:border-border text-sm"
           >
             Next

--- a/ExplorerFrontend/app/converter/converter-client.tsx
+++ b/ExplorerFrontend/app/converter/converter-client.tsx
@@ -1,45 +1,53 @@
 'use client';
 
 import React, { useState } from 'react';
-import { smallestUnitToDecimal, decimalToSmallestUnit, NATIVE_UNIT } from '../lib/helpers';
+import { convertUnits, NATIVE_UNIT } from '../lib/helpers';
+import type { ConvertibleUnit } from '../lib/helpers';
+
+const UNITS: ConvertibleUnit[] = ['Quanta', 'Shor', 'Planck'];
+
+const INPUT_CLASSES =
+  'w-full px-4 py-3 bg-background text-text-primary rounded-lg border border-border focus:outline-none focus:border-accent transition-all duration-300';
+
+// The Quanta option label reuses NATIVE_UNIT so a unit rename stays one-line.
+function unitLabel(unit: ConvertibleUnit): string {
+  return unit === 'Quanta' ? NATIVE_UNIT : unit;
+}
+
+// Shown when the input is a valid number but has more fractional digits
+// than the source unit can represent (convertUnits returns null).
+const FRACTION_ERRORS: Record<ConvertibleUnit, string> = {
+  Quanta: `${NATIVE_UNIT} supports at most 18 decimal places`,
+  Shor: 'Shor supports at most 9 decimal places',
+  Planck: 'Planck is indivisible',
+};
+
+// Selects only ever offer the three known units; fall back to Quanta so
+// the value narrows to ConvertibleUnit without a type assertion.
+function parseUnit(value: string): ConvertibleUnit {
+  return value === 'Shor' || value === 'Planck' ? value : 'Quanta';
+}
 
 function Converter(): JSX.Element {
-  const [quanta, setQuanta] = useState("");
-  const [shor, setShor] = useState("");
-  const [error, setError] = useState("");
+  const [amount, setAmount] = useState('');
+  const [fromUnit, setFromUnit] = useState<ConvertibleUnit>('Quanta');
+  const [toUnit, setToUnit] = useState<ConvertibleUnit>('Shor');
 
-  const handleChangeShors = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const value = e.target.value;
-    if (value === '') {
-      setError('');
-      setShor('');
-      setQuanta('');
-      return;
-    }
-    if (!/^\d+$/.test(value)) {
-      setError("Invalid Input: Enter a whole number (Shor is indivisible)");
-    } else {
-      setError('');
-      setShor(value);
-      setQuanta(smallestUnitToDecimal(value, 18));
-    }
-  };
+  // Keep the raw string in state and derive result + error every render:
+  // keystrokes are never swallowed, invalid input just surfaces an error.
+  const trimmed = amount.trim();
+  const result = trimmed === '' ? '' : convertUnits(trimmed, fromUnit, toUnit);
+  const isPlainNumber = /^(\d+\.?\d*|\.\d+)$/.test(trimmed);
+  const error =
+    trimmed === '' || result !== null
+      ? ''
+      : isPlainNumber
+        ? FRACTION_ERRORS[fromUnit]
+        : 'Invalid Input: Enter a valid number';
 
-  const handleChangeQuanta = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const value = e.target.value;
-    if (value === '') {
-      setError('');
-      setShor('');
-      setQuanta('');
-      return;
-    }
-    if (!/^\d*\.?\d*$/.test(value) || value === '.') {
-      setError("Invalid Input: Enter a valid number");
-    } else {
-      setError('');
-      setQuanta(value);
-      setShor(decimalToSmallestUnit(value, 18));
-    }
+  const handleSwap = (): void => {
+    setFromUnit(toUnit);
+    setToUnit(fromUnit);
   };
 
   return (
@@ -48,45 +56,74 @@ function Converter(): JSX.Element {
         <h2 className="section-title mb-8">Unit Converter</h2>
         <div className="w-full max-w-md card p-8">
           <div className="space-y-6">
-            {/* Quanta Input */}
+            {/* Amount Input */}
             <div>
-              <label htmlFor="quanta-input" className="block text-sm font-medium text-text-secondary mb-2">Quanta</label>
-              <div className="relative">
-                <input
-                  id="quanta-input"
-                  type="text"
-                  value={quanta}
-                  onChange={handleChangeQuanta}
-                  placeholder="Enter amount in Quanta"
-                  className="w-full px-4 py-3 bg-background text-text-primary rounded-lg border border-border focus:outline-none focus:border-accent transition-all duration-300"
-                />
-                <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                  <span className="text-text-secondary">{NATIVE_UNIT}</span>
-                </div>
+              <label htmlFor="amount-input" className="block text-sm font-medium text-text-secondary mb-2">Amount</label>
+              <input
+                id="amount-input"
+                type="text"
+                inputMode="decimal"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                placeholder={`Enter amount in ${unitLabel(fromUnit)}`}
+                className={INPUT_CLASSES}
+              />
+            </div>
+
+            {/* Unit Selects + Swap */}
+            <div className="flex items-end gap-3">
+              <div className="flex-1">
+                <label htmlFor="from-unit" className="block text-sm font-medium text-text-secondary mb-2">From</label>
+                <select
+                  id="from-unit"
+                  value={fromUnit}
+                  onChange={(e) => setFromUnit(parseUnit(e.target.value))}
+                  className={INPUT_CLASSES}
+                >
+                  {UNITS.map((unit) => (
+                    <option key={unit} value={unit}>{unitLabel(unit)}</option>
+                  ))}
+                </select>
+              </div>
+              <button
+                type="button"
+                onClick={handleSwap}
+                aria-label="Swap units"
+                className="p-3 rounded-lg border border-border text-accent hover:border-accent hover:bg-background transition-all duration-300"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
+                </svg>
+              </button>
+              <div className="flex-1">
+                <label htmlFor="to-unit" className="block text-sm font-medium text-text-secondary mb-2">To</label>
+                <select
+                  id="to-unit"
+                  value={toUnit}
+                  onChange={(e) => setToUnit(parseUnit(e.target.value))}
+                  className={INPUT_CLASSES}
+                >
+                  {UNITS.map((unit) => (
+                    <option key={unit} value={unit}>{unitLabel(unit)}</option>
+                  ))}
+                </select>
               </div>
             </div>
 
-            {/* Conversion Arrow */}
-            <div className="flex justify-center">
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
-              </svg>
-            </div>
-
-            {/* Shor Input */}
+            {/* Result */}
             <div>
-              <label htmlFor="shor-input" className="block text-sm font-medium text-text-secondary mb-2">Shor</label>
+              <label htmlFor="result-output" className="block text-sm font-medium text-text-secondary mb-2">Result</label>
               <div className="relative">
                 <input
-                  id="shor-input"
+                  id="result-output"
                   type="text"
-                  value={shor}
-                  onChange={handleChangeShors}
-                  placeholder="Enter amount in Shor"
-                  className="w-full px-4 py-3 bg-background text-text-primary rounded-lg border border-border focus:outline-none focus:border-accent transition-all duration-300"
+                  readOnly
+                  value={result ?? ''}
+                  placeholder="0"
+                  className={`${INPUT_CLASSES} pr-20`}
                 />
                 <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                  <span className="text-text-secondary">Shor</span>
+                  <span className="text-text-secondary">{unitLabel(toUnit)}</span>
                 </div>
               </div>
             </div>
@@ -106,7 +143,10 @@ function Converter(): JSX.Element {
             {/* Info Box */}
             <div className="mt-6 p-4 bg-background rounded-lg border border-border">
               <p className="text-sm text-text-secondary">
-                1 {NATIVE_UNIT} = 1,000,000,000,000,000,000 Shor (10^18)
+                1 {NATIVE_UNIT} = 10^9 Shor = 10^18 Planck
+              </p>
+              <p className="text-sm text-text-secondary mt-1">
+                1 Shor = 10^9 Planck
               </p>
             </div>
           </div>

--- a/ExplorerFrontend/app/converter/page.tsx
+++ b/ExplorerFrontend/app/converter/page.tsx
@@ -4,34 +4,34 @@ import ConverterClient from './converter-client';
 
 export const metadata: Metadata = {
   ...sharedMetadata,
-  title: 'Quanta to Shor Converter | ZondScan',
+  title: 'QRL Unit Converter: Quanta, Shor, Planck | ZondScan',
   description:
-    'Convert Quanta to Shor quickly and accurately using our conversion tool. Get real-time conversion rates and insights on the QRL network.',
+    'Convert between QRL units with exact precision: 1 Quanta = 10^9 Shor = 10^18 Planck. Free unit conversion tool on the ZondScan explorer.',
   alternates: {
     ...sharedMetadata.alternates,
     canonical: 'https://zondscan.com/converter',
   },
   openGraph: {
     ...sharedMetadata.openGraph,
-    title: 'Quanta to Shor Converter | ZondScan',
+    title: 'QRL Unit Converter: Quanta, Shor, Planck | ZondScan',
     description:
-      'Convert Quanta to Shor quickly and accurately using our conversion tool. Get real-time conversion rates and insights on the QRL network.',
+      'Convert between QRL units with exact precision: 1 Quanta = 10^9 Shor = 10^18 Planck. Free unit conversion tool on the ZondScan explorer.',
     url: 'https://zondscan.com/converter',
     siteName: 'ZondScan',
     type: 'website',
   },
   twitter: {
     ...sharedMetadata.twitter,
-    title: 'Quanta to Shor Converter | ZondScan',
+    title: 'QRL Unit Converter: Quanta, Shor, Planck | ZondScan',
     description:
-      'Convert Quanta to Shor quickly and accurately using our conversion tool. Get real-time conversion rates and insights on the QRL network.',
+      'Convert between QRL units with exact precision: 1 Quanta = 10^9 Shor = 10^18 Planck. Free unit conversion tool on the ZondScan explorer.',
   },
 };
 
-export default function QuantaToShorPage(): JSX.Element {
+export default function UnitConverterPage(): JSX.Element {
   return (
     <main aria-labelledby="converter-heading">
-      <h1 id="converter-heading" className="sr-only">Quanta to Shor Converter</h1>
+      <h1 id="converter-heading" className="sr-only">QRL Unit Converter</h1>
       <ConverterClient />
     </main>
   );

--- a/ExplorerFrontend/app/epoch/[id]/epoch-detail-client.tsx
+++ b/ExplorerFrontend/app/epoch/[id]/epoch-detail-client.tsx
@@ -53,6 +53,11 @@ function formatGasUsed(hex: string): string {
   return formatNumberWithCommas(val.toString());
 }
 
+// The execution coinbase is always the zero address on this network, so
+// linking it as "proposer" would be misleading. Render a dash for it until
+// proposer-index enrichment lands (the column stays so it can slot in).
+const ZERO_ADDRESS = 'Q0000000000000000000000000000000000000000';
+
 // ── Summary Row ──────────────────────────────────────────────────────────────
 
 function SummaryRow({ label, children }: { label: string; children: React.ReactNode }) {
@@ -189,6 +194,7 @@ export default function EpochDetailClient({ epochId }: { epochId: string }): JSX
                 <thead>
                   <tr className="border-b border-border">
                     <th className="text-left px-4 py-2.5 text-[11px] font-normal text-text-muted uppercase tracking-wider">Slot</th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-normal text-text-muted uppercase tracking-wider hidden lg:table-cell">Block Hash</th>
                     <th className="text-left px-4 py-2.5 text-[11px] font-normal text-text-muted uppercase tracking-wider">Status</th>
                     <th className="text-left px-4 py-2.5 text-[11px] font-normal text-text-muted uppercase tracking-wider">Time</th>
                     <th className="text-left px-4 py-2.5 text-[11px] font-normal text-text-muted uppercase tracking-wider hidden sm:table-cell">Proposer</th>
@@ -216,6 +222,19 @@ export default function EpochDetailClient({ epochId }: { epochId: string }): JSX
                             <span className="text-text-muted">{formatNumberWithCommas(slot.slot.toString())}</span>
                           )}
                         </td>
+                        <td className="px-4 py-2 hidden lg:table-cell">
+                          {isProposed && slot.blockHash ? (
+                            <Link
+                              href={`/block/${slot.slot}`}
+                              className="text-text-secondary hover:text-accent hover:underline font-mono text-xs transition-colors"
+                              title={slot.blockHash}
+                            >
+                              {truncateHash(slot.blockHash, 10, 6)}
+                            </Link>
+                          ) : (
+                            <span className="text-text-muted">…</span>
+                          )}
+                        </td>
                         <td className="px-4 py-2">
                           <StatusBadge status={slot.status} />
                         </td>
@@ -223,12 +242,14 @@ export default function EpochDetailClient({ epochId }: { epochId: string }): JSX
                           {isProposed ? timeAgo(timestamp) : '…'}
                         </td>
                         <td className="px-4 py-2 hidden sm:table-cell">
-                          {isProposed && proposer ? (
+                          {isProposed && proposer && proposer !== ZERO_ADDRESS ? (
                             <Link href={`/address/${proposer}`} className="text-text-secondary hover:text-accent hover:underline font-mono text-xs transition-colors">
                               {truncateHash(proposer, 8, 6)}
                             </Link>
+                          ) : isProposed ? (
+                            <span className="text-text-muted">-</span>
                           ) : (
-                            <span className="text-text-muted">,</span>
+                            <span className="text-text-muted">…</span>
                           )}
                         </td>
                         <td className="px-4 py-2 text-text-secondary tabular-nums">

--- a/ExplorerFrontend/app/lib/formatters.test.ts
+++ b/ExplorerFrontend/app/lib/formatters.test.ts
@@ -20,6 +20,8 @@ import {
   qNormaliseAbiValue,
   formatNumberWithCommas,
   normalizeHexString,
+  convertUnits,
+  withdrawalCredentialsToAddress,
 } from './helpers';
 
 // ─── hex parsers ─────────────────────────────────────────────────────────
@@ -316,5 +318,74 @@ describe('normalizeHexString', () => {
     expect(normalizeHexString('')).toBe('');
     expect(normalizeHexString(null)).toBe('');
     expect(normalizeHexString(undefined)).toBe('');
+  });
+});
+
+// ─── unit conversion (Quanta / Shor / Planck) ────────────────────────────
+
+describe('convertUnits', () => {
+  it('converts Quanta to Shor (10^9)', () => {
+    expect(convertUnits('1', 'Quanta', 'Shor')).toBe('1000000000');
+  });
+
+  it('converts Shor to Quanta', () => {
+    expect(convertUnits('1', 'Shor', 'Quanta')).toBe('0.000000001');
+  });
+
+  it('converts Quanta to Planck (10^18)', () => {
+    expect(convertUnits('1', 'Quanta', 'Planck')).toBe('1000000000000000000');
+  });
+
+  it('converts fractional Shor to Planck', () => {
+    expect(convertUnits('1.5', 'Shor', 'Planck')).toBe('1500000000');
+  });
+
+  it('converts Planck to Quanta', () => {
+    expect(convertUnits('1', 'Planck', 'Quanta')).toBe('0.000000000000000001');
+  });
+
+  it('rejects fractional Planck (indivisible base unit)', () => {
+    expect(convertUnits('0.5', 'Planck', 'Quanta')).toBeNull();
+  });
+
+  it('rejects Shor input with more than 9 decimal places', () => {
+    expect(convertUnits('1.0123456789', 'Shor', 'Planck')).toBeNull();
+  });
+
+  it('rejects non-decimal input', () => {
+    expect(convertUnits('1e5', 'Quanta', 'Shor')).toBeNull();
+    expect(convertUnits('1.2.3', 'Quanta', 'Shor')).toBeNull();
+    expect(convertUnits('', 'Quanta', 'Shor')).toBeNull();
+  });
+
+  it('round-trips Quanta -> Planck -> Quanta exactly', () => {
+    const planck = convertUnits('123.456789', 'Quanta', 'Planck');
+    expect(planck).toBe('123456789000000000000');
+    expect(convertUnits(planck ?? '', 'Planck', 'Quanta')).toBe('123.456789');
+  });
+});
+
+// ─── beacon withdrawal credentials ───────────────────────────────────────
+
+describe('withdrawalCredentialsToAddress', () => {
+  // Live sample from the validators API (0x00 prefix + 11 zero bytes +
+  // 20-byte execution address).
+  const creds = '000000000000000000000000c0e6dd0e844e0048dcb0bd3fdcc44a970beca38d';
+  const address = 'Qc0e6dd0e844e0048dcb0bd3fdcc44a970beca38d';
+
+  it('decodes zero-prefixed credentials to the Q address', () => {
+    expect(withdrawalCredentialsToAddress(creds)).toBe(address);
+  });
+
+  it('accepts a 0x-prefixed input', () => {
+    expect(withdrawalCredentialsToAddress(`0x${creds}`)).toBe(address);
+  });
+
+  it('returns null when the prefix bytes are non-zero', () => {
+    expect(withdrawalCredentialsToAddress(`01${creds.slice(2)}`)).toBeNull();
+  });
+
+  it('returns null on wrong-length input', () => {
+    expect(withdrawalCredentialsToAddress(creds.slice(2))).toBeNull();
   });
 });

--- a/ExplorerFrontend/app/lib/helpers.ts
+++ b/ExplorerFrontend/app/lib/helpers.ts
@@ -1251,3 +1251,54 @@ export function formatDuration(totalSeconds: number): string {
   const remMins = mins % 60;
   return remMins > 0 ? `${hours}h ${remMins}m` : `${hours}h`;
 }
+
+/**
+ * QRL unit system relative to the base unit Planck:
+ * 1 Quanta = 10^9 Shor = 10^18 Planck (matches @theqrl/web3-utils qrlUnitMap).
+ */
+export const UNIT_PLANCK_EXPONENTS = {
+  Quanta: 18,
+  Shor: 9,
+  Planck: 0,
+} as const;
+
+export type ConvertibleUnit = keyof typeof UNIT_PLANCK_EXPONENTS;
+
+/**
+ * Exact conversion between Quanta/Shor/Planck via BigInt string math (no
+ * floats). Returns null when the input is not a plain decimal number or has
+ * more fractional digits than the source unit can represent (e.g. "0.5"
+ * Planck), so callers can surface a validation error instead of silently
+ * truncating.
+ */
+export function convertUnits(
+  value: string,
+  from: ConvertibleUnit,
+  to: ConvertibleUnit
+): string | null {
+  const trimmed = value.trim();
+  if (!/^(\d+\.?\d*|\.\d+)$/.test(trimmed)) return null;
+  const expFrom = UNIT_PLANCK_EXPONENTS[from];
+  const expTo = UNIT_PLANCK_EXPONENTS[to];
+  const fraction = trimmed.split('.')[1] ?? '';
+  if (fraction.length > expFrom) return null;
+  const planck = decimalToSmallestUnit(trimmed, expFrom);
+  return smallestUnitToDecimal(planck, expTo);
+}
+
+/**
+ * Decode beacon withdrawal credentials to the execution-layer withdrawal
+ * address. On Zond the credentials are prefix byte 0x00 + 11 zero bytes +
+ * the 20-byte address (qrysm WithdrawalCredentialsAddress), so the last 40
+ * hex chars are the address. Returns null for any other shape so callers
+ * fall back to showing the raw credentials.
+ */
+export function withdrawalCredentialsToAddress(
+  credsHex: string | null | undefined
+): string | null {
+  if (!credsHex) return null;
+  const hex = credsHex.trim().toLowerCase().replace(/^0x/, '');
+  if (!/^[0-9a-f]{64}$/.test(hex)) return null;
+  if (!hex.startsWith('000000000000000000000000')) return null;
+  return `Q${hex.slice(24)}`;
+}

--- a/ExplorerFrontend/app/lib/use-url-param.ts
+++ b/ExplorerFrontend/app/lib/use-url-param.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+type HistoryMode = 'replace' | 'push';
+
+/**
+ * Write query-param updates to the URL via the native History API.
+ * Next.js 15 syncs useSearchParams from history.pushState/replaceState, so
+ * this is a shallow update: no server-component re-render, no refetch, no
+ * scroll jump. Pass null (or '') to remove a key. Use a single call when
+ * several params must change together so Back restores them atomically.
+ */
+export function setUrlParams(
+  updates: Record<string, string | null>,
+  history: HistoryMode = 'replace'
+): void {
+  const url = new URL(window.location.href);
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === null || value === '') {
+      url.searchParams.delete(key);
+    } else {
+      url.searchParams.set(key, value);
+    }
+  }
+  if (history === 'push') {
+    window.history.pushState(null, '', url.toString());
+  } else {
+    window.history.replaceState(null, '', url.toString());
+  }
+}
+
+/**
+ * A single URL query param as state. The URL is the source of truth (so
+ * browser Back/Forward restores it); the setter writes shallowly via the
+ * History API. Setting the default value removes the key, keeping canonical
+ * URLs clean. Components using this must render under a Suspense boundary
+ * when statically prerendered (useSearchParams requirement).
+ */
+export function useUrlParam(
+  key: string,
+  defaultValue: string,
+  opts: { history?: HistoryMode } = {}
+): [string, (next: string) => void] {
+  const searchParams = useSearchParams();
+  const value = searchParams.get(key) ?? defaultValue;
+  const { history = 'replace' } = opts;
+
+  const setValue = useCallback(
+    (next: string) => {
+      setUrlParams({ [key]: next === defaultValue ? null : next }, history);
+    },
+    [key, defaultValue, history]
+  );
+
+  return [value, setValue];
+}
+
+/**
+ * Integer variant of useUrlParam for page numbers and the like. Malformed or
+ * out-of-range values in the URL fall back to the default instead of NaN.
+ */
+export function useUrlIntParam(
+  key: string,
+  defaultValue: number,
+  opts: { history?: HistoryMode; min?: number } = {}
+): [number, (next: number) => void] {
+  const { min = 1 } = opts;
+  const [raw, setRaw] = useUrlParam(key, String(defaultValue), opts);
+  const parsed = Number.parseInt(raw, 10);
+  const value = Number.isFinite(parsed) && parsed >= min ? parsed : defaultValue;
+
+  const setValue = useCallback(
+    (next: number) => {
+      setRaw(String(next));
+    },
+    [setRaw]
+  );
+
+  return [value, setValue];
+}

--- a/ExplorerFrontend/app/richlist/loading.tsx
+++ b/ExplorerFrontend/app/richlist/loading.tsx
@@ -3,8 +3,8 @@
  * awaits the /richlist fetch (force-dynamic), so without a fallback the
  * page is briefly blank between click and data.
  *
- * Shape mirrors RichlistClient: header + subtitle and the three-column
- * (rank / address / balance) table card.
+ * Shape mirrors RichlistClient: header + subtitle and the six-column
+ * (rank / address / type / first seen / balance / % supply) table card.
  */
 import { NATIVE_UNIT } from '../lib/helpers';
 
@@ -26,7 +26,10 @@ export default function Loading(): JSX.Element {
                 <tr className="border-b border-border">
                   <th className="table-header">Rank</th>
                   <th className="table-header">Address</th>
+                  <th className="table-header">Type</th>
+                  <th className="table-header">First Seen</th>
                   <th className="px-3 md:px-6 py-3 md:py-4 text-right text-[11px] font-medium uppercase tracking-[0.12em] text-text-muted">Balance</th>
+                  <th className="px-3 md:px-6 py-3 md:py-4 text-right text-[11px] font-medium uppercase tracking-[0.12em] text-text-muted">% Supply</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
@@ -34,7 +37,10 @@ export default function Loading(): JSX.Element {
                   <tr key={i} className="border-b border-border">
                     <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap"><div className="h-4 w-8 skeleton" /></td>
                     <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap"><div className="h-4 w-64 max-w-full skeleton" /></td>
+                    <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap"><div className="h-4 w-16 skeleton" /></td>
+                    <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap"><div className="h-4 w-32 skeleton" /></td>
                     <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap"><div className="h-4 w-24 skeleton ml-auto" /></td>
+                    <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap"><div className="h-4 w-14 skeleton ml-auto" /></td>
                   </tr>
                 ))}
               </tbody>

--- a/ExplorerFrontend/app/richlist/richlist-client.tsx
+++ b/ExplorerFrontend/app/richlist/richlist-client.tsx
@@ -2,11 +2,34 @@
 
 import React from "react";
 import Link from "next/link";
-import { NATIVE_UNIT, toFixed } from "../lib/helpers";
+import Badge from "../components/Badge";
+import { NATIVE_UNIT, formatTimestamp, toFixed } from "../lib/helpers";
 
 interface RichlistEntry {
   id: string;
   balance: string | number;
+  // Newer /richlist responses only; optional so old cached payloads
+  // degrade to "-" instead of rendering NaN / broken badges.
+  isContract?: boolean;
+  firstSeen?: number;
+  supplyPercent?: number;
+}
+
+// Percent of circulating supply, 2 decimals. Values that would round to
+// "0.00%" but are non-zero surface as "<0.01%"; missing data renders "-".
+function formatSupplyPercent(pct: number | undefined): string {
+  if (typeof pct !== "number" || !Number.isFinite(pct)) return "-";
+  if (pct > 0 && pct < 0.005) return "<0.01%";
+  return `${pct.toFixed(2)}%`;
+}
+
+function typeBadge(isContract: boolean | undefined): React.ReactNode {
+  if (typeof isContract !== "boolean") return "-";
+  return isContract ? (
+    <Badge variant="info">Contract</Badge>
+  ) : (
+    <Badge variant="neutral">Wallet</Badge>
+  );
 }
 
 interface RichlistProps {
@@ -66,9 +89,27 @@ export default function RichlistClient({ richlist }: RichlistProps): JSX.Element
               </Link>
             </div>
             <div>
+              <span className="text-accent text-sm">Type:</span>
+              <span className="ml-2 text-text-primary text-sm">
+                {typeBadge(item.isContract)}
+              </span>
+            </div>
+            <div>
+              <span className="text-accent text-sm">First Seen:</span>
+              <span className="ml-2 text-text-primary text-sm">
+                {item.firstSeen ? formatTimestamp(item.firstSeen) : "-"}
+              </span>
+            </div>
+            <div>
               <span className="text-accent text-sm">Balance:</span>
               <span className="ml-2 text-text-primary text-sm">
                 {toFixed(item.balance)} {NATIVE_UNIT}
+              </span>
+            </div>
+            <div>
+              <span className="text-accent text-sm">% Supply:</span>
+              <span className="ml-2 text-text-primary text-sm">
+                {formatSupplyPercent(item.supplyPercent)}
               </span>
             </div>
           </div>
@@ -88,8 +129,17 @@ export default function RichlistClient({ richlist }: RichlistProps): JSX.Element
             <th scope="col" className="table-header">
               Address
             </th>
+            <th scope="col" className="table-header">
+              Type
+            </th>
+            <th scope="col" className="table-header">
+              First Seen
+            </th>
             <th scope="col" className="px-3 md:px-6 py-3 md:py-4 text-right text-[11px] font-medium uppercase tracking-[0.12em] text-text-muted">
               Balance
+            </th>
+            <th scope="col" className="px-3 md:px-6 py-3 md:py-4 text-right text-[11px] font-medium uppercase tracking-[0.12em] text-text-muted">
+              % Supply
             </th>
           </tr>
         </thead>
@@ -128,8 +178,17 @@ export default function RichlistClient({ richlist }: RichlistProps): JSX.Element
                   {item.id}
                 </Link>
               </td>
+              <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap text-text-secondary text-sm">
+                {typeBadge(item.isContract)}
+              </td>
+              <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap text-text-secondary text-sm">
+                {item.firstSeen ? formatTimestamp(item.firstSeen) : "-"}
+              </td>
               <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap text-right text-text-secondary text-sm">
                 {toFixed(item.balance)} {NATIVE_UNIT}
+              </td>
+              <td className="px-3 md:px-6 py-3 md:py-4 whitespace-nowrap text-right text-text-secondary text-sm">
+                {formatSupplyPercent(item.supplyPercent)}
               </td>
             </tr>
           ))}

--- a/ExplorerFrontend/app/validators/[id]/validator-detail-client.tsx
+++ b/ExplorerFrontend/app/validators/[id]/validator-detail-client.tsx
@@ -5,8 +5,9 @@ import { useRouter } from 'next/navigation';
 import axios from 'axios';
 import Link from 'next/link';
 import config from '../../../config';
-import { epochsToDays, formatValidatorBalance } from '../../lib/helpers';
+import { epochsToDays, formatValidatorBalance, withdrawalCredentialsToAddress } from '../../lib/helpers';
 import Badge from '../../components/Badge';
+import CollapsibleHex from '../../components/CollapsibleHex';
 import CopyButton from '../../components/CopyButton';
 import EmptyState from '../../components/EmptyState';
 
@@ -118,6 +119,9 @@ export default function ValidatorDetailClient({ id }: ValidatorDetailClientProps
   }
 
   const [amount, unit] = formatValidatorBalance(validator.effectiveBalance);
+  // Decoded execution-layer withdrawal address; null for non-standard
+  // credentials, in which case only the raw hex row below is shown.
+  const withdrawalAddress = withdrawalCredentialsToAddress(validator.withdrawalCredentialsHex);
 
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 py-4 sm:py-6 lg:py-8">
@@ -141,17 +145,26 @@ export default function ValidatorDetailClient({ id }: ValidatorDetailClientProps
           <p className="text-text-secondary mt-1">
             Current Epoch: {parseInt(validator.currentEpoch).toLocaleString()}
           </p>
+          {withdrawalAddress && (
+            <div className="flex flex-wrap items-center gap-2 mt-2">
+              <span className="text-sm text-text-secondary">Withdrawal Address:</span>
+              <Link
+                href={`/address/${withdrawalAddress}`}
+                className="text-accent hover:underline font-mono text-sm break-all"
+              >
+                {withdrawalAddress}
+              </Link>
+              <CopyButton value={withdrawalAddress} label="Copy withdrawal address" size="sm" />
+            </div>
+          )}
         </div>
         <div className="flex items-center gap-4">
           {getStatusBadge(validator.status)}
-          {validator.slashed && (
-            <Badge variant="error" size="md" dot>Slashed</Badge>
-          )}
         </div>
       </div>
 
       {/* Key Info Cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
         <div className="card p-4">
           <h3 className="text-sm font-medium text-text-secondary mb-1">Effective Balance</h3>
           <p className="font-display text-xl font-semibold text-text-primary">{amount} {unit}</p>
@@ -163,20 +176,6 @@ export default function ValidatorDetailClient({ id }: ValidatorDetailClientProps
           </p>
           <p className="text-sm text-text-muted">{validator.age.toLocaleString()} epochs</p>
         </div>
-        <div className="card p-4">
-          <h3 className="text-sm font-medium text-text-secondary mb-1">Activation Epoch</h3>
-          <p className="text-xl font-semibold text-success">
-            {formatEpoch(validator.activationEpoch)}
-          </p>
-        </div>
-        <div className="card p-4">
-          <h3 className="text-sm font-medium text-text-secondary mb-1">Exit Epoch</h3>
-          <p className={`text-xl font-semibold ${
-            validator.exitEpoch === FAR_FUTURE_EPOCH ? 'text-text-muted' : 'text-error'
-          }`}>
-            {formatEpoch(validator.exitEpoch)}
-          </p>
-        </div>
       </div>
 
       {/* Details Section */}
@@ -185,20 +184,12 @@ export default function ValidatorDetailClient({ id }: ValidatorDetailClientProps
           <h2 className="font-display text-lg font-semibold text-text-primary">Validator Details</h2>
         </div>
         <div className="divide-y divide-border">
-          {/* Public Key */}
+          {/* Public Key (2592-byte ML-DSA-87 key, collapsed by default) */}
           <div className="p-4">
-            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
-              <span className="text-sm text-text-secondary">Public Key</span>
-              <div className="flex items-center gap-2">
-                <code className="text-sm text-text-secondary font-mono break-all">
-                  {validator.publicKeyHex}
-                </code>
-                <CopyButton value={validator.publicKeyHex} label="Copy public key" size="sm" />
-              </div>
-            </div>
+            <CollapsibleHex label="Public Key" hex={validator.publicKeyHex} copyLabel="Copy public key" />
           </div>
 
-          {/* Withdrawal Credentials */}
+          {/* Withdrawal Credentials (raw 32-byte form of the address above) */}
           <div className="p-4">
             <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
               <span className="text-sm text-text-secondary">Withdrawal Credentials</span>

--- a/ExplorerFrontend/app/validators/components/ValidatorTable.tsx
+++ b/ExplorerFrontend/app/validators/components/ValidatorTable.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import Link from 'next/link';
-import { epochsToDays, formatValidatorBalance } from '../../lib/helpers';
+import { epochsToDays, formatValidatorBalance, withdrawalCredentialsToAddress } from '../../lib/helpers';
+import { setUrlParams, useUrlParam, useUrlIntParam } from '../../lib/use-url-param';
 import Badge from '../../components/Badge';
 
 interface Validator {
   index: string;
-  address: string;
+  publicKeyHex: string;
+  withdrawalCredentialsHex?: string;
   status: string;
   age: number;
   stakedAmount: string;
@@ -29,6 +31,24 @@ const statusOrder: Record<string, number> = {
   slashed: 3,
 };
 
+// Defensive parsing for URL-sourced sort state: unknown ?sort / ?dir values
+// fall back to the defaults instead of breaking the table.
+function parseSortField(value: string): SortField {
+  switch (value) {
+    case 'index':
+    case 'age':
+    case 'stakedAmount':
+    case 'status':
+      return value;
+    default:
+      return 'index';
+  }
+}
+
+function parseSortDirection(value: string): SortDirection {
+  return value === 'desc' ? 'desc' : 'asc';
+}
+
 function SortIcon({ field, sortField, sortDirection }: { field: SortField; sortField: SortField; sortDirection: SortDirection }) {
   if (sortField !== field) {
     return <span className="text-text-muted ml-1">↕</span>;
@@ -41,31 +61,95 @@ function SortIcon({ field, sortField, sortDirection }: { field: SortField; sortF
 }
 
 export default function ValidatorTable({ validators, loading }: ValidatorTableProps) {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [sortField, setSortField] = useState<SortField>('index');
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
-  const [currentPage, setCurrentPage] = useState(1);
+  // Table state lives in the URL (?q, ?sort, ?dir, ?page) so Back/Forward
+  // and shared links restore the same view. Defaults are removed from the
+  // URL to keep canonical links clean.
+  const [urlQuery] = useUrlParam('q', '');
+  const [sortParam] = useUrlParam('sort', 'index');
+  const [dirParam] = useUrlParam('dir', 'asc');
+  const [currentPage, setCurrentPage] = useUrlIntParam('page', 1);
+  const sortField = parseSortField(sortParam);
+  const sortDirection = parseSortDirection(dirParam);
+
+  // Local echo of ?q so typing stays responsive while the URL write debounces.
+  const [searchQuery, setSearchQuery] = useState(urlQuery);
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastWrittenQueryRef = useRef(urlQuery);
   const itemsPerPage = 15;
 
-  const handleSort = (field: SortField) => {
-    if (sortField === field) {
-      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
-    } else {
-      setSortField(field);
-      setSortDirection('asc');
-    }
+  // Adopt external ?q changes (Back/Forward while mounted); our own
+  // debounced writes are skipped via lastWrittenQueryRef. The setState is
+  // deferred so it lands outside the synchronous effect body
+  // (set-state-in-effect rule).
+  useEffect(() => {
+    if (urlQuery === lastWrittenQueryRef.current) return;
+    lastWrittenQueryRef.current = urlQuery;
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    const timer = setTimeout(() => setSearchQuery(urlQuery), 0);
+    return () => clearTimeout(timer);
+  }, [urlQuery]);
+
+  // Cancel any pending debounced write on unmount so it cannot fire after
+  // navigation and stamp ?q onto another page's URL.
+  useEffect(() => {
+    return () => {
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    };
+  }, []);
+
+  const handleSearchChange = (value: string) => {
+    setSearchQuery(value);
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    // Debounce the URL write so typing does not spam replaceState; the page
+    // reset rides in the same call so both restore atomically. The write
+    // aborts if a navigation started meanwhile: during a route transition
+    // this component can stay mounted after the URL has already flipped, and
+    // firing then would stamp ?q onto the destination's URL.
+    const scheduledPath = window.location.pathname;
+    searchDebounceRef.current = setTimeout(() => {
+      if (window.location.pathname !== scheduledPath) return;
+      lastWrittenQueryRef.current = value;
+      setUrlParams({ q: value || null, page: null });
+    }, 300);
   };
 
-  const filteredAndSortedValidators = useMemo(() => {
-    let result = [...validators];
+  const handleSort = (field: SortField) => {
+    const nextDirection: SortDirection =
+      sortField === field && sortDirection === 'asc' ? 'desc' : 'asc';
+    // Single replaceState call so sort, direction, and the page reset land
+    // in the URL atomically.
+    setUrlParams({
+      sort: field === 'index' ? null : field,
+      dir: nextDirection === 'asc' ? null : nextDirection,
+      page: null,
+    });
+  };
 
-    // Filter
+  // Decode withdrawal credentials once per data refresh; the decoded
+  // execution address feeds both the Address column and the search filter.
+  const decoratedValidators = useMemo(
+    () =>
+      validators.map((v) => ({
+        ...v,
+        withdrawalAddress: withdrawalCredentialsToAddress(v.withdrawalCredentialsHex),
+      })),
+    [validators]
+  );
+
+  const filteredAndSortedValidators = useMemo(() => {
+    let result = [...decoratedValidators];
+
+    // Filter: strip an optional leading Q (address prefix) so pasted
+    // Q-addresses match the decoded withdrawal address hex; the query also
+    // matches the raw public key hex, index, and status.
     if (searchQuery) {
-      const query = searchQuery.toLowerCase();
+      const normalized = searchQuery.trim().toLowerCase();
+      const query = normalized.startsWith('q') ? normalized.slice(1) : normalized;
       result = result.filter(
         (v) =>
           v.index.toLowerCase().includes(query) ||
-          v.address.toLowerCase().includes(query) ||
+          v.publicKeyHex.toLowerCase().includes(query) ||
+          (v.withdrawalAddress !== null && v.withdrawalAddress.slice(1).includes(query)) ||
           v.status.toLowerCase().includes(query)
       );
     }
@@ -99,10 +183,12 @@ export default function ValidatorTable({ validators, loading }: ValidatorTablePr
     });
 
     return result;
-  }, [validators, searchQuery, sortField, sortDirection]);
+  }, [decoratedValidators, searchQuery, sortField, sortDirection]);
 
   const totalPages = Math.ceil(filteredAndSortedValidators.length / itemsPerPage);
-  const startIndex = (currentPage - 1) * itemsPerPage;
+  // Clamp deep-linked ?page values that exceed the filtered result set.
+  const safePage = Math.min(currentPage, Math.max(totalPages, 1));
+  const startIndex = (safePage - 1) * itemsPerPage;
   const currentValidators = filteredAndSortedValidators.slice(
     startIndex,
     startIndex + itemsPerPage
@@ -144,10 +230,7 @@ export default function ValidatorTable({ validators, loading }: ValidatorTablePr
             aria-label="Search validators"
             placeholder="Search validators..."
             value={searchQuery}
-            onChange={(e) => {
-              setSearchQuery(e.target.value);
-              setCurrentPage(1);
-            }}
+            onChange={(e) => handleSearchChange(e.target.value)}
             className="flex-1 p-2 text-sm sm:text-base bg-surface-2 border border-border rounded-lg text-text-secondary placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
           />
           <div className="text-xs sm:text-sm text-text-secondary flex items-center">
@@ -175,6 +258,9 @@ export default function ValidatorTable({ validators, loading }: ValidatorTablePr
               </th>
               <th scope="col" className="px-4 py-3 text-left text-[11px] font-medium text-text-muted uppercase tracking-[0.12em]">
                 Address
+              </th>
+              <th scope="col" className="hidden md:table-cell px-4 py-3 text-left text-[11px] font-medium text-text-muted uppercase tracking-[0.12em]">
+                Public Key
               </th>
               <th
                 scope="col"
@@ -231,17 +317,24 @@ export default function ValidatorTable({ validators, loading }: ValidatorTablePr
                   </Link>
                 </td>
                 <td className="px-4 py-3 whitespace-nowrap text-sm">
-                  <Link
-                    href={`/validators/${validator.index}`}
-                    className="text-text-secondary hover:text-accent font-mono"
-                  >
-                    <span className="hidden md:inline">
-                      Q{validator.address.slice(0, 16)}...{validator.address.slice(-8)}
-                    </span>
-                    <span className="md:hidden">
-                      Q{validator.address.slice(0, 8)}...
-                    </span>
-                  </Link>
+                  {validator.withdrawalAddress ? (
+                    <Link
+                      href={`/address/${validator.withdrawalAddress}`}
+                      className="text-accent hover:underline font-mono"
+                    >
+                      <span className="hidden md:inline">
+                        {validator.withdrawalAddress.slice(0, 12)}...{validator.withdrawalAddress.slice(-8)}
+                      </span>
+                      <span className="md:hidden">
+                        {validator.withdrawalAddress.slice(0, 8)}...
+                      </span>
+                    </Link>
+                  ) : (
+                    <span className="text-text-muted">-</span>
+                  )}
+                </td>
+                <td className="hidden md:table-cell px-4 py-3 whitespace-nowrap text-sm text-text-secondary font-mono">
+                  {validator.publicKeyHex.slice(0, 16)}...{validator.publicKeyHex.slice(-8)}
                 </td>
                 <td className="px-4 py-3 whitespace-nowrap text-sm">
                   {getStatusBadge(validator.status)}
@@ -264,15 +357,15 @@ export default function ValidatorTable({ validators, loading }: ValidatorTablePr
         <div className="p-3 sm:p-4 border-t border-border flex flex-wrap justify-center items-center gap-1 sm:gap-2">
           <button
             aria-label="Go to previous page"
-            onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-            disabled={currentPage === 1}
+            onClick={() => setCurrentPage(Math.max(1, safePage - 1))}
+            disabled={safePage === 1}
             className="px-2 sm:px-3 py-1 sm:py-1.5 rounded-lg bg-surface-2 text-text-secondary border border-border hover:border-accent disabled:opacity-50 disabled:hover:border-border text-xs sm:text-sm"
           >
             Prev
           </button>
 
           <span className="text-xs sm:text-sm text-text-secondary mx-1 sm:mx-2">
-            {currentPage}/{totalPages}
+            {safePage}/{totalPages}
           </span>
 
           {/* Hide page numbers on very small screens */}
@@ -281,12 +374,12 @@ export default function ValidatorTable({ validators, loading }: ValidatorTablePr
               let pageNum;
               if (totalPages <= 5) {
                 pageNum = i + 1;
-              } else if (currentPage <= 3) {
+              } else if (safePage <= 3) {
                 pageNum = i + 1;
-              } else if (currentPage >= totalPages - 2) {
+              } else if (safePage >= totalPages - 2) {
                 pageNum = totalPages - 4 + i;
               } else {
-                pageNum = currentPage - 2 + i;
+                pageNum = safePage - 2 + i;
               }
 
               return (
@@ -295,7 +388,7 @@ export default function ValidatorTable({ validators, loading }: ValidatorTablePr
                   aria-label={`Go to page ${pageNum}`}
                   onClick={() => setCurrentPage(pageNum)}
                   className={`w-8 h-8 rounded-lg text-sm ${
-                    currentPage === pageNum
+                    safePage === pageNum
                       ? 'bg-accent text-background font-semibold'
                       : 'bg-surface-2 text-text-secondary hover:bg-surface-3'
                   }`}
@@ -308,8 +401,8 @@ export default function ValidatorTable({ validators, loading }: ValidatorTablePr
 
           <button
             aria-label="Go to next page"
-            onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-            disabled={currentPage === totalPages}
+            onClick={() => setCurrentPage(Math.min(totalPages, safePage + 1))}
+            disabled={safePage === totalPages}
             className="px-2 sm:px-3 py-1 sm:py-1.5 rounded-lg bg-surface-2 text-text-secondary border border-border hover:border-accent disabled:opacity-50 disabled:hover:border-border text-xs sm:text-sm"
           >
             Next

--- a/ExplorerFrontend/app/validators/validators-client.tsx
+++ b/ExplorerFrontend/app/validators/validators-client.tsx
@@ -12,7 +12,8 @@ import ValidatorTable from './components/ValidatorTable';
 
 interface Validator {
   index: string;
-  address: string;
+  publicKeyHex: string;
+  withdrawalCredentialsHex?: string;
   status: string;
   age: number;
   stakedAmount: string;
@@ -101,10 +102,13 @@ export default function ValidatorsWrapper(): JSX.Element {
         axios.get(`${config.handlerUrl}/validators/history?limit=100`).catch((err) => { console.error('Failed to fetch validator history:', err); return { data: { history: [] } }; }),
       ]);
 
-      // Process validators - add Q prefix to addresses
+      // The API's `address` field carries the validator's raw ML-DSA-87
+      // public key hex, not an account address. Surface it as publicKeyHex
+      // (no Q prefix) and pass withdrawalCredentialsHex through when the
+      // backend provides it (absent on older cached responses).
       const processedValidators = (validatorsRes.data.validators || []).map((v: any) => ({
         ...v,
-        address: v.address.startsWith('Q') ? v.address : 'Q' + v.address,
+        publicKeyHex: v.address ?? '',
       }));
 
       setValidators(processedValidators);

--- a/QRL2MongoDB/db/contracts_detect.go
+++ b/QRL2MongoDB/db/contracts_detect.go
@@ -6,6 +6,7 @@ import (
 	"QRL2MongoDB/rpc"
 	"QRL2MongoDB/validation"
 	"context"
+	"strings"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -88,6 +89,64 @@ func processContracts(tx *models.Transaction) (string, string, string, bool) {
 	}
 
 	return to, contractAddress, statusTx, isContract
+}
+
+// storeInternalContractCreations registers contracts created by nested
+// CREATE/CREATE2 frames of a traced transaction. The creation branch in
+// processContracts only sees top-level deployments (tx.To == ""), so without
+// this sync-time hook a factory-created contract gets no contractCode row
+// until a later interaction or reprocess pass stumbles on it. Mirrors the
+// processContracts store flow (code fetch + classification + StoreContract),
+// with the outer transaction's sender/hash/block as the creation metadata.
+// The calls slice is empty unless debug tracing is enabled
+// (ENABLE_DEBUG_TRACE), so this is a no-op on nodes without the debug_ API.
+func storeInternalContractCreations(calls []rpc.InternalCall, creator string, txHash string, blockNumber string, statusTx string) {
+	for _, call := range calls {
+		if !strings.HasPrefix(call.Type, "CREATE") || call.To == "" {
+			continue
+		}
+
+		contractCode, err := rpc.GetCode(call.To, "latest")
+		if err != nil {
+			configs.Logger.Error("Failed to get contract code",
+				zap.String("address", call.To),
+				zap.Error(err))
+		}
+
+		// Classify the contract (ERC-20 / ERC-721 / ERC-1155 / unknown).
+		// On transient probe failure the result is zero-valued; the
+		// StoreContract merge's promote-only invariant prevents that
+		// from clobbering a previously-good classification.
+		detection, detErr := rpc.DetectContractType(call.To)
+		if detErr != nil {
+			configs.Logger.Warn("Contract type detection failed; storing without classification",
+				zap.String("address", call.To),
+				zap.Error(detErr))
+		}
+
+		contract := models.ContractInfo{
+			Address:             call.To,
+			Status:              statusTx,
+			IsToken:             detection.Standard != "",
+			Name:                detection.Name,
+			Symbol:              detection.Symbol,
+			Decimals:            detection.Decimals,
+			TotalSupply:         detection.TotalSupply,
+			TokenStandard:       detection.Standard,
+			HasERC165:           detection.HasERC165,
+			ContractCode:        contractCode,
+			CreatorAddress:      creator,
+			CreationTransaction: txHash,
+			CreationBlockNumber: blockNumber,
+			UpdatedAt:           time.Now().UTC().Format(time.RFC3339),
+		}
+
+		if err := StoreContract(contract); err != nil {
+			configs.Logger.Error("Failed to store contract",
+				zap.String("address", call.To),
+				zap.Error(err))
+		}
+	}
 }
 
 // IsAddressContract checks if an address is a contract by querying the contractCode collection

--- a/QRL2MongoDB/db/contracts_reprocess.go
+++ b/QRL2MongoDB/db/contracts_reprocess.go
@@ -164,7 +164,7 @@ func ReprocessIncompleteContracts() error {
 				configs.Logger.Debug("Genesis code probe failed; leaving creation info incomplete",
 					zap.String("address", contract.Address),
 					zap.Error(codeErr))
-			} else if genesisCode != "" && genesisCode != "0x" {
+			} else if genesisCode != "" && genesisCode != "0x" && genesisCode != "0x0" {
 				contract.CreationBlockNumber = "0x0"
 				contract.GenesisContract = true
 				configs.Logger.Info("Contract code present at genesis, pinned creation block to 0x0",

--- a/QRL2MongoDB/db/contracts_reprocess.go
+++ b/QRL2MongoDB/db/contracts_reprocess.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.uber.org/zap"
 )
 
@@ -132,7 +133,9 @@ func ReprocessIncompleteContracts() error {
 			contract.CreationBlockNumber = creationBlockNumber
 		}
 
-		// Backfill missing creation transaction from the transfer collection
+		// Backfill missing creation transaction from the authoritative
+		// sources: the transfer collection (direct deploys) and the
+		// internal-transaction index (factory deploys via CREATE frames).
 		if contract.CreationTransaction == "" && contract.Address != "" {
 			creationTx := findCreationTransaction(contract.Address)
 			if creationTx != nil {
@@ -145,6 +148,47 @@ func ReprocessIncompleteContracts() error {
 						zap.String("creator", contract.CreatorAddress),
 						zap.String("tx", contract.CreationTransaction))
 				}
+			}
+		}
+
+		// Genesis contracts have no creation transaction anywhere on chain.
+		// Probe the code at block 0 BEFORE the mint heuristic below: a
+		// genesis-baked token that later emits a mint would otherwise get the
+		// mint tx latched as its creation tx, permanently blocking this probe.
+		// A hit pins creationBlockNumber to genesis and flags the row so later
+		// passes skip the probe. Fail soft on RPC error (the node may lack
+		// archive state for historical getCode) and leave the record incomplete.
+		if contract.CreationTransaction == "" && contract.CreationBlockNumber == "" && !contract.GenesisContract {
+			genesisCode, codeErr := rpc.GetCode(contract.Address, "0x0")
+			if codeErr != nil {
+				configs.Logger.Debug("Genesis code probe failed; leaving creation info incomplete",
+					zap.String("address", contract.Address),
+					zap.Error(codeErr))
+			} else if genesisCode != "" && genesisCode != "0x" {
+				contract.CreationBlockNumber = "0x0"
+				contract.GenesisContract = true
+				configs.Logger.Info("Contract code present at genesis, pinned creation block to 0x0",
+					zap.String("address", contract.Address))
+			}
+		}
+
+		// Last-resort mint heuristic for factory deploys without internal-tx
+		// coverage: the earliest mint is usually the create+mint tx. When the
+		// creation block is already known, the mint must sit in that exact
+		// block: a later mint would stamp a creation tx from the wrong block.
+		if contract.CreationTransaction == "" && !contract.GenesisContract && contract.Address != "" {
+			mintTx := findCreationTransactionFromMint(contract.Address, contract.CreationBlockNumber)
+			if mintTx != nil {
+				contract.CreationTransaction = mintTx.TxHash
+				if contract.CreationBlockNumber == "" {
+					contract.CreationBlockNumber = mintTx.BlockNumber
+				}
+				if mintTx.From != "" && mintTx.From != "Q" {
+					contract.CreatorAddress = mintTx.From
+				}
+				configs.Logger.Info("Backfilled creation info from earliest mint",
+					zap.String("contract", contract.Address),
+					zap.String("tx", contract.CreationTransaction))
 			}
 		}
 
@@ -194,10 +238,13 @@ type creationTxInfo struct {
 	BlockNumber string `bson:"blockNumber"`
 }
 
-// findCreationTransaction looks up the contract creation transaction.
-// It first checks the transfer collection (direct deployments have contractAddress set).
-// For factory-deployed contracts it falls back to the tokenTransfers collection,
-// finding the initial mint event (from zero address) and resolving the real tx sender.
+// findCreationTransaction looks up the contract creation transaction from the
+// authoritative sources: the transfer collection (direct deployments have
+// contractAddress set), then the internal-transaction index for a
+// CREATE/CREATE2 frame targeting the address (authoritative for factory
+// deployments, including non-token ones). The mint heuristic lives separately
+// in findCreationTransactionFromMint so callers can order the genesis probe
+// between the two.
 func findCreationTransaction(contractAddress string) *creationTxInfo {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -211,37 +258,88 @@ func findCreationTransaction(contractAddress string) *creationTxInfo {
 		return &result
 	}
 
-	// 2. Factory deployment: find the initial mint in tokenTransfers
+	// 2. Factory deployment: CREATE/CREATE2 frame from the internal-transaction
+	// index (populated when debug tracing is enabled). An address is only ever
+	// created once, so a plain FindOne needs no sort.
+	var frame struct {
+		Hash        string `bson:"hash"`
+		From        string `bson:"from"`
+		BlockNumber string `bson:"blockNumber"`
+	}
+	err = configs.InternalTransactionByAddressCollections.FindOne(ctx, bson.M{
+		"type": bson.M{"$in": []string{"CREATE", "CREATE2"}},
+		"to":   contractAddress,
+	}).Decode(&frame)
+	if err == nil && frame.Hash != "" {
+		// The frame's own `from` is the immediate caller (the factory
+		// contract); resolve the outer transaction sender for the creator
+		// field, falling back to the frame's from if the lookup fails.
+		from := lookupTransactionSender(ctx, frame.Hash)
+		if from == "" {
+			from = frame.From
+		}
+		return &creationTxInfo{
+			TxHash:      frame.Hash,
+			From:        from,
+			BlockNumber: frame.BlockNumber,
+		}
+	}
+
+	return nil
+}
+
+// findCreationTransactionFromMint is the last-resort heuristic for factory
+// deployments without internal-tx coverage: find the initial mint in
+// tokenTransfers. Mints store the zero address in the full-width spelling
+// (StoreTokenTransfer normalizes empty senders to configs.QRLZeroAddress);
+// the short "Q0" form is matched too in case any legacy row carries it. Sort
+// ascending by blockNumberInt so the EARLIEST mint (the create+mint tx) is
+// picked, not an arbitrary one. When the creation block is already known,
+// requiredBlock pins the lookup to that block so a later mint cannot be
+// misattributed as the creation tx; pass "" when the block is unknown.
+func findCreationTransactionFromMint(contractAddress string, requiredBlock string) *creationTxInfo {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	filter := bson.M{
+		"contractAddress": contractAddress,
+		"from":            bson.M{"$in": []string{configs.QRLZeroAddress, "Q0"}},
+	}
+	if requiredBlock != "" {
+		filter["blockNumber"] = requiredBlock
+	}
+
 	var mint struct {
 		TxHash      string `bson:"txHash"`
 		BlockNumber string `bson:"blockNumber"`
 	}
-	err = configs.GetTokenTransfersCollection().FindOne(ctx, bson.M{
-		"contractAddress": contractAddress,
-		"from":            "Q0",
-	}).Decode(&mint)
+	mintOpts := options.FindOne().SetSort(bson.D{{Key: "blockNumberInt", Value: 1}})
+	err := configs.GetTokenTransfersCollection().FindOne(ctx, filter, mintOpts).Decode(&mint)
 	if err != nil || mint.TxHash == "" {
 		return nil
 	}
 
 	// Look up the actual transaction sender from the transfer collection
+	from := lookupTransactionSender(ctx, mint.TxHash)
+	return &creationTxInfo{
+		TxHash:      mint.TxHash,
+		From:        from,
+		BlockNumber: mint.BlockNumber,
+	}
+}
+
+// lookupTransactionSender resolves the outer sender of a transaction from the
+// transfer collection. Returns "" when the row is missing; callers treat that
+// as "creator unknown" and keep whatever fallback they have.
+func lookupTransactionSender(ctx context.Context, txHash string) string {
 	var tx struct {
 		From string `bson:"from"`
 	}
-	err = configs.TransferCollections.FindOne(ctx, bson.M{
-		"txHash": mint.TxHash,
+	err := configs.TransferCollections.FindOne(ctx, bson.M{
+		"txHash": txHash,
 	}).Decode(&tx)
 	if err != nil {
-		// Still return what we have from the mint event
-		return &creationTxInfo{
-			TxHash:      mint.TxHash,
-			BlockNumber: mint.BlockNumber,
-		}
+		return ""
 	}
-
-	return &creationTxInfo{
-		TxHash:      mint.TxHash,
-		From:        tx.From,
-		BlockNumber: mint.BlockNumber,
-	}
+	return tx.From
 }

--- a/QRL2MongoDB/db/contracts_store.go
+++ b/QRL2MongoDB/db/contracts_store.go
@@ -125,6 +125,12 @@ func StoreContract(contract models.ContractInfo) error {
 		if merged.CreationBlockNumber == "" && contract.CreationBlockNumber != "" {
 			merged.CreationBlockNumber = contract.CreationBlockNumber
 		}
+		// GenesisContract latches true forever, mirroring HasERC165: code at
+		// block 0 is an immutable chain fact, a later pass with a zero-valued
+		// flag must never clear it.
+		if contract.GenesisContract {
+			merged.GenesisContract = true
+		}
 		if merged.ContractCode == "" && contract.ContractCode != "" && contract.ContractCode != "0x" {
 			merged.ContractCode = contract.ContractCode
 		}
@@ -290,6 +296,11 @@ func syncerOwnedSet(c models.ContractInfo) bson.M {
 	}
 	if c.BaseURI != "" {
 		m["baseURI"] = c.BaseURI
+	}
+	// GenesisContract latches true; omit when false so a pass that never ran
+	// the genesis probe can't clear a previously-set flag.
+	if c.GenesisContract {
+		m["genesisContract"] = true
 	}
 	// Phase 3a collection metadata: classifier writes only the URI; the
 	// resolved fields are owned by the fetcher and updated through

--- a/QRL2MongoDB/db/token_detection.go
+++ b/QRL2MongoDB/db/token_detection.go
@@ -82,11 +82,19 @@ func EnsureContractClassified(contractAddress string, blockNumber string, txHash
 		UpdatedAt:     time.Now().UTC().Format(time.RFC3339),
 	}
 
-	if existingContract == nil {
-		// First sighting, try to backfill creator info from the transfer
-		// collection now (cheap DB lookup) rather than waiting for the
-		// hourly reprocess job.
-		contractInfo.CreationBlockNumber = blockNumber
+	if existingContract != nil {
+		preserveCreationInfo(&contractInfo, existingContract)
+	}
+
+	// Backfill creation info now (cheap DB lookup) rather than waiting for the
+	// hourly reprocess job. Runs on first sighting AND when an existing record
+	// still has empty creation fields (gap-fill, not blind preserve). Only the
+	// authoritative sources are consulted here: the earliest-mint heuristic
+	// and the genesis code probe are deliberately left to the reprocess pass,
+	// which orders the probe first so a genesis-baked token cannot get a later
+	// mint tx latched as its creation tx. The first-sighted log block is NOT
+	// the creation block for a token first seen late, so nothing is guessed.
+	if contractInfo.CreationTransaction == "" {
 		if creationTx := findCreationTransaction(contractAddress); creationTx != nil {
 			contractInfo.CreationTransaction = creationTx.TxHash
 			contractInfo.CreationBlockNumber = creationTx.BlockNumber
@@ -94,8 +102,6 @@ func EnsureContractClassified(contractAddress string, blockNumber string, txHash
 				contractInfo.CreatorAddress = creationTx.From
 			}
 		}
-	} else {
-		preserveCreationInfo(&contractInfo, existingContract)
 	}
 
 	if err := StoreContract(contractInfo); err != nil {

--- a/QRL2MongoDB/db/transactions.go
+++ b/QRL2MongoDB/db/transactions.go
@@ -281,31 +281,24 @@ func processTransactionData(tx *models.Transaction, blockTimestamp string, to st
 	resultBigFloat := new(big.Float).Quo(bigIntAsFloat, divisor)
 	valueFloat64, _ := resultBigFloat.Float64()
 
-	hashmap := map[string]string{"from": tx.From, "to": tx.To}
-
-	for _, address := range hashmap {
-		if address != "" {
-			responseBalance, err := rpc.GetBalance(address)
-			if err != nil {
-				configs.Logger.Warn("Failed to do rpc request: ", zap.Error(err))
-				continue
-			}
-
-			getBalanceResult := new(big.Int)
-			if responseBalance != "" && len(responseBalance) > 2 {
-				getBalanceResult.SetString(responseBalance[2:], 16)
-			} else {
-				configs.Logger.Warn("Invalid balance response", zap.String("balance", responseBalance))
-				continue
-			}
-
-			divisor := new(big.Float).SetFloat64(float64(utils.QUANTA))
-			bigIntAsFloat := new(big.Float).SetInt(getBalanceResult)
-			resultBigFloat := new(big.Float).Quo(bigIntAsFloat, divisor)
-			resultFloat64, _ := resultBigFloat.Float64()
-
-			UpsertTransactions(address, resultFloat64, isContract)
-		}
+	// Per-role address upserts. The old map iteration passed the RECIPIENT's
+	// isContract flag to both parties, so any EOA that ever sent a tx to a
+	// contract got a sticky isContract=true addresses row (UpsertTransactions
+	// never demotes true). Senders are always EOAs on Zond: contract-originated
+	// value moves are internal txs handled separately, so the sender is
+	// upserted with isContract=false and only the recipient carries the
+	// computed flag.
+	if from != "" {
+		upsertAddressBalance(from, false)
+	}
+	if to != "" {
+		upsertAddressBalance(to, isContract)
+	}
+	// Contract creation (to == ""): register the freshly created contract's
+	// addresses row immediately with isContract=true instead of waiting for
+	// its first inbound transaction.
+	if contractAddress != "" {
+		upsertAddressBalance(contractAddress, true)
 	}
 
 	trace := rpc.CallDebugTraceTransaction(tx.Hash)
@@ -321,6 +314,12 @@ func processTransactionData(tx *models.Transaction, blockTimestamp string, to st
 		configs.Logger.Error("Failed to store internal calls",
 			zap.String("txHash", txHash), zap.Error(err))
 	}
+
+	// Register contracts created by nested CREATE/CREATE2 frames (factory
+	// deployments). Only effective when debug tracing is enabled: with
+	// ENABLE_DEBUG_TRACE unset the trace carries no internal calls and this
+	// is a no-op, matching how traces are gated everywhere else.
+	storeInternalContractCreations(trace.InternalCalls, from, txHash, blockNumber, statusTx)
 
 	// Calculate fees using hex strings. Guard against empty/short
 	// gasPrice, slicing [2:] on those panics; treat too-short as zero.
@@ -538,6 +537,33 @@ func TransactionByAddressCollection(timeStamp string, txType string, from string
 	}
 
 	return result, err
+}
+
+// upsertAddressBalance fetches the current balance of one address via RPC and
+// upserts its addresses row with the given contract flag. Failures are logged
+// and swallowed: a missed balance refresh self-heals on the address's next
+// transaction.
+func upsertAddressBalance(address string, isContract bool) {
+	responseBalance, err := rpc.GetBalance(address)
+	if err != nil {
+		configs.Logger.Warn("Failed to do rpc request: ", zap.Error(err))
+		return
+	}
+
+	getBalanceResult := new(big.Int)
+	if responseBalance != "" && len(responseBalance) > 2 {
+		getBalanceResult.SetString(responseBalance[2:], 16)
+	} else {
+		configs.Logger.Warn("Invalid balance response", zap.String("balance", responseBalance))
+		return
+	}
+
+	divisor := new(big.Float).SetFloat64(float64(utils.QUANTA))
+	bigIntAsFloat := new(big.Float).SetInt(getBalanceResult)
+	resultBigFloat := new(big.Float).Quo(bigIntAsFloat, divisor)
+	resultFloat64, _ := resultBigFloat.Float64()
+
+	UpsertTransactions(address, resultFloat64, isContract)
 }
 
 func UpsertTransactions(address string, value float64, isContract bool) (*mongo.UpdateResult, error) {

--- a/QRL2MongoDB/models/contract.go
+++ b/QRL2MongoDB/models/contract.go
@@ -58,7 +58,11 @@ type ContractInfo struct {
 	CreatorAddress      string `bson:"creatorAddress" json:"creatorAddress"`
 	CreationTransaction string `bson:"creationTransaction" json:"creationTransaction"`
 	CreationBlockNumber string `bson:"creationBlockNumber" json:"creationBlockNumber"`
-	UpdatedAt           string `bson:"updatedAt" json:"updatedAt"`
+	// GenesisContract marks contracts whose code already exists at block 0;
+	// they have no creation transaction anywhere on chain. Written by the
+	// reprocess backfill only; latches true (see db/contracts_store.go).
+	GenesisContract bool   `bson:"genesisContract,omitempty" json:"genesisContract,omitempty"`
+	UpdatedAt       string `bson:"updatedAt" json:"updatedAt"`
 	// CustomERC20 properties
 	MaxSupply       string `bson:"maxSupply,omitempty" json:"maxSupply,omitempty"`
 	MaxWalletAmount string `bson:"maxWalletAmount,omitempty" json:"maxWalletAmount,omitempty"`

--- a/QRL2MongoDB/rpc/calls.go
+++ b/QRL2MongoDB/rpc/calls.go
@@ -487,8 +487,8 @@ func GetBalance(address string) (string, error) {
 	return result.Result, nil
 }
 
-// GetValidators fetches up to maxPages of validators from the beacon chain
-// API and returns the parsed pages. Persistence is the caller's concern
+// GetValidators fetches every page of validators from the beacon chain API
+// and returns the parsed pages. Persistence is the caller's concern
 // (synchroniser feeds the pages to services.StoreValidators); keeping this
 // function transport-only keeps rpc free of any db/services dependency.
 func GetValidators() ([]models.BeaconValidatorResponse, error) {
@@ -504,10 +504,14 @@ func GetValidators() ([]models.BeaconValidatorResponse, error) {
 	client := GetHTTPClient()
 
 	pageToken := ""
-	maxPages := 3 // Configurable based on needs
-	pages := make([]models.BeaconValidatorResponse, 0, maxPages)
+	// Safety ceiling against a misbehaving API that keeps returning page
+	// tokens, not an expected operating point. Pagination normally ends when
+	// NextPageToken comes back empty; the old cap of 3 silently truncated the
+	// validator set once it outgrew three pages.
+	const maxPages = 100
+	var pages []models.BeaconValidatorResponse
 
-	for len(pages) < maxPages {
+	for {
 		requestURL := baseURL
 		if pageToken != "" {
 			requestURL += "?page_token=" + pageToken
@@ -544,6 +548,11 @@ func GetValidators() ([]models.BeaconValidatorResponse, error) {
 
 		// Check if there's a next page
 		if beaconResponse.NextPageToken == "" {
+			break
+		}
+		if len(pages) >= maxPages {
+			zap.L().Warn("Validator pagination hit safety ceiling, result truncated",
+				zap.Int("max_pages", maxPages))
 			break
 		}
 		pageToken = beaconResponse.NextPageToken
@@ -604,8 +613,15 @@ func GetCode(address string, blockNrOrHash string) (string, error) {
 		return "", fmt.Errorf("invalid address format: %v", err)
 	}
 
+	// Honor the caller's block parameter. This used to hardcode "latest",
+	// which silently broke historical probes like the genesis-code check in
+	// ReprocessIncompleteContracts.
+	if blockNrOrHash == "" {
+		blockNrOrHash = "latest"
+	}
+
 	var GetCode models.GetCode
-	if err := rpcCall("qrl_getCode", []interface{}{address, "latest"}, &GetCode); err != nil {
+	if err := rpcCall("qrl_getCode", []interface{}{address, blockNrOrHash}, &GetCode); err != nil {
 		zap.L().Info("Failed to execute request", zap.Error(err))
 		return "", err
 	}

--- a/QRL2MongoDB/synchroniser/gap_detection.go
+++ b/QRL2MongoDB/synchroniser/gap_detection.go
@@ -218,11 +218,12 @@ func detectAndFillGapsPeriodically() {
 		return
 	}
 
-	// Check the last MaxGapDetectionBlocks blocks for gaps
+	// Check the last MaxGapDetectionBlocks blocks for gaps. Clamp to 0, not 1:
+	// the genesis block is a fillable gap like any other.
 	lastKnownNum := utils.HexToInt(lastKnown).Int64()
 	fromNum := lastKnownNum - MaxGapDetectionBlocks
-	if fromNum < 1 {
-		fromNum = 1
+	if fromNum < 0 {
+		fromNum = 0
 	}
 
 	fromBlock := utils.IntToHex(int(fromNum))

--- a/QRL2MongoDB/synchroniser/periodic_tasks.go
+++ b/QRL2MongoDB/synchroniser/periodic_tasks.go
@@ -168,12 +168,6 @@ func StartWalletCountSync(stopCh <-chan struct{}) {
 func processBlockPeriodically() {
 	configs.Logger.Info("Starting block processing check")
 
-	// Initialize collections if they don't exist
-	if !db.IsCollectionsExist() {
-		processInitialBlock()
-		return
-	}
-
 	// Process the latest block
 	latestBlock, err := rpc.GetLatestBlock()
 	if err != nil {
@@ -181,12 +175,11 @@ func processBlockPeriodically() {
 		return
 	}
 
+	// Collections and the genesis block are guaranteed by Sync() before this
+	// loop starts, so no initialization branch is needed here. A sync state
+	// of "0x0" (fresh chain, only genesis stored) falls through to the
+	// normal path and starts processing at block 0x1.
 	lastProcessedBlock := db.GetLastKnownBlockNumber()
-	if lastProcessedBlock == "0x0" {
-		configs.Logger.Info("No blocks in database, initializing...")
-		processInitialBlock()
-		return
-	}
 
 	// Log both states to help diagnose issues
 	configs.Logger.Info("Block sync status",
@@ -330,6 +323,11 @@ func updateDataPeriodically() {
 	configs.Logger.Info("Counting wallets...")
 	db.CountWallets()
 
+	// Update total circulating supply (writes the totalBalance document the
+	// backend's supply endpoint reads)
+	configs.Logger.Info("Updating total circulating supply...")
+	db.UpdateTotalBalance()
+
 	// Update transaction volume
 	configs.Logger.Info("Calculating daily transaction volume...")
 	db.GetDailyTransactionVolume()
@@ -356,11 +354,6 @@ func updateDataPeriodically() {
 // which lets Sync() (and therefore main.go's doneCh) complete cleanly.
 func singleBlockInsertion(stopCh <-chan struct{}) {
 	configs.Logger.Info("Starting single block insertion process")
-
-	// Initialize collections if they don't exist
-	if !db.IsCollectionsExist() {
-		processInitialBlock()
-	}
 
 	// Create a wait group to keep the main goroutine alive
 	var wg sync.WaitGroup

--- a/QRL2MongoDB/synchroniser/sync.go
+++ b/QRL2MongoDB/synchroniser/sync.go
@@ -115,6 +115,39 @@ func Sync(stopCh <-chan struct{}) {
 		// the syncer can still index blocks and we'll log the issue loudly.
 	}
 
+	// Idempotent genesis guard: the producer loop below starts at
+	// lastKnown+1, which skips block 0 forever on a fresh DB (a sync state of
+	// "0x0" means "nothing synced", not "block 0 done"). Insert block 0
+	// through the normal insert path; InsertBlockDocument no-ops when the
+	// block already exists, so a restart never duplicates it.
+	if !db.BlockExists("0x0") {
+		// Retry with the same backoff the latest-block fetch below uses: gap
+		// detection only scans the newest blocks, so a startup failure here
+		// would otherwise leave genesis missing for the whole process
+		// lifetime (until the next restart).
+		var genesisBlock *models.ZondDatabaseBlock
+		var genErr error
+		for retries := 0; retries < 5; retries++ {
+			genesisBlock, genErr = rpc.GetBlockByNumberMainnet("0x0")
+			if genErr == nil {
+				break
+			}
+			configs.Logger.Warn("Failed to fetch genesis block, retrying...",
+				zap.Error(genErr),
+				zap.Int("retry", retries+1))
+			time.Sleep(time.Duration(1<<uint(retries)) * time.Second)
+		}
+		if genErr != nil {
+			configs.Logger.Error("Failed to fetch genesis block after retries; continuing without it (retried on next restart)",
+				zap.Error(genErr))
+		} else {
+			db.UpdateTransactionStatuses(genesisBlock)
+			db.InsertBlockDocument(*genesisBlock)
+			db.ProcessTransactions(*genesisBlock)
+			configs.Logger.Info("Genesis block inserted")
+		}
+	}
+
 	// DB queries, no retry needed, these are local and don't fail transiently.
 	nextBlock = db.GetLastKnownBlockNumber()
 	if nextBlock == "0x0" {
@@ -288,52 +321,6 @@ func forceUpdateSyncState(blockNumber string) {
 		configs.Logger.Info("Successfully updated sync state",
 			zap.String("block", blockNumber))
 	}
-}
-
-// processInitialBlock processes the genesis block and initializes collections
-func processInitialBlock() {
-	configs.Logger.Info("Processing genesis block")
-
-	// Initialize token collections using the token sync module
-	if err := InitializeTokenCollections(); err != nil {
-		configs.Logger.Error("Failed to initialize token collections", zap.Error(err))
-		// Continue anyway - we'll log the error but try to proceed
-	}
-
-	// Initialize validators
-	configs.Logger.Info("Initializing validators")
-	if err := syncValidators(); err != nil {
-		configs.Logger.Error("Failed to initialize validators", zap.Error(err))
-	} else {
-		configs.Logger.Info("Successfully initialized validators")
-	}
-
-	// Get block 0
-	genesisBlock, err := rpc.GetBlockByNumberMainnet("0x0")
-	if err != nil {
-		configs.Logger.Error("Failed to get genesis block",
-			zap.Error(err))
-		return
-	}
-
-	// Update tx status in block 0
-	db.UpdateTransactionStatuses(genesisBlock)
-
-	// Insert block document
-	blocksCollection := configs.GetCollection(configs.DB, "blocks")
-	ctx := context.Background()
-	_, err = blocksCollection.InsertOne(ctx, genesisBlock)
-	if err != nil {
-		configs.Logger.Error("Failed to insert genesis block",
-			zap.Error(err))
-		return
-	}
-
-	// Process transactions
-	db.ProcessTransactions(*genesisBlock)
-
-	db.StoreLastKnownBlockNumber("0x0")
-	configs.Logger.Info("Genesis block processed successfully")
 }
 
 // processSubsequentBlocks processes a single block and returns the next block to process

--- a/backendAPI/configs/setup.go
+++ b/backendAPI/configs/setup.go
@@ -427,10 +427,13 @@ func initializeCollections(db *mongo.Database) {
 		log.Printf("Warning: Failed to initialize dailyTransactionsVolume collection: %v", err)
 	}
 
-	// Initialize totalCirculatingSupply collection with fallback data
+	// Initialize totalCirculatingSupply collection with fallback data.
+	// Keyed to the syncer's well-known _id so the seed and the syncer's
+	// writer share one document; an unkeyed upsert used to insert a
+	// random-_id doc the reader could pick up forever.
 	_, err = db.Collection(totalCirculatingSupplyCollName).UpdateOne(
 		ctx,
-		bson.M{},
+		bson.M{"_id": "totalBalance"},
 		bson.M{"$setOnInsert": bson.M{"circulating": "0"}},
 		options.Update().SetUpsert(true),
 	)

--- a/backendAPI/db/address.go
+++ b/backendAPI/db/address.go
@@ -14,7 +14,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 func ReturnSingleAddress(query string) (models.Address, error) {
@@ -55,39 +54,104 @@ func ReturnSingleAddress(query string) (models.Address, error) {
 	return result, nil
 }
 
-func ReturnRichlist() ([]models.Address, error) {
+func ReturnRichlist() ([]models.RichlistEntry, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	var addresses []models.Address
 	defer cancel()
 
-	projection := bson.D{
-		{Key: "id", Value: 1},
-		{Key: "balance", Value: 1},
+	// Contract detection joins contractCode by address instead of trusting
+	// addresses.isContract (known-poisoned data). Both collections store
+	// canonical Q+lowercase addresses and contractCode has a unique index
+	// on address, so the equality lookup is safe. A row only counts as a
+	// contract when at least one joined doc carries real bytecode
+	// (non-empty and not "0x", which guards failed deploys).
+	pipeline := []bson.M{
+		{"$sort": bson.M{"balance": -1}},
+		{"$limit": 50},
+		{"$lookup": bson.M{
+			"from":         "contractCode",
+			"localField":   "id",
+			"foreignField": "address",
+			"as":           "contract",
+		}},
+		{"$project": bson.M{
+			"_id":     0,
+			"id":      1,
+			"balance": 1,
+			"isContract": bson.M{"$gt": []interface{}{
+				bson.M{"$size": bson.M{"$filter": bson.M{
+					"input": "$contract",
+					"as":    "c",
+					"cond": bson.M{"$not": bson.M{"$in": []interface{}{
+						bson.M{"$ifNull": []interface{}{"$$c.contractCode", ""}},
+						[]interface{}{"", "0x"},
+					}}},
+				}}},
+				0,
+			}},
+		}},
 	}
 
-	opts := options.Find().
-		SetProjection(projection).
-		SetSort(bson.D{{Key: "balance", Value: -1}}).
-		SetLimit(50)
-
-	results, err := configs.AddressesCollections.Find(ctx, bson.D{}, opts)
+	cursor, err := configs.AddressesCollections.Aggregate(ctx, pipeline)
 	if err != nil {
 		// Early return: proceeding onto the nil cursor used to panic on
 		// every request whenever Mongo errored here.
 		log.Printf("error querying richlist: %v", err)
 		return nil, err
 	}
+	defer cursor.Close(ctx)
 
-	defer results.Close(ctx)
-	for results.Next(ctx) {
-		var singleAddress models.Address
-		if err = results.Decode(&singleAddress); err != nil {
-			log.Printf("error decoding richlist address: %v", err)
-		}
-		addresses = append(addresses, singleAddress)
+	var entries []models.RichlistEntry
+	if err := cursor.All(ctx, &entries); err != nil {
+		log.Printf("error decoding richlist: %v", err)
+		return nil, err
 	}
 
-	return addresses, nil
+	// Percent-of-supply uses the same balances the ranking sorts on so the
+	// column stays consistent with the ordering. On error the column
+	// degrades to 0 rather than failing the whole richlist.
+	total, err := totalAddressBalance(ctx)
+	if err != nil {
+		log.Printf("error summing total balance for richlist: %v", err)
+	}
+
+	for i := range entries {
+		if total > 0 {
+			entries[i].SupplyPercent = entries[i].Balance / total * 100
+		}
+		// One index-backed FindOne per row; the /richlist route caches the
+		// result for 30 s, so this runs at most once per cache window.
+		entries[i].FirstSeen = FirstSeen(entries[i].ID)
+	}
+
+	return entries, nil
+}
+
+// totalAddressBalance sums every address balance, the denominator for the
+// richlist's percent-of-supply column.
+func totalAddressBalance(ctx context.Context) (float64, error) {
+	pipeline := []bson.M{
+		{"$group": bson.M{"_id": nil, "total": bson.M{"$sum": "$balance"}}},
+	}
+
+	cursor, err := configs.AddressesCollections.Aggregate(ctx, pipeline)
+	if err != nil {
+		return 0, err
+	}
+	defer cursor.Close(ctx)
+
+	var row struct {
+		Total float64 `bson:"total"`
+	}
+	if cursor.Next(ctx) {
+		if err := cursor.Decode(&row); err != nil {
+			return 0, err
+		}
+	}
+	if err := cursor.Err(); err != nil {
+		return 0, err
+	}
+
+	return row.Total, nil
 }
 
 func ReturnRankAddress(address string) (int64, error) {

--- a/backendAPI/db/address.go
+++ b/backendAPI/db/address.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"strconv"
 	"strings"
 	"time"
 
@@ -106,12 +107,24 @@ func ReturnRichlist() ([]models.RichlistEntry, error) {
 		return nil, err
 	}
 
-	// Percent-of-supply uses the same balances the ranking sorts on so the
-	// column stays consistent with the ordering. On error the column
-	// degrades to 0 rather than failing the whole richlist.
-	total, err := totalAddressBalance(ctx)
-	if err != nil {
-		log.Printf("error summing total balance for richlist: %v", err)
+	// Percent-of-supply prefers the precalculated circulating total (written
+	// by the syncer every 30 min, shared with /overview) over summing the
+	// whole addresses collection, which is O(N) per cache window. The
+	// aggregation stays as the fallback for fresh deployments where the
+	// total has not been written yet; on error the column degrades to 0
+	// rather than failing the whole richlist.
+	var total float64
+	if circulating := ReturnTotalCirculatingSupply(); circulating != "" {
+		if parsed, parseErr := strconv.ParseFloat(circulating, 64); parseErr == nil {
+			total = parsed
+		}
+	}
+	if total <= 0 {
+		var sumErr error
+		total, sumErr = totalAddressBalance(ctx)
+		if sumErr != nil {
+			log.Printf("error summing total balance for richlist: %v", sumErr)
+		}
 	}
 
 	for i := range entries {

--- a/backendAPI/db/stats.go
+++ b/backendAPI/db/stats.go
@@ -21,7 +21,11 @@ func ReturnTotalCirculatingSupply() string {
 
 	var result models.CirculatingSupply
 
-	err := configs.TotalCirculatingSupplyCollection.FindOne(ctx, primitive.D{}).Decode(&result)
+	// Pin the read to the syncer's well-known document. An unfiltered
+	// FindOne could return the bootstrap seed doc (circulating "0") even
+	// after the syncer had written a real total under _id "totalBalance".
+	filter := bson.M{"_id": "totalBalance"}
+	err := configs.TotalCirculatingSupplyCollection.FindOne(ctx, filter).Decode(&result)
 	if err != nil {
 		log.Printf("error fetching circulating supply: %v", err)
 		return ""

--- a/backendAPI/db/token.go
+++ b/backendAPI/db/token.go
@@ -609,6 +609,7 @@ func GetTokenInfo(contractAddress string) (*models.TokenInfo, error) {
 		CreatorAddress:  contract.ContractCreatorAddress,
 		CreationTxHash:  contract.CreationTransaction,
 		CreationBlock:   contract.CreationBlockNumber,
+		GenesisContract: contract.GenesisContract,
 	}, nil
 }
 

--- a/backendAPI/db/transaction.go
+++ b/backendAPI/db/transaction.go
@@ -319,25 +319,7 @@ func ReturnAddressActivityRange(address string) (int64, int64, error) {
 
 	filter := addressOrFilter(normalizedAddress)
 
-	fetchBoundary := func(order int) (int64, error) {
-		var doc struct {
-			TimeStamp string `bson:"timeStamp"`
-		}
-		opts := options.FindOne().
-			SetProjection(primitive.D{{Key: "timeStamp", Value: 1}}).
-			SetSort(primitive.D{{Key: "timeStamp", Value: order}})
-		err := configs.TransactionByAddressCollection.FindOne(ctx, filter, opts).Decode(&doc)
-		if err != nil {
-			return 0, err
-		}
-		ts, err := strconv.ParseInt(strings.TrimPrefix(doc.TimeStamp, "0x"), 16, 64)
-		if err != nil {
-			return 0, fmt.Errorf("malformed timeStamp %q: %w", doc.TimeStamp, err)
-		}
-		return ts, nil
-	}
-
-	first, err := fetchBoundary(1)
+	first, err := fetchActivityBoundary(ctx, filter, 1)
 	if err == mongo.ErrNoDocuments {
 		return 0, 0, nil
 	}
@@ -346,13 +328,58 @@ func ReturnAddressActivityRange(address string) (int64, int64, error) {
 		return 0, 0, err
 	}
 
-	last, err := fetchBoundary(-1)
+	last, err := fetchActivityBoundary(ctx, filter, -1)
 	if err != nil {
 		log.Printf("error fetching last activity: %v", err)
 		return 0, 0, err
 	}
 
 	return first, last, nil
+}
+
+// fetchActivityBoundary returns the unix timestamp (seconds) of the oldest
+// (order 1) or newest (order -1) native transaction matching the address
+// filter, or mongo.ErrNoDocuments when there are none. Index-backed: the
+// sort rides the same timeStamp ordering assumption documented on
+// ReturnAddressActivityRange.
+func fetchActivityBoundary(ctx context.Context, filter bson.M, order int) (int64, error) {
+	var doc struct {
+		TimeStamp string `bson:"timeStamp"`
+	}
+	opts := options.FindOne().
+		SetProjection(primitive.D{{Key: "timeStamp", Value: 1}}).
+		SetSort(primitive.D{{Key: "timeStamp", Value: order}})
+	err := configs.TransactionByAddressCollection.FindOne(ctx, filter, opts).Decode(&doc)
+	if err != nil {
+		return 0, err
+	}
+	ts, err := strconv.ParseInt(strings.TrimPrefix(doc.TimeStamp, "0x"), 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("malformed timeStamp %q: %w", doc.TimeStamp, err)
+	}
+	return ts, nil
+}
+
+// FirstSeen returns the unix timestamp (seconds) of the oldest native
+// transaction involving the address, or 0 when it has none (the richlist
+// renders that as a dash). Same first-boundary lookup the address page's
+// Activity card uses via ReturnAddressActivityRange.
+func FirstSeen(address string) int64 {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	filter := addressOrFilter(normalizeAddress(address))
+
+	first, err := fetchActivityBoundary(ctx, filter, 1)
+	if err == mongo.ErrNoDocuments {
+		return 0
+	}
+	if err != nil {
+		log.Printf("error fetching first seen for %s: %v", address, err)
+		return 0
+	}
+
+	return first
 }
 
 func ReturnSingleTransfer(query string) (models.Transfer, error) {

--- a/backendAPI/db/validator.go
+++ b/backendAPI/db/validator.go
@@ -68,12 +68,13 @@ func ReturnValidators(pageToken string) (*models.ValidatorResponse, error) {
 		}
 
 		validators = append(validators, models.Validator{
-			Index:        d.ID,
-			Address:      d.PublicKeyHex,
-			Status:       status,
-			Age:          age,
-			StakedAmount: d.EffectiveBalance,
-			IsActive:     isActive,
+			Index:                    d.ID,
+			Address:                  d.PublicKeyHex,
+			WithdrawalCredentialsHex: d.WithdrawalCredentialsHex,
+			Status:                   status,
+			Age:                      age,
+			StakedAmount:             d.EffectiveBalance,
+			IsActive:                 isActive,
 		})
 
 		if balance, err := strconv.ParseInt(d.EffectiveBalance, 10, 64); err == nil {

--- a/backendAPI/models/address.go
+++ b/backendAPI/models/address.go
@@ -8,3 +8,15 @@ type Address struct {
 	Balance  float64            `json:"balance"`
 	Nonce    uint64             `json:"nonce"`
 }
+
+// RichlistEntry is one row of the /richlist response. Deliberately separate
+// from Address: that struct serves /address/aggregate (and leaks the Mongo
+// ObjectId), while the richlist table needs the enrichment columns below and
+// must not expose internal ids.
+type RichlistEntry struct {
+	ID            string  `json:"id" bson:"id"`
+	Balance       float64 `json:"balance" bson:"balance"`
+	IsContract    bool    `json:"isContract" bson:"isContract"`
+	FirstSeen     int64   `json:"firstSeen" bson:"firstSeen"`
+	SupplyPercent float64 `json:"supplyPercent" bson:"supplyPercent"`
+}

--- a/backendAPI/models/contract.go
+++ b/backendAPI/models/contract.go
@@ -34,6 +34,11 @@ type ContractInfo struct {
 	HasERC165     bool   `json:"hasERC165,omitempty" bson:"hasERC165,omitempty"`
 	BaseURI       string `json:"baseURI,omitempty" bson:"baseURI,omitempty"`
 
+	// Set by the syncer for contracts baked into the genesis allocation
+	// (no creation transaction exists). Pass-through so the frontend can
+	// label them; mirror QRL2MongoDB/models/contract.go.
+	GenesisContract bool `json:"genesisContract,omitempty" bson:"genesisContract,omitempty"`
+
 	// Collection-level off-chain metadata (Phase 3a). Mirrors
 	// QRL2MongoDB/models/contract.go. Written by the syncer's metadata
 	// fetcher service; the backend holds them for read-through to clients.

--- a/backendAPI/models/token_balance.go
+++ b/backendAPI/models/token_balance.go
@@ -119,4 +119,5 @@ type TokenInfo struct {
 	CreatorAddress  string `json:"creatorAddress"`
 	CreationTxHash  string `json:"creationTxHash"`
 	CreationBlock   string `json:"creationBlock"`
+	GenesisContract bool   `json:"genesisContract,omitempty"`
 }

--- a/backendAPI/models/validator.go
+++ b/backendAPI/models/validator.go
@@ -28,12 +28,13 @@ type ValidatorResponse struct {
 
 // Validator represents a single validator in the API response
 type Validator struct {
-	Index        string `json:"index"`        // Validator index
-	Address      string `json:"address"`      // Public key in hex format
-	Status       string `json:"status"`       // active, pending, exited, slashed
-	Age          int64  `json:"age"`          // Age in epochs
-	StakedAmount string `json:"stakedAmount"` // Amount staked
-	IsActive     bool   `json:"isActive"`     // Whether the validator is currently active
+	Index                    string `json:"index"`                    // Validator index
+	Address                  string `json:"address"`                  // Public key in hex format
+	WithdrawalCredentialsHex string `json:"withdrawalCredentialsHex"` // Withdrawal credentials in hex format
+	Status                   string `json:"status"`                   // active, pending, exited, slashed
+	Age                      int64  `json:"age"`                      // Age in epochs
+	StakedAmount             string `json:"stakedAmount"`             // Amount staked
+	IsActive                 bool   `json:"isActive"`                 // Whether the validator is currently active
 }
 
 // EpochInfo represents the current epoch state

--- a/backendAPI/models/zond.go
+++ b/backendAPI/models/zond.go
@@ -1,9 +1,5 @@
 package models
 
-import (
-	"go.mongodb.org/mongo-driver/bson/primitive"
-)
-
 type ZondDatabaseBlock struct {
 	Jsonrpc string `json:"jsonrpc"`
 	ID      int    `json:"id"`
@@ -57,7 +53,9 @@ type Result struct {
 	WithdrawalsRoot  string        `json:"withdrawalsRoot"`
 }
 
+// CirculatingSupply mirrors the syncer's totalCirculatingSupply document,
+// which lives under the fixed string _id "totalBalance" (not an ObjectId).
 type CirculatingSupply struct {
-	ID          primitive.ObjectID `bson:"_id,omitempty"`
-	Circulating string             `bson:"circulating"`
+	ID          string `bson:"_id,omitempty"`
+	Circulating string `bson:"circulating"`
 }

--- a/backendAPI/routes/market_routes.go
+++ b/backendAPI/routes/market_routes.go
@@ -25,8 +25,13 @@ func handleOverview(c *gin.Context) {
 		currentPrice := market.PriceUSD
 		walletCount := db.GetWalletCount()
 
-		circulating := db.ReturnTotalCirculatingSupply()
-		if circulating == "" {
+		// "0" is the bootstrap seed value written before the syncer's first
+		// supply pass, treat it like a missing doc so the UI never shows 0
+		// circulating during initial sync. The raw value still feeds
+		// dataInitialized below, which must not count the fallback.
+		rawCirculating := db.ReturnTotalCirculatingSupply()
+		circulating := rawCirculating
+		if circulating == "" || circulating == "0" {
 			circulating = "65000000" // default when no data is available
 		}
 
@@ -58,7 +63,7 @@ func handleOverview(c *gin.Context) {
 			"contractCount":  contractCount,
 			"status": gin.H{
 				"syncing":         true,
-				"dataInitialized": marketCap > 0 || currentPrice > 0 || walletCount > 0 || circulating != "0" || volume > 0,
+				"dataInitialized": marketCap > 0 || currentPrice > 0 || walletCount > 0 || (rawCirculating != "" && rawCirculating != "0") || volume > 0,
 			},
 		}, nil
 	})

--- a/scripts/repair-address-iscontract.js
+++ b/scripts/repair-address-iscontract.js
@@ -1,0 +1,62 @@
+// repair-address-iscontract.js
+//
+// One-time repair for isContract poisoning in the addresses collection.
+// A syncer bug passed the recipient's isContract flag to BOTH parties of a
+// transaction, so any EOA that ever sent a tx to a contract was stored with
+// a sticky isContract=true row. Run this ONCE against the explorer MongoDB
+// AFTER deploying the syncer fix (per-role upserts in db/transactions.go);
+// running it against an unfixed syncer just lets the poisoning creep back.
+//
+// What it does:
+//   1. Resets isContract to false on ALL addresses docs (including docs that
+//      are missing the field entirely, so wallet counts see them too).
+//   2. Re-flags isContract=true for every address that has a contractCode
+//      document with actual deployed code (contractCode not "" and not "0x").
+//
+// Usage: mongosh <connection-string> scripts/repair-address-iscontract.js
+
+const dbz = db.getSiblingDB('qrldata-z');
+
+// --- Before summary ---
+const totalAddresses = dbz.addresses.countDocuments({});
+const flaggedBefore = dbz.addresses.countDocuments({ isContract: true });
+const missingBefore = dbz.addresses.countDocuments({ isContract: { $exists: false } });
+print(`addresses total:                 ${totalAddresses}`);
+print(`isContract=true before repair:   ${flaggedBefore}`);
+print(`isContract missing before:       ${missingBefore}`);
+
+// --- Step 1: reset every addresses doc to isContract=false ---
+const resetResult = dbz.addresses.updateMany({}, { $set: { isContract: false } });
+print(`step 1: reset ${resetResult.modifiedCount} docs to isContract=false`);
+
+// --- Step 2: re-flag real contracts from the contractCode collection ---
+// Both collections store canonical Q-prefixed lowercase addresses
+// (addresses.id == contractCode.address).
+let contractsSeen = 0;
+let flaggedNow = 0;
+let missingAddressDoc = 0;
+dbz.contractCode
+  .find({ contractCode: { $exists: true, $nin: ['', '0x'] } }, { address: 1 })
+  .forEach((contract) => {
+    contractsSeen += 1;
+    const res = dbz.addresses.updateOne(
+      { id: contract.address },
+      { $set: { isContract: true } }
+    );
+    if (res.matchedCount === 0) {
+      // Contract has no addresses row yet (never held a balance); the fixed
+      // syncer creates it on the next touch, nothing to repair here.
+      missingAddressDoc += 1;
+    } else {
+      flaggedNow += 1;
+    }
+  });
+print(`step 2: ${contractsSeen} contractCode docs with deployed code`);
+print(`step 2: flagged ${flaggedNow} addresses docs isContract=true`);
+print(`step 2: ${missingAddressDoc} contracts had no addresses doc (skipped)`);
+
+// --- After summary ---
+const flaggedAfter = dbz.addresses.countDocuments({ isContract: true });
+const walletsAfter = dbz.addresses.countDocuments({ isContract: false });
+print(`isContract=true after repair:    ${flaggedAfter} (was ${flaggedBefore})`);
+print(`isContract=false after repair:   ${walletsAfter}`);


### PR DESCRIPTION
Implements the community feedback batch reported on Discord (2026-07-20), covering all three components. Every item was root-caused before fixing; several latent data bugs surfaced along the way and are fixed here too.

## Feedback items addressed

1. **Rich list**: rows now show address Type (Wallet/Contract), First Seen date, and % of supply. The type comes from a `contractCode` lookup in a new aggregation because `addresses.isContract` was poisoned (see syncer fixes).
2. **Smart contracts with unknown creator/tx/block**: root causes fixed in the syncer. Factory-deployed contracts never hit the direct-creation path, and the repair job's mint lookup filtered on `from:"Q0"` which never matches the stored full-width zero address. Added: CREATE/CREATE2 internal-frame backfill, sync-time registration of internal creates (when tracing is on), earliest-mint heuristic constrained to a known creation block, genesis code probe (ordered before the heuristic) with a `genesisContract` flag, and frontend Genesis labels instead of broken empty links. Existing incomplete rows self-heal via the hourly reprocess pass.
3. **Back button loses page/tab state**: state on /contracts, token contract views, address panels, and /validators now lives in URL query params via a shared shallow history-API hook, so Back/Forward and deep links restore the exact view. `DebouncedInput` was also fixed to stop re-emitting on parent re-renders, which would have reset page params on every poll.
4. **Unit converter**: rebuilt as any-to-any Quanta/Shor/Planck with exact BigInt math. The old form converted Quanta to Shor at 18 decimals; correct is 1 Quanta = 10^9 Shor = 10^18 Planck. Unit tests included.
5. **Validators**: double-QQ prefix fixed (it was the pubkey, prepended twice). List and detail now decode withdrawal credentials (prefix 0x00 + 11 zero bytes + 20-byte address) to a real linked Q-address; public key is collapsed via a new `CollapsibleHex` (extracted from `ContractBytecode`); duplicated fields on the detail page merged so each appears once.
6. **Genesis block missing**: the syncer never inserted block 0 (every other layer handles it). Idempotent startup guard with retry backoff inserts it; the dead `processInitialBlock` path was removed. This also self-heals epoch 0's phantom "missed slot".
7. **Epoch slots**: proposed rows link the block hash; the zero-address proposer is de-emphasized (dash) until proposer-index enrichment lands; placeholder typo fixed.
10. **Overview link** added to the sidebar nav.

## Latent bugs found and fixed

- Syncer poisoned `addresses.isContract`: senders inherited the recipient's contract flag, sticky-true. Fixed per-role; `scripts/repair-address-iscontract.js` (mongosh) recomputes the flag once from `contractCode`. This also unskews the homepage wallet count.
- Circulating supply pipeline was dead: `UpdateTotalBalance` had no callers, and the API reader/seed disagreed with the writer on the doc `_id`, so `/overview` served circulating `"0"` forever. Wired into the periodic task, reader filtered to `_id "totalBalance"`, `"0"` treated as uninitialized.
- `GetValidators` silently truncated at 3 pages; now paginates until the token is exhausted (with a safety ceiling).
- `rpc.GetCode` ignored its block parameter (hardcoded latest); fixed, existing callers unaffected.

## Validation

- `QRL2MongoDB`: `go build ./...`, `go vet ./...`, `go test ./...` green; `gofmt -l` clean.
- `backendAPI`: `go build ./...`, `go vet ./...`, `go test ./...` green.
- `ExplorerFrontend`: `npm run lint` 0 errors, `tsc --noEmit` clean, `npm test` 127/127, `npm run build` succeeds.
- Adversarial review pass over the full diff; all confirmed findings fixed in-branch (DebouncedInput re-emit, mint-heuristic ordering vs genesis probe, genesis fetch retry, stale debounced search writes, out-of-range page clamp).

## Deploy notes (after merge)

1. Rebuild backend + syncer via `update-backend.sh` (never a bare pm2 restart after pull). The syncer inserts block 0 on startup and repairs incomplete contracts on the next hourly pass.
2. Run `scripts/repair-address-iscontract.js` once via mongosh against the explorer DB after the new syncer is running.
3. Rebuild the frontend via `update-frontend.sh`.
4. Spot-checks: `/block/0` resolves; a factory token (e.g. the reported QRL Token address) shows creator + creation tx; `/api/overview` circulating is non-zero; richlist shows the new columns; converter shows 1 Quanta = 10^9 Shor.

## Known limitations / follow-ups

- Feedback items 7 (per-slot proposer assignments), 8 (slashing/penalizations page), and 9 (supply charts page) need new beacon-API sync pipelines; designs are scoped and can land as separate PRs.
- The epoch view still assumes slot == execution block number; fine while the chain has no genuinely missed slots, flagged for the proposer-assignments work.
- Validator "first seen"/history remain partially synthetic (pre-existing).