### PR TITLE
chore(frontend): pin QRL Connect 4.0.0

### DIFF
--- a/ExplorerFrontend/package-lock.json
+++ b/ExplorerFrontend/package-lock.json
@@ -11,7 +11,7 @@
         "@headlessui/react": "^2.2.0",
         "@heroicons/react": "^2.0.18",
         "@noble/hashes": "^1.8.0",
-        "@qrlwallet/connect": "^2.0.0",
+        "@qrlwallet/connect": "4.0.0",
         "@tailwindcss/postcss": "^4.2.2",
         "@tanstack/react-query": "^5.90.16",
         "@tanstack/react-table": "^8.21.3",
@@ -3635,31 +3635,31 @@
       }
     },
     "node_modules/@qrlwallet/connect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@qrlwallet/connect/-/connect-2.0.0.tgz",
-      "integrity": "sha512-UwxDt8FkNSCWWxpzOaUJFzJV6unvF3KHSQxHpDQQDgbNCJvFgIDSv1BLNW+mp1wreO0NTTct9Minrjd3jJoqIA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@qrlwallet/connect/-/connect-4.0.0.tgz",
+      "integrity": "sha512-U5JVykDspf0HH3QR1U5pY/amXkMCqFjQvcdrpP+xOdzDydJf7hjpEartkjh/4z7ULmWPO1Dmd25GFqKsPbE2sw==",
       "license": "MIT",
       "dependencies": {
+        "@noble/hashes": "^2.2.0",
         "@noble/post-quantum": "^0.5.4",
+        "@theqrl/mldsa87": "^2.1.1",
         "eventemitter3": "^5.0.1",
-        "socket.io-client": "^4.8.1",
-        "uuid": "^11.1.0"
+        "socket.io-client": "^4.8.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
-    "node_modules/@qrlwallet/connect/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
+    "node_modules/@qrlwallet/connect/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@react-aria/focus": {

--- a/ExplorerFrontend/package.json
+++ b/ExplorerFrontend/package.json
@@ -6,7 +6,7 @@
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.0.18",
     "@noble/hashes": "^1.8.0",
-    "@qrlwallet/connect": "^2.0.0",
+    "@qrlwallet/connect": "4.0.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@tanstack/react-query": "^5.90.16",
     "@tanstack/react-table": "^8.21.3",


### PR DESCRIPTION
## Summary

- pin @qrlwallet/connect to exact version 4.0.0
- refresh the npm lockfile against the published registry tarball
- remove the SDK 2 UUID subtree and lock the SDK 4 cryptographic dependencies

## Validation

- npm ci
- npm run lint: 0 errors, 16 existing warnings in untouched files
- npx tsc --noEmit
- npm test -- --runInBand: 139 tests passed
- npm run build: explorer and hosted dApp example passed
- npm audit --omit=dev --audit-level=high: 13 known low findings in the legacy QRL web3 elliptic chain
- npm audit --audit-level=high: 13 low and 3 moderate findings, zero high or critical
- git diff --check
- public-repo infrastructure leak scan: clean

## Runtime impact and risk

SDK 4 requires Node.js 20.19 or newer. CI and the current frontend toolchain use Node.js 22. This is a major SDK upgrade, with the wallet authorization behavior already exercised by the existing 139-test frontend suite and the full production build.

This PR performs no deployment.