### PR TITLE
chore: promote QRL Connect 4.0.0 pin

### DIFF
--- a/ExplorerFrontend/package-lock.json
+++ b/ExplorerFrontend/package-lock.json
@@ -11,7 +11,7 @@
         "@headlessui/react": "^2.2.0",
         "@heroicons/react": "^2.0.18",
         "@noble/hashes": "^1.8.0",
-        "@qrlwallet/connect": "^2.0.0",
+        "@qrlwallet/connect": "4.0.0",
         "@tailwindcss/postcss": "^4.2.2",
         "@tanstack/react-query": "^5.90.16",
         "@tanstack/react-table": "^8.21.3",
@@ -3635,31 +3635,31 @@
       }
     },
     "node_modules/@qrlwallet/connect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@qrlwallet/connect/-/connect-2.0.0.tgz",
-      "integrity": "sha512-UwxDt8FkNSCWWxpzOaUJFzJV6unvF3KHSQxHpDQQDgbNCJvFgIDSv1BLNW+mp1wreO0NTTct9Minrjd3jJoqIA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@qrlwallet/connect/-/connect-4.0.0.tgz",
+      "integrity": "sha512-U5JVykDspf0HH3QR1U5pY/amXkMCqFjQvcdrpP+xOdzDydJf7hjpEartkjh/4z7ULmWPO1Dmd25GFqKsPbE2sw==",
       "license": "MIT",
       "dependencies": {
+        "@noble/hashes": "^2.2.0",
         "@noble/post-quantum": "^0.5.4",
+        "@theqrl/mldsa87": "^2.1.1",
         "eventemitter3": "^5.0.1",
-        "socket.io-client": "^4.8.1",
-        "uuid": "^11.1.0"
+        "socket.io-client": "^4.8.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
-    "node_modules/@qrlwallet/connect/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
+    "node_modules/@qrlwallet/connect/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@react-aria/focus": {

--- a/ExplorerFrontend/package.json
+++ b/ExplorerFrontend/package.json
@@ -6,7 +6,7 @@
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.0.18",
     "@noble/hashes": "^1.8.0",
-    "@qrlwallet/connect": "^2.0.0",
+    "@qrlwallet/connect": "4.0.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@tanstack/react-query": "^5.90.16",
     "@tanstack/react-table": "^8.21.3",


### PR DESCRIPTION
## Summary

Promote the exact @qrlwallet/connect 4.0.0 consumer pin from dev to main.

## Included change

- PR #176
- exact registry tarball and integrity in the frontend lockfile
- SDK 4 Node.js floor of 20.19, satisfied by the Node.js 22 frontend toolchain

## Validation

- feature PR CI: frontend, backend, and synchronizer jobs passed
- local clean install, TypeScript, 139 tests, lint, and full production build passed
- outgoing diff and public-repo infrastructure leak scan passed
- production audit: 13 known low findings in the legacy QRL web3 elliptic chain
- full audit: 13 low and 3 moderate findings, zero high or critical

## Risk and rollout

The release diff is limited to the frontend package manifest and lockfile. This PR performs no deployment.