### PR TITLE
fix(monitor): watch nginx, TLS and cert expiry

### DIFF
--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -194,3 +194,46 @@ if mongosh --quiet --eval 'db.runCommand({ping:1}).ok' qrldata-z 2>/dev/null | g
 else
     check_debounced "mongodb" 2 "fail" "**MongoDB** not responding" ""
 fi
+
+# --- nginx service ---
+# Every check above probes an app directly on loopback, so all of them stay
+# green when nginx itself is down and nothing is actually reachable from the
+# internet. That is exactly what happened on 2026-07-28: a DNS blip during an
+# unattended-upgrades restart failed the config test, nginx stayed dead for 9h,
+# and this monitor never said a word. Watch the reverse proxy explicitly.
+if systemctl is-active --quiet nginx; then
+    check_debounced "nginx-service" 2 "pass" "" "nginx is running again"
+else
+    check_debounced "nginx-service" 2 "fail" "**nginx** is not running (every site on this host is down)" ""
+fi
+
+# --- nginx TLS termination ---
+# Pinned to loopback so this tests our own vhost + cert, not Cloudflare's edge.
+# -k because the origin cert is a Cloudflare Origin CA cert, which the system
+# trust store deliberately does not chain to.
+HTTP_CODE=$(curl -sk --max-time 8 -o /dev/null -w "%{http_code}" \
+    --resolve zondscan.com:443:127.0.0.1 https://zondscan.com/)
+if [ "$HTTP_CODE" = "200" ]; then
+    check_debounced "nginx-tls" 2 "pass" "" "nginx TLS is serving again"
+else
+    check_debounced "nginx-tls" 2 "fail" "**nginx TLS** not serving zondscan.com on :443 (HTTP $HTTP_CODE)" ""
+fi
+
+# --- Origin cert expiry ---
+# Cloudflare Origin CA certs are long-lived with no renewal infra, so a silent
+# expiry is a guaranteed future outage that nobody is watching for. Warn early,
+# once per cert, at 30 days remaining.
+#
+# Set MONITOR_SSL_DIR to the directory holding per-site <name>/cert.pub. Left
+# unset the check is skipped, which keeps deployment-specific paths out of this
+# repo.
+for CERT_FILE in "${MONITOR_SSL_DIR:-/nonexistent}"/*/cert.pub; do
+    [ -f "$CERT_FILE" ] || continue
+    CERT_NAME=$(basename "$(dirname "$CERT_FILE")")
+    if ! openssl x509 -in "$CERT_FILE" -noout -checkend 2592000 >/dev/null 2>&1; then
+        CERT_END=$(openssl x509 -in "$CERT_FILE" -noout -enddate 2>/dev/null | cut -d= -f2)
+        alert "cert-expiry-$CERT_NAME" "**Origin cert** ($CERT_NAME) expires within 30 days ($CERT_END)"
+    else
+        resolve "cert-expiry-$CERT_NAME" "Origin cert ($CERT_NAME) renewed"
+    fi
+done


### PR DESCRIPTION
## Why

On 2026-07-28 nginx on the explorer host was down for **9 hours** and no alert fired. Every site on the box served Cloudflare 521 the whole time.

`monitor.sh` was running fine every minute throughout. It stayed silent because every check it makes probes an app *directly on loopback*: pm2 processes, gqrl RPC on :8545, beacon on :3500, the frontend on :3000, the backend on :8082, mongo. All of those were genuinely healthy. Only the reverse proxy in front of them was dead, and nginx was not on the list.

Root cause of the outage itself: an `unattended-upgrades` restart ran `nginx -t` during a transient DNS failure on a proxied upstream hostname. The config test failed, nginx refused to start, and nothing ever retried it.

## What this adds

- **nginx service check**: `systemctl is-active nginx`, debounced 2 ticks like the other checks.
- **nginx TLS check**: probes `https://zondscan.com/` pinned to `127.0.0.1` via `--resolve`, so it tests our own vhost and origin cert rather than the Cloudflare edge. Catches "nginx is running but not actually serving".
- **Origin cert expiry**: warns at 30 days. The origin certs are long-lived with no renewal infra, so a silent expiry is a guaranteed future outage nobody is watching for. Opt-in via `MONITOR_SSL_DIR` so no deployment-specific path is baked into this public repo.

## Deployment note

`MONITOR_SSL_DIR` must be exported for the cert check to run; unset, that check is skipped and the rest still works.

## Known limitation

This monitor still runs on the box it watches, so by construction it cannot report a whole-host failure, and it could not have alerted here if the box had gone down entirely rather than just nginx. An independent external watchdog running off-box covers that case and is deployed separately.

## Testing

- `bash -n` clean.
- Deployed and run on the box: exits 0, all new checks evaluate correctly (`nginx is-active` -> active, TLS probe -> 200, 6 origin certs found and all valid).
- Alert and recovery lifecycle verified end to end against the Discord webhook (message delivery confirmed, HTTP 204).