### PR TITLE
release: promote monitoring and wallet authorization hardening

### DIFF
--- a/ExplorerFrontend/app/components/ConnectButton.tsx
+++ b/ExplorerFrontend/app/components/ConnectButton.tsx
@@ -1,8 +1,17 @@
-'use client';
+"use client";
 
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { QRCodeCanvas } from 'qrcode.react';
-import { getQrlConnect, ConnectionStatus, type QRLConnectProvider } from '../lib/qrlConnect';
+import { useCallback, useEffect, useRef, useState } from "react";
+import { QRCodeCanvas } from "qrcode.react";
+import {
+  getQrlConnect,
+  ConnectionStatus,
+  type QRLConnectProvider,
+} from "../lib/qrlConnect";
+import {
+  getRestorableWalletSession,
+  parseAuthorizedQrlAccount,
+  requestAuthorizedQrlAccount,
+} from "../lib/qrlAccounts";
 
 interface ConnectButtonProps {
   /** Called whenever the connected account changes (or null on disconnect). */
@@ -12,20 +21,20 @@ interface ConnectButtonProps {
 }
 
 const STATUS_LABEL: Record<ConnectionStatus, string> = {
-  [ConnectionStatus.DISCONNECTED]: 'Disconnected',
-  [ConnectionStatus.CONNECTING]: 'Connecting to relay…',
-  [ConnectionStatus.WAITING]: 'Waiting for wallet scan…',
-  [ConnectionStatus.KEY_EXCHANGE]: 'Exchanging keys…',
-  [ConnectionStatus.CONNECTED]: 'Connected',
-  [ConnectionStatus.RECONNECTING]: 'Reconnecting…',
+  [ConnectionStatus.DISCONNECTED]: "Disconnected",
+  [ConnectionStatus.CONNECTING]: "Connecting to relay…",
+  [ConnectionStatus.WAITING]: "Waiting for wallet scan…",
+  [ConnectionStatus.KEY_EXCHANGE]: "Exchanging keys…",
+  [ConnectionStatus.CONNECTED]: "Connected",
+  [ConnectionStatus.RECONNECTING]: "Reconnecting…",
 };
 
 /**
  * Pair-with-wallet button used by the Write contract tab. On click, opens a
  * modal with a QR code + deep-link URI from `@qrlwallet/connect`. After a
  * successful handshake the wallet's address is surfaced upward via
- * `onAccount`. Closing the modal doesn't disconnect, only the explicit
- * Disconnect button does.
+ * `onAccount`. Closing the modal keeps the session active. The explicit
+ * Disconnect button terminates it.
  *
  * The QRLConnect instance is a module-level singleton (see
  * lib/qrlConnect.ts) so multiple components sharing it don't double-announce
@@ -37,17 +46,16 @@ const STATUS_LABEL: Record<ConnectionStatus, string> = {
 // than calling setState() inside useEffect) satisfies the new
 // `react-hooks/set-state-in-effect` rule.
 function initialAccount(): string | null {
-  if (typeof window === 'undefined') return null;
+  if (typeof window === "undefined") return null;
   try {
-    const qrl = getQrlConnect();
-    if (qrl.hasStoredSession()) return qrl.getAccounts()[0] ?? null;
+    return getRestorableWalletSession(getQrlConnect()).account;
   } catch {
     // SSR / test environments without window.crypto etc.
   }
   return null;
 }
 function initialStatus(): ConnectionStatus {
-  if (typeof window === 'undefined') return ConnectionStatus.DISCONNECTED;
+  if (typeof window === "undefined") return ConnectionStatus.DISCONNECTED;
   try {
     const qrl = getQrlConnect();
     if (qrl.hasStoredSession()) return ConnectionStatus.RECONNECTING;
@@ -57,21 +65,24 @@ function initialStatus(): ConnectionStatus {
   return ConnectionStatus.DISCONNECTED;
 }
 
-export default function ConnectButton({ onAccount, onProvider }: ConnectButtonProps): JSX.Element {
+export default function ConnectButton({
+  onAccount,
+  onProvider,
+}: ConnectButtonProps): JSX.Element {
   const [open, setOpen] = useState(false);
   const [uri, setUri] = useState<string | null>(null);
   const [status, setStatus] = useState<ConnectionStatus>(initialStatus);
   const [account, setAccount] = useState<string | null>(initialAccount);
   const [error, setError] = useState<string | null>(null);
+  const [disconnecting, setDisconnecting] = useState(false);
   const providerRef = useRef<QRLConnectProvider | null>(null);
+  const authorizationRef = useRef<Promise<void> | null>(null);
 
-  // Event wire-up. Guarded by `providerRef.current` rather than the empty-
-  // deps array alone, because React 18 Strict Mode double-invokes effects
-  // in dev and we must not register listeners twice. All state writes
-  // happen inside event-emitter callbacks (never in the effect body), so
-  // this complies with `react-hooks/set-state-in-effect`.
+  // Event wire-up. React runs cleanup before reattaching this effect, including
+  // its development Strict Mode cycle, so each event has one active listener.
+  // State writes happen inside event-emitter callbacks.
   useEffect(() => {
-    if (providerRef.current) return;
+    let active = true;
     const qrl = getQrlConnect();
     providerRef.current = qrl;
     onProvider?.(qrl);
@@ -79,38 +90,95 @@ export default function ConnectButton({ onAccount, onProvider }: ConnectButtonPr
     // from the stored session via the useState initializer above.
     if (account) onAccount?.(account);
 
+    const authorizeAccount = () => {
+      if (authorizationRef.current) return;
+
+      const authorization = requestAuthorizedQrlAccount(qrl)
+        .then((next) => {
+          if (!active) return;
+          setAccount(next);
+          onAccount?.(next);
+          setError(null);
+          setOpen(false);
+          setUri(null);
+        })
+        .catch(async (e) => {
+          const authorizationError =
+            e instanceof Error
+              ? e.message
+              : "Wallet account authorization failed";
+          if (active) {
+            setAccount(null);
+            onAccount?.(null);
+            setError(authorizationError);
+            setUri(null);
+          }
+          try {
+            await qrl.disconnect();
+          } catch (retirementError) {
+            if (!active) return;
+            const detail =
+              retirementError instanceof Error
+                ? retirementError.message
+                : "relay channel retirement failed";
+            setError(
+              `${authorizationError}. The relay session is still active: ${detail}`,
+            );
+          }
+        })
+        .finally(() => {
+          authorizationRef.current = null;
+        });
+      authorizationRef.current = authorization;
+    };
     const onConnect = () => {
       setStatus(ConnectionStatus.CONNECTED);
-      const accounts = qrl.getAccounts();
-      const next = accounts[0] ?? null;
-      setAccount(next);
-      onAccount?.(next);
-      // Close the modal once we've got an account.
-      setOpen(false);
-      setUri(null);
+      void authorizeAccount();
     };
     const onAccountsChanged = (accounts: string[]) => {
-      const next = accounts[0] ?? null;
-      setAccount(next);
-      onAccount?.(next);
+      if (accounts.length === 0) {
+        setAccount(null);
+        onAccount?.(null);
+        return;
+      }
+      try {
+        const next = parseAuthorizedQrlAccount(accounts);
+        setAccount(next);
+        onAccount?.(next);
+        setError(null);
+      } catch (e) {
+        setAccount(null);
+        onAccount?.(null);
+        setError(
+          e instanceof Error ? e.message : "Wallet returned an invalid account",
+        );
+      }
     };
     const onDisconnect = () => {
+      const stored = getRestorableWalletSession(qrl);
+      if (stored.restorable) {
+        setStatus(ConnectionStatus.RECONNECTING);
+        setAccount(stored.account);
+        onAccount?.(stored.account);
+        return;
+      }
       setStatus(ConnectionStatus.DISCONNECTED);
       setAccount(null);
       onAccount?.(null);
     };
     const onStatusChanged = (s: ConnectionStatus) => setStatus(s);
 
-    qrl.on('connect', onConnect);
-    qrl.on('accountsChanged', onAccountsChanged);
-    qrl.on('disconnect', onDisconnect);
-    qrl.on('statusChanged', onStatusChanged);
+    qrl.on("connect", onConnect);
+    qrl.on("accountsChanged", onAccountsChanged);
+    qrl.on("disconnect", onDisconnect);
+    qrl.on("statusChanged", onStatusChanged);
 
     return () => {
-      qrl.off('connect', onConnect);
-      qrl.off('accountsChanged', onAccountsChanged);
-      qrl.off('disconnect', onDisconnect);
-      qrl.off('statusChanged', onStatusChanged);
+      active = false;
+      qrl.off("connect", onConnect);
+      qrl.off("accountsChanged", onAccountsChanged);
+      qrl.off("disconnect", onDisconnect);
+      qrl.off("statusChanged", onStatusChanged);
     };
     // `account` is read once at mount only, listing it would re-attach
     // listeners on every account change, which is wrong.
@@ -151,29 +219,53 @@ export default function ConnectButton({ onAccount, onProvider }: ConnectButtonPr
   const disconnect = useCallback(async () => {
     const qrl = providerRef.current;
     if (!qrl) return;
+    setError(null);
     try {
       await qrl.disconnect();
-    } catch {
-      // Best-effort; the local state will be cleared by the disconnect event.
+      setOpen(false);
+      setUri(null);
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : "Unable to retire the relay session",
+      );
     }
-    setOpen(false);
-    setUri(null);
   }, []);
+
+  const cancelPairing = useCallback(async () => {
+    const qrl = providerRef.current;
+    if (!qrl || disconnecting) return;
+    setError(null);
+    setDisconnecting(true);
+    try {
+      await qrl.disconnect();
+      setOpen(false);
+      setUri(null);
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : "Unable to retire the relay session",
+      );
+    } finally {
+      setDisconnecting(false);
+    }
+  }, [disconnecting]);
 
   if (account) {
     const short = `${account.slice(0, 8)}…${account.slice(-6)}`;
     return (
-      <div className="flex items-center gap-2 flex-wrap">
-        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-green-500/15 text-green-300 text-xs font-mono">
-          <span className="h-1.5 w-1.5 rounded-full bg-green-400" /> {short}
-        </span>
-        <button
-          type="button"
-          onClick={disconnect}
-          className="inline-flex items-center justify-center px-3 py-1.5 rounded-lg bg-card-gradient border border-border hover:border-accent text-xs text-text-secondary hover:text-accent transition-colors"
-        >
-          Disconnect
-        </button>
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-green-500/15 text-green-300 text-xs font-mono">
+            <span className="h-1.5 w-1.5 rounded-full bg-green-400" /> {short}
+          </span>
+          <button
+            type="button"
+            onClick={disconnect}
+            className="inline-flex items-center justify-center px-3 py-1.5 rounded-lg bg-card-gradient border border-border hover:border-accent text-xs text-text-secondary hover:text-accent transition-colors"
+          >
+            Disconnect
+          </button>
+        </div>
+        {error && <p className="text-xs text-red-300">{error}</p>}
       </div>
     );
   }
@@ -191,28 +283,32 @@ export default function ConnectButton({ onAccount, onProvider }: ConnectButtonPr
       {open && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
-          onClick={() => setOpen(false)}
+          onClick={() => void cancelPairing()}
           role="dialog"
           aria-modal="true"
         >
           <div
             className="max-w-sm w-full rounded-xl border border-border bg-card-gradient p-4 md:p-5 space-y-3"
-            onClick={e => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between">
-              <h3 className="text-sm md:text-base font-semibold text-text-primary">Pair MyQRLWallet</h3>
+              <h3 className="text-sm md:text-base font-semibold text-text-primary">
+                Pair MyQRLWallet
+              </h3>
               <button
                 type="button"
-                onClick={() => setOpen(false)}
+                onClick={() => void cancelPairing()}
+                disabled={disconnecting}
                 className="text-xs text-text-secondary hover:text-text-primary"
                 aria-label="Close"
               >
-                ✕
+                {disconnecting ? "Disconnecting…" : "✕"}
               </button>
             </div>
 
             <p className="text-xs text-text-secondary">
-              Scan the QR with MyQRLWallet (mobile) or tap the URI to deep-link if you&apos;re on a phone.
+              Scan the QR with MyQRLWallet (mobile) or tap the URI to deep-link
+              if you&apos;re on a phone.
             </p>
 
             <div className="flex justify-center">
@@ -228,11 +324,13 @@ export default function ConnectButton({ onAccount, onProvider }: ConnectButtonPr
             </div>
 
             <div className="text-[10px] text-text-muted font-mono break-all">
-              {uri ?? ''}
+              {uri ?? ""}
             </div>
 
             <div className="flex items-center justify-between text-xs">
-              <span className="text-text-secondary">{STATUS_LABEL[status]}</span>
+              <span className="text-text-secondary">
+                {STATUS_LABEL[status]}
+              </span>
               <button
                 type="button"
                 onClick={newConnection}

--- a/ExplorerFrontend/app/lib/qrlAccounts.ts
+++ b/ExplorerFrontend/app/lib/qrlAccounts.ts
@@ -1,0 +1,47 @@
+const CURRENT_QRL_ADDRESS = /^Q[0-9a-fA-F]{40}$/;
+
+interface WalletAccountProvider {
+  request(args: { method: string; params?: unknown[] }): Promise<unknown>;
+  getAccounts(): string[];
+  hasStoredSession(): boolean;
+}
+
+export interface RestorableWalletSession {
+  restorable: boolean;
+  account: string | null;
+}
+
+export function parseAuthorizedQrlAccount(accounts: unknown): string {
+  if (
+    !Array.isArray(accounts) ||
+    accounts.length !== 1 ||
+    typeof accounts[0] !== 'string' ||
+    !CURRENT_QRL_ADDRESS.test(accounts[0])
+  ) {
+    throw new Error('Wallet authorization must return exactly one current-format QRL address');
+  }
+  return accounts[0];
+}
+
+export async function requestAuthorizedQrlAccount(
+  provider: Pick<WalletAccountProvider, 'request'>,
+): Promise<string> {
+  const accounts = await provider.request({ method: 'qrl_requestAccounts' });
+  return parseAuthorizedQrlAccount(accounts);
+}
+
+export function getRestorableWalletSession(
+  provider: Pick<WalletAccountProvider, 'getAccounts' | 'hasStoredSession'>,
+): RestorableWalletSession {
+  try {
+    if (!provider.hasStoredSession()) return { restorable: false, account: null };
+  } catch {
+    return { restorable: false, account: null };
+  }
+
+  try {
+    return { restorable: true, account: parseAuthorizedQrlAccount(provider.getAccounts()) };
+  } catch {
+    return { restorable: true, account: null };
+  }
+}

--- a/ExplorerFrontend/app/lib/qrlConnect.test.ts
+++ b/ExplorerFrontend/app/lib/qrlConnect.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import {
+  getRestorableWalletSession,
+  parseAuthorizedQrlAccount,
+  requestAuthorizedQrlAccount,
+} from './qrlAccounts';
+
+const ACCOUNT = `Q${'a'.repeat(40)}`;
+
+describe('QRL Connect account authorization', () => {
+  it('requests account access through qrl_requestAccounts', async () => {
+    const request = jest.fn(async (_args: { method: string; params?: unknown[] }) => [ACCOUNT]);
+
+    await expect(requestAuthorizedQrlAccount({ request })).resolves.toBe(ACCOUNT);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith({ method: 'qrl_requestAccounts' });
+  });
+
+  it.each([
+    ['lowercase prefix', [`q${'a'.repeat(40)}`]],
+    ['0x prefix', [`0x${'a'.repeat(40)}`]],
+    ['short address', [`Q${'a'.repeat(39)}`]],
+    ['long address', [`Q${'a'.repeat(41)}`]],
+    ['non-hex address', [`Q${'z'.repeat(40)}`]],
+    ['multiple accounts', [ACCOUNT, `Q${'b'.repeat(40)}`]],
+    ['empty account list', []],
+    ['non-array response', ACCOUNT],
+  ])('rejects %s', (_label, accounts) => {
+    expect(() => parseAuthorizedQrlAccount(accounts)).toThrow(
+      'exactly one current-format QRL address',
+    );
+  });
+
+  it('preserves an authorized account while its stored session is restorable', () => {
+    expect(
+      getRestorableWalletSession({
+        hasStoredSession: () => true,
+        getAccounts: () => [ACCOUNT],
+      }),
+    ).toEqual({ restorable: true, account: ACCOUNT });
+  });
+
+  it('fails closed on a malformed account without discarding the restorable session', () => {
+    expect(
+      getRestorableWalletSession({
+        hasStoredSession: () => true,
+        getAccounts: () => [`q${'a'.repeat(40)}`],
+      }),
+    ).toEqual({ restorable: true, account: null });
+  });
+
+  it('marks a session non-restorable after explicit storage removal', () => {
+    expect(
+      getRestorableWalletSession({
+        hasStoredSession: () => false,
+        getAccounts: () => [ACCOUNT],
+      }),
+    ).toEqual({ restorable: false, account: null });
+  });
+});

--- a/ExplorerFrontend/package-lock.json
+++ b/ExplorerFrontend/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.90.16",
         "@tanstack/react-table": "^8.21.3",
         "@theqrl/wallet.js": "^6.2.3",
-        "@theqrl/web3": "^1.0.1",
+        "@theqrl/web3": "1.0.1",
         "@theqrl/web3-zond-abi": "^0.3.3",
         "@visx/axis": "4.0.1-alpha.0",
         "@visx/brush": "4.0.1-alpha.0",
@@ -4343,13 +4343,13 @@
       }
     },
     "node_modules/@theqrl/qrl-cryptography": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/qrl-cryptography/-/qrl-cryptography-0.3.0.tgz",
-      "integrity": "sha512-2d7QcK/ZQKOmphnj0lSRJLyeXO3o0degg0mjEMHH+5g4LXvrgoVV1i/bTqzS78DgGRB4Mn3kUPXg6QW3KO712w==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@theqrl/qrl-cryptography/-/qrl-cryptography-0.1.3.tgz",
+      "integrity": "sha512-rtgii8JB6W0Gk7jen2WZU6Iubl+mHKFUobGG6zzipippVxhbeA0Vb6SJ/Hi5IEbGr44KlY4sBZMjWEBLaSEQpw==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.2.0",
-        "@theqrl/mldsa87": "2.1.3"
+        "@noble/hashes": "^2.2.0",
+        "@theqrl/mldsa87": "2.0.4"
       },
       "engines": {
         "node": ">=20.19"
@@ -4359,6 +4359,30 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
       "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@theqrl/qrl-cryptography/node_modules/@theqrl/mldsa87": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.4.tgz",
+      "integrity": "sha512-xUcrFSZ1OeRSyzU5xCd/TuB+dE/z7U9MafNtKZYmPhRwcucNbhobsXHab8GO5w02dy732sdPidOT2Tkn+vjZuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@theqrl/qrl-cryptography/node_modules/@theqrl/mldsa87/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -4393,102 +4417,102 @@
       }
     },
     "node_modules/@theqrl/web3": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-1.0.3.tgz",
-      "integrity": "sha512-AO/BeNtU/l7//87xAFYtrM/GFdV99DwVqGSqTzw38+WQpplBr3dURmd/ixXVHMsYEuEy+ewCR1h/IqypKeR6Lg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-1.0.1.tgz",
+      "integrity": "sha512-ykqJFoYhl83RsiD4QdMUsjHGMTi1DlJm70MjSJamtisfuE1T6WDgDoXohPHR8NL3sStn1os/4+cUAPiOu7sWRw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "1.0.3",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-net": "1.0.3",
-        "@theqrl/web3-providers-http": "1.0.3",
-        "@theqrl/web3-providers-ws": "1.0.3",
-        "@theqrl/web3-qrl": "1.0.3",
-        "@theqrl/web3-qrl-abi": "1.0.3",
-        "@theqrl/web3-qrl-accounts": "1.0.3",
-        "@theqrl/web3-qrl-contract": "1.0.3",
-        "@theqrl/web3-qrl-iban": "1.0.3",
-        "@theqrl/web3-qrl-qrns": "1.0.3",
-        "@theqrl/web3-rpc-methods": "1.0.3",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-utils": "1.0.3",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/web3-core": "1.0.1",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-net": "1.0.1",
+        "@theqrl/web3-providers-http": "1.0.1",
+        "@theqrl/web3-providers-ws": "1.0.1",
+        "@theqrl/web3-qrl": "1.0.1",
+        "@theqrl/web3-qrl-abi": "1.0.1",
+        "@theqrl/web3-qrl-accounts": "1.0.1",
+        "@theqrl/web3-qrl-contract": "1.0.1",
+        "@theqrl/web3-qrl-iban": "1.0.1",
+        "@theqrl/web3-qrl-qrns": "1.0.1",
+        "@theqrl/web3-rpc-methods": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-core": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-1.0.3.tgz",
-      "integrity": "sha512-s8PUFBBC/f/HxYUxKz6Xju38tfUZ3GBlzwPS5bdyxipwEzhgfh8BZgrROZ2ZrRL1HowZI7OblY7oN9FQw6EWLQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-1.0.1.tgz",
+      "integrity": "sha512-oiT+RlEIMTDSYSpPp0i80T55vmuoBXbkGaVao338+6jlemO3zW0NYmnkqrNqxkMk1HO4cePnPCUxFvMj9h9QMg==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-providers-http": "1.0.3",
-        "@theqrl/web3-providers-ws": "1.0.3",
-        "@theqrl/web3-qrl-iban": "1.0.3",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-utils": "1.0.3",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-providers-http": "1.0.1",
+        "@theqrl/web3-providers-ws": "1.0.1",
+        "@theqrl/web3-qrl-iban": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       },
       "optionalDependencies": {
-        "@theqrl/web3-providers-ipc": "1.0.3"
+        "@theqrl/web3-providers-ipc": "1.0.1"
       }
     },
     "node_modules/@theqrl/web3-core/node_modules/@theqrl/web3-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.2.tgz",
-      "integrity": "sha512-UwUPXAbA5+Z+OtKEknZJnCCssnohriycMuVaWnboBRQPLv4hHrFWnubOLJi6D3+xGlCk3TCbMlm2SiuZumbq8A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.1.tgz",
+      "integrity": "sha512-aAirwyS84SA8e4LYkpJ4BF1mut4jSrIt1HksveTmKHZgojJr4y/D/o4bP4w+MgBMymrmdXRzZUJHhk1N3pRktQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "1.0.2"
+        "@theqrl/web3-types": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-core/node_modules/@theqrl/web3-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.2.tgz",
-      "integrity": "sha512-Coz6+BuNPbgR34hbVwxnLEETvD3PSYCRQKQ4kolIPDczk8mDEYIwa7TyCegRcklbrH9Hc765l4BMsDZI0QsmDQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.1.tgz",
+      "integrity": "sha512-uc+HBs7nMQjM7eD+39Gz/lDQ/1+o98y5xAaPApSvDYfcpDobMW+uV+LrMgBgak0y//OO0w0gtzzd7ohEk7OJmA==",
       "license": "LGPL-3.0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-core/node_modules/@theqrl/web3-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.3.tgz",
-      "integrity": "sha512-ChCz/HUqUIP7XFivTIYpzZLqEow0FcIOGvZ/ayiyXLjneOdXhd2ylyqUy8eb/494FYDj7KujfPUPe3OUgt4gFQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.1.tgz",
+      "integrity": "sha512-X5H3RIWu3fUXkBz3B6T5pJlGnyUbh414I1HpQ9zUKj/ZZ8Z+EMgO/UMHWSblDRgeucI8DFFjIFGVSuD2ChB5mA==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-core/node_modules/@theqrl/web3-validator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.3.tgz",
-      "integrity": "sha512-O5VaGMf9z/Zy4kH9nqnwVcGoVnXiIXW81YzG9RUY0S9IURtp9+bdCiPiOo8KVJHUXpgubIvEWXeLLAqO6+kvjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.1.tgz",
+      "integrity": "sha512-uwzArtbrk9/JByyPph/ZPeuYs8f5jp8TtXU8BN5yTMOO+WpGDYpqMiaUshLzQdslpUC5vlQqlTW0+3oac1DYxQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
         "util": "0.12.5",
         "zod": "3.22.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-core/node_modules/zod": {
@@ -4514,70 +4538,70 @@
       }
     },
     "node_modules/@theqrl/web3-net": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-1.0.3.tgz",
-      "integrity": "sha512-KRn3mBoRy45Kl9vgzTyeg0TWOxuiGmW2KQE5dI3fCyYfrnQroBNXiw7wlRwZM3DNofZFCzdt1CIbkOlE/iOnRA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-1.0.1.tgz",
+      "integrity": "sha512-F+DDxtqRf1DnD8B6rLRn/L0NJslaF71CcexWBOmeDVlhiUJ2bL2Jd497QZGcya96atobqa/RUGcBxIrjerA29Q==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "1.0.3",
-        "@theqrl/web3-rpc-methods": "1.0.3",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-utils": "1.0.3"
+        "@theqrl/web3-core": "1.0.1",
+        "@theqrl/web3-rpc-methods": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-net/node_modules/@theqrl/web3-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.2.tgz",
-      "integrity": "sha512-UwUPXAbA5+Z+OtKEknZJnCCssnohriycMuVaWnboBRQPLv4hHrFWnubOLJi6D3+xGlCk3TCbMlm2SiuZumbq8A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.1.tgz",
+      "integrity": "sha512-aAirwyS84SA8e4LYkpJ4BF1mut4jSrIt1HksveTmKHZgojJr4y/D/o4bP4w+MgBMymrmdXRzZUJHhk1N3pRktQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "1.0.2"
+        "@theqrl/web3-types": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-net/node_modules/@theqrl/web3-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.2.tgz",
-      "integrity": "sha512-Coz6+BuNPbgR34hbVwxnLEETvD3PSYCRQKQ4kolIPDczk8mDEYIwa7TyCegRcklbrH9Hc765l4BMsDZI0QsmDQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.1.tgz",
+      "integrity": "sha512-uc+HBs7nMQjM7eD+39Gz/lDQ/1+o98y5xAaPApSvDYfcpDobMW+uV+LrMgBgak0y//OO0w0gtzzd7ohEk7OJmA==",
       "license": "LGPL-3.0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-net/node_modules/@theqrl/web3-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.3.tgz",
-      "integrity": "sha512-ChCz/HUqUIP7XFivTIYpzZLqEow0FcIOGvZ/ayiyXLjneOdXhd2ylyqUy8eb/494FYDj7KujfPUPe3OUgt4gFQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.1.tgz",
+      "integrity": "sha512-X5H3RIWu3fUXkBz3B6T5pJlGnyUbh414I1HpQ9zUKj/ZZ8Z+EMgO/UMHWSblDRgeucI8DFFjIFGVSuD2ChB5mA==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-net/node_modules/@theqrl/web3-validator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.3.tgz",
-      "integrity": "sha512-O5VaGMf9z/Zy4kH9nqnwVcGoVnXiIXW81YzG9RUY0S9IURtp9+bdCiPiOo8KVJHUXpgubIvEWXeLLAqO6+kvjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.1.tgz",
+      "integrity": "sha512-uwzArtbrk9/JByyPph/ZPeuYs8f5jp8TtXU8BN5yTMOO+WpGDYpqMiaUshLzQdslpUC5vlQqlTW0+3oac1DYxQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
         "util": "0.12.5",
         "zod": "3.22.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-net/node_modules/zod": {
@@ -4590,70 +4614,70 @@
       }
     },
     "node_modules/@theqrl/web3-providers-http": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-1.0.3.tgz",
-      "integrity": "sha512-dFDqpOFft8vhxLZ9omZ8qDiLqkHcaKo0HvI8IX8lhFxuXsxRa28NracYn2MjxTR3p45oqrc9VbK3BJ2aHG5PxA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-1.0.1.tgz",
+      "integrity": "sha512-XhhvPROFEoeVSOyXXxM+kP0fe/M31LpOOwtbeKcc+1VfEdfy1CqFrdAK0VkFT9aXu58Kc96cFJPA1FcQyID1ew==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-utils": "1.0.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
         "cross-fetch": "4.1.0"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-http/node_modules/@theqrl/web3-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.2.tgz",
-      "integrity": "sha512-UwUPXAbA5+Z+OtKEknZJnCCssnohriycMuVaWnboBRQPLv4hHrFWnubOLJi6D3+xGlCk3TCbMlm2SiuZumbq8A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.1.tgz",
+      "integrity": "sha512-aAirwyS84SA8e4LYkpJ4BF1mut4jSrIt1HksveTmKHZgojJr4y/D/o4bP4w+MgBMymrmdXRzZUJHhk1N3pRktQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "1.0.2"
+        "@theqrl/web3-types": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-http/node_modules/@theqrl/web3-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.2.tgz",
-      "integrity": "sha512-Coz6+BuNPbgR34hbVwxnLEETvD3PSYCRQKQ4kolIPDczk8mDEYIwa7TyCegRcklbrH9Hc765l4BMsDZI0QsmDQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.1.tgz",
+      "integrity": "sha512-uc+HBs7nMQjM7eD+39Gz/lDQ/1+o98y5xAaPApSvDYfcpDobMW+uV+LrMgBgak0y//OO0w0gtzzd7ohEk7OJmA==",
       "license": "LGPL-3.0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-http/node_modules/@theqrl/web3-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.3.tgz",
-      "integrity": "sha512-ChCz/HUqUIP7XFivTIYpzZLqEow0FcIOGvZ/ayiyXLjneOdXhd2ylyqUy8eb/494FYDj7KujfPUPe3OUgt4gFQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.1.tgz",
+      "integrity": "sha512-X5H3RIWu3fUXkBz3B6T5pJlGnyUbh414I1HpQ9zUKj/ZZ8Z+EMgO/UMHWSblDRgeucI8DFFjIFGVSuD2ChB5mA==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-http/node_modules/@theqrl/web3-validator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.3.tgz",
-      "integrity": "sha512-O5VaGMf9z/Zy4kH9nqnwVcGoVnXiIXW81YzG9RUY0S9IURtp9+bdCiPiOo8KVJHUXpgubIvEWXeLLAqO6+kvjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.1.tgz",
+      "integrity": "sha512-uwzArtbrk9/JByyPph/ZPeuYs8f5jp8TtXU8BN5yTMOO+WpGDYpqMiaUshLzQdslpUC5vlQqlTW0+3oac1DYxQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
         "util": "0.12.5",
         "zod": "3.22.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-http/node_modules/zod": {
@@ -4666,74 +4690,74 @@
       }
     },
     "node_modules/@theqrl/web3-providers-ipc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-1.0.3.tgz",
-      "integrity": "sha512-ALqjX/8iB9SgAnCihZvOCjIS4efyEpthZ/72ZjOza4TX8HNx8n88vVXO9fBF0JOZSJDxq8EFcPyVqoa8HqKJmg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-1.0.1.tgz",
+      "integrity": "sha512-rbsWTbM+nWXljibMFESXYqZ3v6vk8QL6KYjMb75WGPShjur8s3fhkTDbttJ1GaFJNzguJ7pmCNitnJPBQFTFig==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-utils": "1.0.3"
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ipc/node_modules/@theqrl/web3-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.2.tgz",
-      "integrity": "sha512-UwUPXAbA5+Z+OtKEknZJnCCssnohriycMuVaWnboBRQPLv4hHrFWnubOLJi6D3+xGlCk3TCbMlm2SiuZumbq8A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.1.tgz",
+      "integrity": "sha512-aAirwyS84SA8e4LYkpJ4BF1mut4jSrIt1HksveTmKHZgojJr4y/D/o4bP4w+MgBMymrmdXRzZUJHhk1N3pRktQ==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
-        "@theqrl/web3-types": "1.0.2"
+        "@theqrl/web3-types": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ipc/node_modules/@theqrl/web3-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.2.tgz",
-      "integrity": "sha512-Coz6+BuNPbgR34hbVwxnLEETvD3PSYCRQKQ4kolIPDczk8mDEYIwa7TyCegRcklbrH9Hc765l4BMsDZI0QsmDQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.1.tgz",
+      "integrity": "sha512-uc+HBs7nMQjM7eD+39Gz/lDQ/1+o98y5xAaPApSvDYfcpDobMW+uV+LrMgBgak0y//OO0w0gtzzd7ohEk7OJmA==",
       "license": "LGPL-3.0",
       "optional": true,
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ipc/node_modules/@theqrl/web3-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.3.tgz",
-      "integrity": "sha512-ChCz/HUqUIP7XFivTIYpzZLqEow0FcIOGvZ/ayiyXLjneOdXhd2ylyqUy8eb/494FYDj7KujfPUPe3OUgt4gFQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.1.tgz",
+      "integrity": "sha512-X5H3RIWu3fUXkBz3B6T5pJlGnyUbh414I1HpQ9zUKj/ZZ8Z+EMgO/UMHWSblDRgeucI8DFFjIFGVSuD2ChB5mA==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ipc/node_modules/@theqrl/web3-validator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.3.tgz",
-      "integrity": "sha512-O5VaGMf9z/Zy4kH9nqnwVcGoVnXiIXW81YzG9RUY0S9IURtp9+bdCiPiOo8KVJHUXpgubIvEWXeLLAqO6+kvjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.1.tgz",
+      "integrity": "sha512-uwzArtbrk9/JByyPph/ZPeuYs8f5jp8TtXU8BN5yTMOO+WpGDYpqMiaUshLzQdslpUC5vlQqlTW0+3oac1DYxQ==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
         "util": "0.12.5",
         "zod": "3.22.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ipc/node_modules/zod": {
@@ -4747,72 +4771,72 @@
       }
     },
     "node_modules/@theqrl/web3-providers-ws": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-1.0.3.tgz",
-      "integrity": "sha512-kFYTTbpuRZpRw+i/+EKHXHZgvj3xC64tQZjNeU+1+S3qW9rZNy5i8gJxZAPzOkRwMYncbS3wv5KRxkbDh/KEGw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-1.0.1.tgz",
+      "integrity": "sha512-2k+LYAmK6F93Ydh4EBaQ+LGsyQKiCqgiMT6WimV/j0GYxaXfZQoBabvg8dkVtMPLZOXEcUkqPGSs+6DfHNvPdQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-utils": "1.0.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
         "@types/ws": "8.18.1",
         "isomorphic-ws": "5.0.0",
         "ws": "8.21.0"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ws/node_modules/@theqrl/web3-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.2.tgz",
-      "integrity": "sha512-UwUPXAbA5+Z+OtKEknZJnCCssnohriycMuVaWnboBRQPLv4hHrFWnubOLJi6D3+xGlCk3TCbMlm2SiuZumbq8A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.1.tgz",
+      "integrity": "sha512-aAirwyS84SA8e4LYkpJ4BF1mut4jSrIt1HksveTmKHZgojJr4y/D/o4bP4w+MgBMymrmdXRzZUJHhk1N3pRktQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "1.0.2"
+        "@theqrl/web3-types": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ws/node_modules/@theqrl/web3-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.2.tgz",
-      "integrity": "sha512-Coz6+BuNPbgR34hbVwxnLEETvD3PSYCRQKQ4kolIPDczk8mDEYIwa7TyCegRcklbrH9Hc765l4BMsDZI0QsmDQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.1.tgz",
+      "integrity": "sha512-uc+HBs7nMQjM7eD+39Gz/lDQ/1+o98y5xAaPApSvDYfcpDobMW+uV+LrMgBgak0y//OO0w0gtzzd7ohEk7OJmA==",
       "license": "LGPL-3.0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ws/node_modules/@theqrl/web3-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.3.tgz",
-      "integrity": "sha512-ChCz/HUqUIP7XFivTIYpzZLqEow0FcIOGvZ/ayiyXLjneOdXhd2ylyqUy8eb/494FYDj7KujfPUPe3OUgt4gFQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.1.tgz",
+      "integrity": "sha512-X5H3RIWu3fUXkBz3B6T5pJlGnyUbh414I1HpQ9zUKj/ZZ8Z+EMgO/UMHWSblDRgeucI8DFFjIFGVSuD2ChB5mA==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ws/node_modules/@theqrl/web3-validator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.3.tgz",
-      "integrity": "sha512-O5VaGMf9z/Zy4kH9nqnwVcGoVnXiIXW81YzG9RUY0S9IURtp9+bdCiPiOo8KVJHUXpgubIvEWXeLLAqO6+kvjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.1.tgz",
+      "integrity": "sha512-uwzArtbrk9/JByyPph/ZPeuYs8f5jp8TtXU8BN5yTMOO+WpGDYpqMiaUshLzQdslpUC5vlQqlTW0+3oac1DYxQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
         "util": "0.12.5",
         "zod": "3.22.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-providers-ws/node_modules/zod": {
@@ -4825,115 +4849,153 @@
       }
     },
     "node_modules/@theqrl/web3-qrl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl/-/web3-qrl-1.0.3.tgz",
-      "integrity": "sha512-t1wG9jfrzKGIlPS7YDNiR/HzR52R5tpf/Q/+BEaO19rZFS0dD371Q2zmL43W/4qsfxiIXif9A6oD+nDqh54+oA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl/-/web3-qrl-1.0.1.tgz",
+      "integrity": "sha512-9pEYoxJ1hs76D0rWrFdCKNV+teu6VtKLo3ELt0u/5E3T7p+i6PmFy1SAwTftlT6RePmnj01ohI5w8jF/JIAZrg==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/wallet.js": "6.2.3",
-        "@theqrl/web3-core": "1.0.3",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-net": "1.0.3",
-        "@theqrl/web3-providers-ws": "1.0.3",
-        "@theqrl/web3-qrl-abi": "1.0.3",
-        "@theqrl/web3-qrl-accounts": "1.0.3",
-        "@theqrl/web3-rpc-methods": "1.0.3",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-utils": "1.0.3",
-        "@theqrl/web3-validator": "1.0.3",
+        "@theqrl/wallet.js": "2.0.2",
+        "@theqrl/web3-core": "1.0.1",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-net": "1.0.1",
+        "@theqrl/web3-providers-ws": "1.0.1",
+        "@theqrl/web3-qrl-abi": "1.0.1",
+        "@theqrl/web3-qrl-accounts": "1.0.1",
+        "@theqrl/web3-rpc-methods": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1",
         "setimmediate": "1.0.5"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-abi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-abi/-/web3-qrl-abi-1.0.3.tgz",
-      "integrity": "sha512-thtgZLMVnfoukBfp8/n8QP/DgIZJhfR4G3w0Wm2KHVP+l2zjylkjnup0ZKxjDcDKTHPr+8q+B+50OttHAt1v2w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-abi/-/web3-qrl-abi-1.0.1.tgz",
+      "integrity": "sha512-i+vZ9Rtoz0lfDa/fJm/XxkLr76WyXJWkNx7VoVrZYDzzoSnCuouKOVVSVRSy/5bm1a6XHtMelfv/v3CYQX39jQ==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@ethersproject/bignumber": "5.8.0",
-        "@theqrl/abi": "1.0.3",
-        "@theqrl/wallet.js": "6.2.3",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-utils": "1.0.3",
-        "@theqrl/web3-validator": "1.0.3",
-        "crc-32": "1.2.2"
+        "@theqrl/abi": "1.0.1",
+        "@theqrl/wallet.js": "2.0.2",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1",
+        "crc-32": "1.2.2",
+        "sha3": "2.1.4"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-abi/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@theqrl/web3-qrl-abi/node_modules/@theqrl/abi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-1.0.3.tgz",
-      "integrity": "sha512-Pd+1jtkSXVETIow3ZjKJhcMJswOfs0dyhJyys45PXNaVx0K3GzY27cVwuBe9EAD5di5eQ9uaVJZjbiZIRkg4IA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-1.0.1.tgz",
+      "integrity": "sha512-QvM+8QCSw8OSo/WpevJlkwytEdnDK99QpCm7cmyVMDjLgNnMpO7id9Tgj901WELdzGq/rWLEJCDevUGJF3m+YQ==",
       "license": "MIT",
       "dependencies": {
+        "@ethersproject/address": "5.8.0",
         "@ethersproject/bignumber": "5.8.0",
         "@ethersproject/bytes": "5.8.0",
         "@ethersproject/constants": "5.8.0",
+        "@ethersproject/hash": "5.8.0",
+        "@ethersproject/keccak256": "5.8.0",
         "@ethersproject/logger": "5.8.0",
         "@ethersproject/properties": "5.8.0",
         "@ethersproject/strings": "5.8.0",
-        "@theqrl/web3-utils": "1.0.3"
+        "@theqrl/web3-utils": "1.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-abi/node_modules/@theqrl/mldsa87": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.1.tgz",
+      "integrity": "sha512-BPEvwrrphkMjyPnDorMzQdfrtICTZsiUxiBnwFkv2SfIcQwTTPQV3kTVfidZXXE7033ZCvhu1u5Aiw6TrjxPPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
       },
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-abi/node_modules/@theqrl/wallet.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-2.0.2.tgz",
+      "integrity": "sha512-gqmPE1D7qk2d6Qir0/iZeRGGr2eAVjps9Zql0P4pIw/uBjs81FBYio90c+RawkuKyc2WjlOLF6l3VI02z/rMSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1",
+        "@theqrl/mldsa87": "2.0.1"
       }
     },
     "node_modules/@theqrl/web3-qrl-abi/node_modules/@theqrl/web3-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.2.tgz",
-      "integrity": "sha512-UwUPXAbA5+Z+OtKEknZJnCCssnohriycMuVaWnboBRQPLv4hHrFWnubOLJi6D3+xGlCk3TCbMlm2SiuZumbq8A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.1.tgz",
+      "integrity": "sha512-aAirwyS84SA8e4LYkpJ4BF1mut4jSrIt1HksveTmKHZgojJr4y/D/o4bP4w+MgBMymrmdXRzZUJHhk1N3pRktQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "1.0.2"
+        "@theqrl/web3-types": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-abi/node_modules/@theqrl/web3-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.2.tgz",
-      "integrity": "sha512-Coz6+BuNPbgR34hbVwxnLEETvD3PSYCRQKQ4kolIPDczk8mDEYIwa7TyCegRcklbrH9Hc765l4BMsDZI0QsmDQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.1.tgz",
+      "integrity": "sha512-uc+HBs7nMQjM7eD+39Gz/lDQ/1+o98y5xAaPApSvDYfcpDobMW+uV+LrMgBgak0y//OO0w0gtzzd7ohEk7OJmA==",
       "license": "LGPL-3.0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-abi/node_modules/@theqrl/web3-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.3.tgz",
-      "integrity": "sha512-ChCz/HUqUIP7XFivTIYpzZLqEow0FcIOGvZ/ayiyXLjneOdXhd2ylyqUy8eb/494FYDj7KujfPUPe3OUgt4gFQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.1.tgz",
+      "integrity": "sha512-X5H3RIWu3fUXkBz3B6T5pJlGnyUbh414I1HpQ9zUKj/ZZ8Z+EMgO/UMHWSblDRgeucI8DFFjIFGVSuD2ChB5mA==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-abi/node_modules/@theqrl/web3-validator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.3.tgz",
-      "integrity": "sha512-O5VaGMf9z/Zy4kH9nqnwVcGoVnXiIXW81YzG9RUY0S9IURtp9+bdCiPiOo8KVJHUXpgubIvEWXeLLAqO6+kvjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.1.tgz",
+      "integrity": "sha512-uwzArtbrk9/JByyPph/ZPeuYs8f5jp8TtXU8BN5yTMOO+WpGDYpqMiaUshLzQdslpUC5vlQqlTW0+3oac1DYxQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
         "util": "0.12.5",
         "zod": "3.22.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-abi/node_modules/zod": {
@@ -4946,75 +5008,122 @@
       }
     },
     "node_modules/@theqrl/web3-qrl-accounts": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-accounts/-/web3-qrl-accounts-1.0.3.tgz",
-      "integrity": "sha512-LhnI2GKczPPImsdKDv8Cx0sQAMnBK89FrA9oIe2XB+rVizlzG5TRwNZbN+QuoKhhpkWzk3bKpb2UUXM/1Zm0rA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-accounts/-/web3-qrl-accounts-1.0.1.tgz",
+      "integrity": "sha512-A+07dRhMynD0xCbJI5/M/TAxbhgpaJV9m2VjtZXqq4SG78TOICqveJ7cSaz7rkS1aQFTtKKaVqkR0EES34jkxA==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@ethereumjs/rlp": "10.1.1",
-        "@theqrl/mldsa87": "2.1.3",
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/wallet.js": "6.2.3",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-utils": "1.0.3",
-        "@theqrl/web3-validator": "1.0.3",
-        "crc-32": "1.2.2"
+        "@theqrl/mldsa87": "2.0.4",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/wallet.js": "2.0.2",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1",
+        "crc-32": "1.2.2",
+        "sha3": "2.1.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-accounts/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-accounts/node_modules/@theqrl/mldsa87": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.4.tgz",
+      "integrity": "sha512-xUcrFSZ1OeRSyzU5xCd/TuB+dE/z7U9MafNtKZYmPhRwcucNbhobsXHab8GO5w02dy732sdPidOT2Tkn+vjZuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-accounts/node_modules/@theqrl/wallet.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-2.0.2.tgz",
+      "integrity": "sha512-gqmPE1D7qk2d6Qir0/iZeRGGr2eAVjps9Zql0P4pIw/uBjs81FBYio90c+RawkuKyc2WjlOLF6l3VI02z/rMSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1",
+        "@theqrl/mldsa87": "2.0.1"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-accounts/node_modules/@theqrl/wallet.js/node_modules/@theqrl/mldsa87": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.1.tgz",
+      "integrity": "sha512-BPEvwrrphkMjyPnDorMzQdfrtICTZsiUxiBnwFkv2SfIcQwTTPQV3kTVfidZXXE7033ZCvhu1u5Aiw6TrjxPPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
       },
       "engines": {
         "node": ">=20.19.0"
       }
     },
     "node_modules/@theqrl/web3-qrl-accounts/node_modules/@theqrl/web3-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.2.tgz",
-      "integrity": "sha512-UwUPXAbA5+Z+OtKEknZJnCCssnohriycMuVaWnboBRQPLv4hHrFWnubOLJi6D3+xGlCk3TCbMlm2SiuZumbq8A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.1.tgz",
+      "integrity": "sha512-aAirwyS84SA8e4LYkpJ4BF1mut4jSrIt1HksveTmKHZgojJr4y/D/o4bP4w+MgBMymrmdXRzZUJHhk1N3pRktQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "1.0.2"
+        "@theqrl/web3-types": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-accounts/node_modules/@theqrl/web3-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.2.tgz",
-      "integrity": "sha512-Coz6+BuNPbgR34hbVwxnLEETvD3PSYCRQKQ4kolIPDczk8mDEYIwa7TyCegRcklbrH9Hc765l4BMsDZI0QsmDQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.1.tgz",
+      "integrity": "sha512-uc+HBs7nMQjM7eD+39Gz/lDQ/1+o98y5xAaPApSvDYfcpDobMW+uV+LrMgBgak0y//OO0w0gtzzd7ohEk7OJmA==",
       "license": "LGPL-3.0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-accounts/node_modules/@theqrl/web3-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.3.tgz",
-      "integrity": "sha512-ChCz/HUqUIP7XFivTIYpzZLqEow0FcIOGvZ/ayiyXLjneOdXhd2ylyqUy8eb/494FYDj7KujfPUPe3OUgt4gFQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.1.tgz",
+      "integrity": "sha512-X5H3RIWu3fUXkBz3B6T5pJlGnyUbh414I1HpQ9zUKj/ZZ8Z+EMgO/UMHWSblDRgeucI8DFFjIFGVSuD2ChB5mA==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-accounts/node_modules/@theqrl/web3-validator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.3.tgz",
-      "integrity": "sha512-O5VaGMf9z/Zy4kH9nqnwVcGoVnXiIXW81YzG9RUY0S9IURtp9+bdCiPiOo8KVJHUXpgubIvEWXeLLAqO6+kvjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.1.tgz",
+      "integrity": "sha512-uwzArtbrk9/JByyPph/ZPeuYs8f5jp8TtXU8BN5yTMOO+WpGDYpqMiaUshLzQdslpUC5vlQqlTW0+3oac1DYxQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
         "util": "0.12.5",
         "zod": "3.22.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-accounts/node_modules/zod": {
@@ -5027,73 +5136,73 @@
       }
     },
     "node_modules/@theqrl/web3-qrl-contract": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-contract/-/web3-qrl-contract-1.0.3.tgz",
-      "integrity": "sha512-iLH1PbWQpPuMaDKVYhc0Bmu47C+T2TFkolsuTaIhwNy98a0gMq/qUfeIZpMADVH/O+IkYxTpZ349u0KiMiqjMA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-contract/-/web3-qrl-contract-1.0.1.tgz",
+      "integrity": "sha512-9Pv/5l2IsXg9BgUJgHeMQ5m9WgxRB/zsqHBwtBHD7aiK3f/bEQH7wKq2lkFLg9c8GbzulmUIbMDAjEy0waUVOw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "1.0.3",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-qrl": "1.0.3",
-        "@theqrl/web3-qrl-abi": "1.0.3",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-utils": "1.0.3",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/web3-core": "1.0.1",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-qrl": "1.0.1",
+        "@theqrl/web3-qrl-abi": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-contract/node_modules/@theqrl/web3-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.2.tgz",
-      "integrity": "sha512-UwUPXAbA5+Z+OtKEknZJnCCssnohriycMuVaWnboBRQPLv4hHrFWnubOLJi6D3+xGlCk3TCbMlm2SiuZumbq8A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.1.tgz",
+      "integrity": "sha512-aAirwyS84SA8e4LYkpJ4BF1mut4jSrIt1HksveTmKHZgojJr4y/D/o4bP4w+MgBMymrmdXRzZUJHhk1N3pRktQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "1.0.2"
+        "@theqrl/web3-types": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-contract/node_modules/@theqrl/web3-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.2.tgz",
-      "integrity": "sha512-Coz6+BuNPbgR34hbVwxnLEETvD3PSYCRQKQ4kolIPDczk8mDEYIwa7TyCegRcklbrH9Hc765l4BMsDZI0QsmDQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.1.tgz",
+      "integrity": "sha512-uc+HBs7nMQjM7eD+39Gz/lDQ/1+o98y5xAaPApSvDYfcpDobMW+uV+LrMgBgak0y//OO0w0gtzzd7ohEk7OJmA==",
       "license": "LGPL-3.0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-contract/node_modules/@theqrl/web3-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.3.tgz",
-      "integrity": "sha512-ChCz/HUqUIP7XFivTIYpzZLqEow0FcIOGvZ/ayiyXLjneOdXhd2ylyqUy8eb/494FYDj7KujfPUPe3OUgt4gFQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.1.tgz",
+      "integrity": "sha512-X5H3RIWu3fUXkBz3B6T5pJlGnyUbh414I1HpQ9zUKj/ZZ8Z+EMgO/UMHWSblDRgeucI8DFFjIFGVSuD2ChB5mA==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-contract/node_modules/@theqrl/web3-validator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.3.tgz",
-      "integrity": "sha512-O5VaGMf9z/Zy4kH9nqnwVcGoVnXiIXW81YzG9RUY0S9IURtp9+bdCiPiOo8KVJHUXpgubIvEWXeLLAqO6+kvjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.1.tgz",
+      "integrity": "sha512-uwzArtbrk9/JByyPph/ZPeuYs8f5jp8TtXU8BN5yTMOO+WpGDYpqMiaUshLzQdslpUC5vlQqlTW0+3oac1DYxQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
         "util": "0.12.5",
         "zod": "3.22.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-contract/node_modules/zod": {
@@ -5106,70 +5215,70 @@
       }
     },
     "node_modules/@theqrl/web3-qrl-iban": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-iban/-/web3-qrl-iban-1.0.3.tgz",
-      "integrity": "sha512-WstKSRoGHnoSifHxmQQXPAmTqN94mWSdEX9VRPtNyKOMRiMAGGn+vYzvCnyKzCdGUYQLJilj2VxlU1J5F/Qdpw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-iban/-/web3-qrl-iban-1.0.1.tgz",
+      "integrity": "sha512-Ag+I8OfL6m8mDMjd3/TH0jdi0e0/77n4ecDCRp1yeQw6d1EbIgL3ACkLdOO+xSgu6Ho1c6ebP54vMHvjxSAiSw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-utils": "1.0.3",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-iban/node_modules/@theqrl/web3-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.2.tgz",
-      "integrity": "sha512-UwUPXAbA5+Z+OtKEknZJnCCssnohriycMuVaWnboBRQPLv4hHrFWnubOLJi6D3+xGlCk3TCbMlm2SiuZumbq8A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.1.tgz",
+      "integrity": "sha512-aAirwyS84SA8e4LYkpJ4BF1mut4jSrIt1HksveTmKHZgojJr4y/D/o4bP4w+MgBMymrmdXRzZUJHhk1N3pRktQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "1.0.2"
+        "@theqrl/web3-types": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-iban/node_modules/@theqrl/web3-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.2.tgz",
-      "integrity": "sha512-Coz6+BuNPbgR34hbVwxnLEETvD3PSYCRQKQ4kolIPDczk8mDEYIwa7TyCegRcklbrH9Hc765l4BMsDZI0QsmDQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.1.tgz",
+      "integrity": "sha512-uc+HBs7nMQjM7eD+39Gz/lDQ/1+o98y5xAaPApSvDYfcpDobMW+uV+LrMgBgak0y//OO0w0gtzzd7ohEk7OJmA==",
       "license": "LGPL-3.0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-iban/node_modules/@theqrl/web3-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.3.tgz",
-      "integrity": "sha512-ChCz/HUqUIP7XFivTIYpzZLqEow0FcIOGvZ/ayiyXLjneOdXhd2ylyqUy8eb/494FYDj7KujfPUPe3OUgt4gFQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.1.tgz",
+      "integrity": "sha512-X5H3RIWu3fUXkBz3B6T5pJlGnyUbh414I1HpQ9zUKj/ZZ8Z+EMgO/UMHWSblDRgeucI8DFFjIFGVSuD2ChB5mA==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-iban/node_modules/@theqrl/web3-validator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.3.tgz",
-      "integrity": "sha512-O5VaGMf9z/Zy4kH9nqnwVcGoVnXiIXW81YzG9RUY0S9IURtp9+bdCiPiOo8KVJHUXpgubIvEWXeLLAqO6+kvjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.1.tgz",
+      "integrity": "sha512-uwzArtbrk9/JByyPph/ZPeuYs8f5jp8TtXU8BN5yTMOO+WpGDYpqMiaUshLzQdslpUC5vlQqlTW0+3oac1DYxQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
         "util": "0.12.5",
         "zod": "3.22.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-iban/node_modules/zod": {
@@ -5182,75 +5291,75 @@
       }
     },
     "node_modules/@theqrl/web3-qrl-qrns": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-qrns/-/web3-qrl-qrns-1.0.3.tgz",
-      "integrity": "sha512-ROe9CzPKxgywfqYbv7BdMvtHCUyqJyx/+BEQBkTNFw5M8GAt/mxRro5DoGP7jgngevQ7pw47RQUEKbGKscUyfQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-qrns/-/web3-qrl-qrns-1.0.1.tgz",
+      "integrity": "sha512-QOMYaLHzQyyjKhiQ2vjDP/CwSBghG2GAzbMKLwLj1/bRLepzvXVYB/SMD8N3TZxZhzdni/DtiQg1OrbkdAfjcA==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@adraffy/ens-normalize": "1.11.1",
-        "@theqrl/web3-core": "1.0.3",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-net": "1.0.3",
-        "@theqrl/web3-qrl": "1.0.3",
-        "@theqrl/web3-qrl-contract": "1.0.3",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-utils": "1.0.3",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/web3-core": "1.0.1",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-net": "1.0.1",
+        "@theqrl/web3-qrl": "1.0.1",
+        "@theqrl/web3-qrl-contract": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-utils": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-qrns/node_modules/@theqrl/web3-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.2.tgz",
-      "integrity": "sha512-UwUPXAbA5+Z+OtKEknZJnCCssnohriycMuVaWnboBRQPLv4hHrFWnubOLJi6D3+xGlCk3TCbMlm2SiuZumbq8A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.1.tgz",
+      "integrity": "sha512-aAirwyS84SA8e4LYkpJ4BF1mut4jSrIt1HksveTmKHZgojJr4y/D/o4bP4w+MgBMymrmdXRzZUJHhk1N3pRktQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "1.0.2"
+        "@theqrl/web3-types": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-qrns/node_modules/@theqrl/web3-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.2.tgz",
-      "integrity": "sha512-Coz6+BuNPbgR34hbVwxnLEETvD3PSYCRQKQ4kolIPDczk8mDEYIwa7TyCegRcklbrH9Hc765l4BMsDZI0QsmDQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.1.tgz",
+      "integrity": "sha512-uc+HBs7nMQjM7eD+39Gz/lDQ/1+o98y5xAaPApSvDYfcpDobMW+uV+LrMgBgak0y//OO0w0gtzzd7ohEk7OJmA==",
       "license": "LGPL-3.0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-qrns/node_modules/@theqrl/web3-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.3.tgz",
-      "integrity": "sha512-ChCz/HUqUIP7XFivTIYpzZLqEow0FcIOGvZ/ayiyXLjneOdXhd2ylyqUy8eb/494FYDj7KujfPUPe3OUgt4gFQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.1.tgz",
+      "integrity": "sha512-X5H3RIWu3fUXkBz3B6T5pJlGnyUbh414I1HpQ9zUKj/ZZ8Z+EMgO/UMHWSblDRgeucI8DFFjIFGVSuD2ChB5mA==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-qrns/node_modules/@theqrl/web3-validator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.3.tgz",
-      "integrity": "sha512-O5VaGMf9z/Zy4kH9nqnwVcGoVnXiIXW81YzG9RUY0S9IURtp9+bdCiPiOo8KVJHUXpgubIvEWXeLLAqO6+kvjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.1.tgz",
+      "integrity": "sha512-uwzArtbrk9/JByyPph/ZPeuYs8f5jp8TtXU8BN5yTMOO+WpGDYpqMiaUshLzQdslpUC5vlQqlTW0+3oac1DYxQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
         "util": "0.12.5",
         "zod": "3.22.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl-qrns/node_modules/zod": {
@@ -5262,56 +5371,90 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
-    "node_modules/@theqrl/web3-qrl/node_modules/@theqrl/web3-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.2.tgz",
-      "integrity": "sha512-UwUPXAbA5+Z+OtKEknZJnCCssnohriycMuVaWnboBRQPLv4hHrFWnubOLJi6D3+xGlCk3TCbMlm2SiuZumbq8A==",
-      "license": "LGPL-3.0",
+    "node_modules/@theqrl/web3-qrl/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl/node_modules/@theqrl/mldsa87": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.1.tgz",
+      "integrity": "sha512-BPEvwrrphkMjyPnDorMzQdfrtICTZsiUxiBnwFkv2SfIcQwTTPQV3kTVfidZXXE7033ZCvhu1u5Aiw6TrjxPPQ==",
+      "license": "MIT",
       "dependencies": {
-        "@theqrl/web3-types": "1.0.2"
+        "@noble/hashes": "2.0.1"
       },
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl/node_modules/@theqrl/wallet.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-2.0.2.tgz",
+      "integrity": "sha512-gqmPE1D7qk2d6Qir0/iZeRGGr2eAVjps9Zql0P4pIw/uBjs81FBYio90c+RawkuKyc2WjlOLF6l3VI02z/rMSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1",
+        "@theqrl/mldsa87": "2.0.1"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl/node_modules/@theqrl/web3-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.1.tgz",
+      "integrity": "sha512-aAirwyS84SA8e4LYkpJ4BF1mut4jSrIt1HksveTmKHZgojJr4y/D/o4bP4w+MgBMymrmdXRzZUJHhk1N3pRktQ==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@theqrl/web3-types": "1.0.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl/node_modules/@theqrl/web3-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.2.tgz",
-      "integrity": "sha512-Coz6+BuNPbgR34hbVwxnLEETvD3PSYCRQKQ4kolIPDczk8mDEYIwa7TyCegRcklbrH9Hc765l4BMsDZI0QsmDQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.1.tgz",
+      "integrity": "sha512-uc+HBs7nMQjM7eD+39Gz/lDQ/1+o98y5xAaPApSvDYfcpDobMW+uV+LrMgBgak0y//OO0w0gtzzd7ohEk7OJmA==",
       "license": "LGPL-3.0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl/node_modules/@theqrl/web3-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.3.tgz",
-      "integrity": "sha512-ChCz/HUqUIP7XFivTIYpzZLqEow0FcIOGvZ/ayiyXLjneOdXhd2ylyqUy8eb/494FYDj7KujfPUPe3OUgt4gFQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.1.tgz",
+      "integrity": "sha512-X5H3RIWu3fUXkBz3B6T5pJlGnyUbh414I1HpQ9zUKj/ZZ8Z+EMgO/UMHWSblDRgeucI8DFFjIFGVSuD2ChB5mA==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl/node_modules/@theqrl/web3-validator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.3.tgz",
-      "integrity": "sha512-O5VaGMf9z/Zy4kH9nqnwVcGoVnXiIXW81YzG9RUY0S9IURtp9+bdCiPiOo8KVJHUXpgubIvEWXeLLAqO6+kvjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.1.tgz",
+      "integrity": "sha512-uwzArtbrk9/JByyPph/ZPeuYs8f5jp8TtXU8BN5yTMOO+WpGDYpqMiaUshLzQdslpUC5vlQqlTW0+3oac1DYxQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
         "util": "0.12.5",
         "zod": "3.22.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-qrl/node_modules/zod": {
@@ -5324,54 +5467,54 @@
       }
     },
     "node_modules/@theqrl/web3-rpc-methods": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-1.0.3.tgz",
-      "integrity": "sha512-1vmo0Vko7oh5V52kc9tUKOxxmvFFdavoEcdEBrQyLQAMzLRNPGHHRjO9d7kMGOgJPiYzGduGYae29SKn2JIRpg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-1.0.1.tgz",
+      "integrity": "sha512-elgQ7tg4vqRf0je9hQ5mM4N7VdX6jUUOHnYv2NGovDPMMuVJisNbl8itDqRk50/7cUNRrp9lNEPiSbdqHLIxSw==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "1.0.3",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/web3-core": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-rpc-methods/node_modules/@theqrl/web3-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.2.tgz",
-      "integrity": "sha512-UwUPXAbA5+Z+OtKEknZJnCCssnohriycMuVaWnboBRQPLv4hHrFWnubOLJi6D3+xGlCk3TCbMlm2SiuZumbq8A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.1.tgz",
+      "integrity": "sha512-aAirwyS84SA8e4LYkpJ4BF1mut4jSrIt1HksveTmKHZgojJr4y/D/o4bP4w+MgBMymrmdXRzZUJHhk1N3pRktQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "1.0.2"
+        "@theqrl/web3-types": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-rpc-methods/node_modules/@theqrl/web3-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.2.tgz",
-      "integrity": "sha512-Coz6+BuNPbgR34hbVwxnLEETvD3PSYCRQKQ4kolIPDczk8mDEYIwa7TyCegRcklbrH9Hc765l4BMsDZI0QsmDQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.1.tgz",
+      "integrity": "sha512-uc+HBs7nMQjM7eD+39Gz/lDQ/1+o98y5xAaPApSvDYfcpDobMW+uV+LrMgBgak0y//OO0w0gtzzd7ohEk7OJmA==",
       "license": "LGPL-3.0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-rpc-methods/node_modules/@theqrl/web3-validator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.3.tgz",
-      "integrity": "sha512-O5VaGMf9z/Zy4kH9nqnwVcGoVnXiIXW81YzG9RUY0S9IURtp9+bdCiPiOo8KVJHUXpgubIvEWXeLLAqO6+kvjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.1.tgz",
+      "integrity": "sha512-uwzArtbrk9/JByyPph/ZPeuYs8f5jp8TtXU8BN5yTMOO+WpGDYpqMiaUshLzQdslpUC5vlQqlTW0+3oac1DYxQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
         "util": "0.12.5",
         "zod": "3.22.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3-rpc-methods/node_modules/zod": {
@@ -5444,55 +5587,55 @@
       }
     },
     "node_modules/@theqrl/web3/node_modules/@theqrl/web3-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.2.tgz",
-      "integrity": "sha512-UwUPXAbA5+Z+OtKEknZJnCCssnohriycMuVaWnboBRQPLv4hHrFWnubOLJi6D3+xGlCk3TCbMlm2SiuZumbq8A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-1.0.1.tgz",
+      "integrity": "sha512-aAirwyS84SA8e4LYkpJ4BF1mut4jSrIt1HksveTmKHZgojJr4y/D/o4bP4w+MgBMymrmdXRzZUJHhk1N3pRktQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "1.0.2"
+        "@theqrl/web3-types": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3/node_modules/@theqrl/web3-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.2.tgz",
-      "integrity": "sha512-Coz6+BuNPbgR34hbVwxnLEETvD3PSYCRQKQ4kolIPDczk8mDEYIwa7TyCegRcklbrH9Hc765l4BMsDZI0QsmDQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-1.0.1.tgz",
+      "integrity": "sha512-uc+HBs7nMQjM7eD+39Gz/lDQ/1+o98y5xAaPApSvDYfcpDobMW+uV+LrMgBgak0y//OO0w0gtzzd7ohEk7OJmA==",
       "license": "LGPL-3.0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3/node_modules/@theqrl/web3-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.3.tgz",
-      "integrity": "sha512-ChCz/HUqUIP7XFivTIYpzZLqEow0FcIOGvZ/ayiyXLjneOdXhd2ylyqUy8eb/494FYDj7KujfPUPe3OUgt4gFQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-1.0.1.tgz",
+      "integrity": "sha512-X5H3RIWu3fUXkBz3B6T5pJlGnyUbh414I1HpQ9zUKj/ZZ8Z+EMgO/UMHWSblDRgeucI8DFFjIFGVSuD2ChB5mA==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
-        "@theqrl/web3-validator": "1.0.3"
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
+        "@theqrl/web3-validator": "1.0.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3/node_modules/@theqrl/web3-validator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.3.tgz",
-      "integrity": "sha512-O5VaGMf9z/Zy4kH9nqnwVcGoVnXiIXW81YzG9RUY0S9IURtp9+bdCiPiOo8KVJHUXpgubIvEWXeLLAqO6+kvjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-1.0.1.tgz",
+      "integrity": "sha512-uwzArtbrk9/JByyPph/ZPeuYs8f5jp8TtXU8BN5yTMOO+WpGDYpqMiaUshLzQdslpUC5vlQqlTW0+3oac1DYxQ==",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/qrl-cryptography": "0.3.0",
-        "@theqrl/web3-errors": "1.0.2",
-        "@theqrl/web3-types": "1.0.2",
+        "@theqrl/qrl-cryptography": "0.1.3",
+        "@theqrl/web3-errors": "1.0.1",
+        "@theqrl/web3-types": "1.0.1",
         "util": "0.12.5",
         "zod": "3.22.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=20"
       }
     },
     "node_modules/@theqrl/web3/node_modules/zod": {
@@ -7212,7 +7355,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7272,9 +7414,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7349,6 +7491,30 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-crc32": {
@@ -9876,7 +10042,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15097,6 +15262,15 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/sha3": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.4.tgz",
+      "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "6.0.3"
+      }
     },
     "node_modules/sharp": {
       "version": "0.35.3",

--- a/ExplorerFrontend/package.json
+++ b/ExplorerFrontend/package.json
@@ -11,7 +11,7 @@
     "@tanstack/react-query": "^5.90.16",
     "@tanstack/react-table": "^8.21.3",
     "@theqrl/wallet.js": "^6.2.3",
-    "@theqrl/web3": "^1.0.1",
+    "@theqrl/web3": "1.0.1",
     "@theqrl/web3-zond-abi": "^0.3.3",
     "@visx/axis": "4.0.1-alpha.0",
     "@visx/brush": "4.0.1-alpha.0",

--- a/ExplorerFrontend/scripts/README.md
+++ b/ExplorerFrontend/scripts/README.md
@@ -20,7 +20,7 @@ Stages the [QRL Connect](https://github.com/DigitalGuards/myqrlwallet-connect) t
    └──────────────┘
 ```
 
-The hosted `/dapp-example` is a live demo of that protocol: a dApp that generates a QR code, walks through the SYN/SYNACK/ACK handshake, and exercises `qrl_sendTransaction` / `personal_sign` / read-only RPC calls, all while streaming every event to an on-page log so developers can see the wire format. Deep architecture lives in the connect repo's [`CLAUDE.md`](https://github.com/DigitalGuards/myqrlwallet-connect/blob/dev/CLAUDE.md) and [`example/README.md`](https://github.com/DigitalGuards/myqrlwallet-connect/blob/dev/example/README.md).
+The hosted `/dapp-example` is a live demo of that protocol: a dApp that generates a QR code, walks through the SYN/SYNACK/ACK handshake, and exercises `qrl_sendTransaction` / `personal_sign` / read-only RPC calls, all while streaming every event to an on-page log so developers can see the wire format. Deep architecture lives in the connect repo's [`example/README.md`](https://github.com/DigitalGuards/myqrlwallet-connect/blob/main/example/README.md).
 
 ### What the script does
 
@@ -36,7 +36,7 @@ A Next.js rewrite in `next.config.js` maps `/dapp-example` (no trailing slash) t
 | Variable              | Default                                                       | Purpose                                    |
 | --------------------- | ------------------------------------------------------------- | ------------------------------------------ |
 | `QRL_CONNECT_REPO`    | `https://github.com/DigitalGuards/myqrlwallet-connect.git`    | Alternate remote.                          |
-| `QRL_CONNECT_REF`     | `dev`                                                         | Branch or tag to clone. Pin to a tag for stable deploys. |
+| `QRL_CONNECT_REF`     | `main`                                                        | Branch or tag to clone. Pin to a tag for stable deploys. |
 | `QRL_CONNECT_LOCAL`   | _(unset)_                                                     | Absolute path to a local connect checkout. Rsyncs instead of cloning, useful when developing against uncommitted SDK changes. |
 | `SKIP_DAPP_EXAMPLE`   | `0`                                                           | Set to `1` to bypass entirely (fast local builds). |
 

--- a/ExplorerFrontend/scripts/build-dapp-example.sh
+++ b/ExplorerFrontend/scripts/build-dapp-example.sh
@@ -13,7 +13,7 @@ if [[ "${SKIP_DAPP_EXAMPLE:-0}" == "1" ]]; then
 fi
 
 REPO_URL="${QRL_CONNECT_REPO:-https://github.com/DigitalGuards/myqrlwallet-connect.git}"
-REF="${QRL_CONNECT_REF:-dev}"
+REF="${QRL_CONNECT_REF:-main}"
 LOCAL_SRC="${QRL_CONNECT_LOCAL:-}"
 
 FRONTEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -194,3 +194,46 @@ if mongosh --quiet --eval 'db.runCommand({ping:1}).ok' qrldata-z 2>/dev/null | g
 else
     check_debounced "mongodb" 2 "fail" "**MongoDB** not responding" ""
 fi
+
+# --- nginx service ---
+# Every check above probes an app directly on loopback, so all of them stay
+# green when nginx itself is down and nothing is actually reachable from the
+# internet. That is exactly what happened on 2026-07-28: a DNS blip during an
+# unattended-upgrades restart failed the config test, nginx stayed dead for 9h,
+# and this monitor never said a word. Watch the reverse proxy explicitly.
+if systemctl is-active --quiet nginx; then
+    check_debounced "nginx-service" 2 "pass" "" "nginx is running again"
+else
+    check_debounced "nginx-service" 2 "fail" "**nginx** is not running (every site on this host is down)" ""
+fi
+
+# --- nginx TLS termination ---
+# Pinned to loopback so this tests our own vhost + cert, not Cloudflare's edge.
+# -k because the origin cert is a Cloudflare Origin CA cert, which the system
+# trust store deliberately does not chain to.
+HTTP_CODE=$(curl -sk --max-time 8 -o /dev/null -w "%{http_code}" \
+    --resolve zondscan.com:443:127.0.0.1 https://zondscan.com/)
+if [ "$HTTP_CODE" = "200" ]; then
+    check_debounced "nginx-tls" 2 "pass" "" "nginx TLS is serving again"
+else
+    check_debounced "nginx-tls" 2 "fail" "**nginx TLS** not serving zondscan.com on :443 (HTTP $HTTP_CODE)" ""
+fi
+
+# --- Origin cert expiry ---
+# Cloudflare Origin CA certs are long-lived with no renewal infra, so a silent
+# expiry is a guaranteed future outage that nobody is watching for. Warn early,
+# once per cert, at 30 days remaining.
+#
+# Set MONITOR_SSL_DIR to the directory holding per-site <name>/cert.pub. Left
+# unset the check is skipped, which keeps deployment-specific paths out of this
+# repo.
+for CERT_FILE in "${MONITOR_SSL_DIR:-/nonexistent}"/*/cert.pub; do
+    [ -f "$CERT_FILE" ] || continue
+    CERT_NAME=$(basename "$(dirname "$CERT_FILE")")
+    if ! openssl x509 -in "$CERT_FILE" -noout -checkend 2592000 >/dev/null 2>&1; then
+        CERT_END=$(openssl x509 -in "$CERT_FILE" -noout -enddate 2>/dev/null | cut -d= -f2)
+        alert "cert-expiry-$CERT_NAME" "**Origin cert** ($CERT_NAME) expires within 30 days ($CERT_END)"
+    else
+        resolve "cert-expiry-$CERT_NAME" "Origin cert ($CERT_NAME) renewed"
+    fi
+done


### PR DESCRIPTION
## Summary
- promote the green service-monitoring update from dev
- require explicit QRL account authorization after relay pairing
- enforce exactly one current-format Q plus 40-hex account
- preserve transiently restorable sessions while making cancellation and retirement failures visible
- pin QRL Web3 1.0.1 so wider roadmap addresses are not introduced

## Validation
- frontend TypeScript check
- 139 frontend tests
- frontend lint with zero errors
- production frontend build including the hosted dApp example
- SDK 4 compatibility overlay build
- production dependency audit with no moderate, high, or critical findings
- GitHub CI green on the feature-to-dev PR

The package manifest remains on the currently published QRL Connect release. SDK 4 publication and exact pinning are a separate coordinated release gate.