### PR TITLE
feat(learn): link QRL Ecosystem Index and Quantum Readiness Index

### DIFF
--- a/ExplorerFrontend/app/learn/articles.ts
+++ b/ExplorerFrontend/app/learn/articles.ts
@@ -55,7 +55,7 @@ export const learnArticles: LearnArticleMeta[] = [
       'A plain English introduction to QRL 2.0: proof of stake consensus, EVM smart contracts, ML-DSA-87 signatures, and how the new chain relates to legacy QRL.',
     category: 'basics',
     order: 1,
-    updated: '2026-08-05',
+    updated: '2026-08-24',
     readingMinutes: 6,
   },
   {
@@ -65,7 +65,7 @@ export const learnArticles: LearnArticleMeta[] = [
       "How quantum computers threaten the signatures securing today's blockchains, and how QRL answers with hash based XMSS and lattice based ML-DSA-87.",
     category: 'basics',
     order: 2,
-    updated: '2026-08-05',
+    updated: '2026-08-24',
     readingMinutes: 7,
   },
   {

--- a/ExplorerFrontend/app/learn/page.tsx
+++ b/ExplorerFrontend/app/learn/page.tsx
@@ -32,6 +32,30 @@ export const metadata: Metadata = {
   },
 };
 
+interface ExternalResource {
+  title: string;
+  description: string;
+  href: string;
+  domain: string;
+}
+
+const EXTERNAL_RESOURCES: readonly ExternalResource[] = [
+  {
+    title: 'QRL Ecosystem Index',
+    description:
+      'A community-maintained directory of projects, tools, services, and resources across QRL 1.x and QRL 2.0, with a submission process for new entries.',
+    href: 'https://www.qrlecosystem.com/',
+    domain: 'qrlecosystem.com',
+  },
+  {
+    title: 'Blockchain Quantum Readiness Index',
+    description:
+      'An independent index that scores over a hundred blockchains on quantum readiness, with per-project reports and a published methodology. QRL sits in its top quantum-ready tier.',
+    href: 'https://qrindex.org/',
+    domain: 'qrindex.org',
+  },
+];
+
 export default function LearnIndexPage(): JSX.Element {
   return (
     <div className="page-content py-4 sm:py-6 lg:py-8">
@@ -86,6 +110,35 @@ export default function LearnIndexPage(): JSX.Element {
           </section>
         );
       })}
+
+      <section aria-labelledby="learn-external-resources" className="mb-10">
+        <h2 id="learn-external-resources" className="section-title mb-1">
+          Further reading
+        </h2>
+        <p className="text-sm text-text-secondary mb-4">
+          Independent sites worth bookmarking once you have the basics down. Both are
+          maintained outside ZondScan.
+        </p>
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {EXTERNAL_RESOURCES.map((resource) => (
+            <a
+              key={resource.href}
+              href={resource.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="card card-hover p-5 flex flex-col group"
+            >
+              <h3 className="font-display text-base font-semibold text-text-primary group-hover:text-accent transition-colors mb-2">
+                {resource.title}
+              </h3>
+              <p className="text-sm text-text-secondary leading-relaxed flex-1">
+                {resource.description}
+              </p>
+              <p className="text-xs text-text-muted mt-4">{resource.domain}</p>
+            </a>
+          ))}
+        </div>
+      </section>
     </div>
   );
 }

--- a/ExplorerFrontend/app/learn/page.tsx
+++ b/ExplorerFrontend/app/learn/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 import { sharedMetadata } from '../lib/seo/metaData';
 import {
   LEARN_CATEGORIES,
@@ -36,7 +37,6 @@ interface ExternalResource {
   title: string;
   description: string;
   href: string;
-  domain: string;
 }
 
 const EXTERNAL_RESOURCES: readonly ExternalResource[] = [
@@ -45,16 +45,64 @@ const EXTERNAL_RESOURCES: readonly ExternalResource[] = [
     description:
       'A community-maintained directory of projects, tools, services, and resources across QRL 1.x and QRL 2.0, with a submission process for new entries.',
     href: 'https://www.qrlecosystem.com/',
-    domain: 'qrlecosystem.com',
   },
   {
     title: 'Blockchain Quantum Readiness Index',
     description:
-      'An independent index that scores over a hundred blockchains on quantum readiness, with per-project reports and a published methodology. QRL sits in its top quantum-ready tier.',
+      'An independent index that scores over a hundred blockchains on quantum readiness, with per-project reports and a published methodology.',
     href: 'https://qrindex.org/',
-    domain: 'qrindex.org',
   },
 ];
+
+/** Bare hostname shown as the card footer for an external resource. */
+function resourceDomain(href: string): string {
+  return new URL(href).hostname.replace(/^www\./, '');
+}
+
+interface LearnCardProps {
+  href: string;
+  title: string;
+  description: string;
+  /** Footer line: reading time for articles, domain for external links. */
+  meta: string;
+  external?: boolean;
+}
+
+/** One card in the /learn grids; internal articles and external links share it. */
+function LearnCard({ href, title, description, meta, external }: LearnCardProps): JSX.Element {
+  const cardClass = 'card card-hover p-5 flex flex-col group';
+  const body = (
+    <>
+      <h3 className="font-display text-base font-semibold text-text-primary group-hover:text-accent transition-colors mb-2">
+        {title}
+        {external ? (
+          <>
+            <span className="sr-only"> (opens in a new tab)</span>
+            <ArrowTopRightOnSquareIcon
+              className="w-3.5 h-3.5 text-text-muted inline-block ml-1.5 align-baseline flex-shrink-0"
+              aria-hidden="true"
+            />
+          </>
+        ) : null}
+      </h3>
+      <p className="text-sm text-text-secondary leading-relaxed flex-1">{description}</p>
+      <p className="text-xs text-text-muted mt-4">{meta}</p>
+    </>
+  );
+
+  if (external) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" className={cardClass}>
+        {body}
+      </a>
+    );
+  }
+  return (
+    <Link href={href} className={cardClass}>
+      {body}
+    </Link>
+  );
+}
 
 export default function LearnIndexPage(): JSX.Element {
   return (
@@ -90,21 +138,13 @@ export default function LearnIndexPage(): JSX.Element {
             <p className="text-sm text-text-secondary mb-4">{category.blurb}</p>
             <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
               {articles.map((article) => (
-                <Link
+                <LearnCard
                   key={article.slug}
                   href={`/learn/${article.slug}`}
-                  className="card card-hover p-5 flex flex-col group"
-                >
-                  <h3 className="font-display text-base font-semibold text-text-primary group-hover:text-accent transition-colors mb-2">
-                    {article.title}
-                  </h3>
-                  <p className="text-sm text-text-secondary leading-relaxed flex-1">
-                    {article.description}
-                  </p>
-                  <p className="text-xs text-text-muted mt-4">
-                    {article.readingMinutes} min read
-                  </p>
-                </Link>
+                  title={article.title}
+                  description={article.description}
+                  meta={`${article.readingMinutes} min read`}
+                />
               ))}
             </div>
           </section>
@@ -116,26 +156,19 @@ export default function LearnIndexPage(): JSX.Element {
           Further reading
         </h2>
         <p className="text-sm text-text-secondary mb-4">
-          Independent sites worth bookmarking once you have the basics down. Both are
-          maintained outside ZondScan.
+          Independent sites worth bookmarking once you have the basics down. These
+          are maintained outside ZondScan and open in a new tab.
         </p>
         <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {EXTERNAL_RESOURCES.map((resource) => (
-            <a
+            <LearnCard
               key={resource.href}
               href={resource.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="card card-hover p-5 flex flex-col group"
-            >
-              <h3 className="font-display text-base font-semibold text-text-primary group-hover:text-accent transition-colors mb-2">
-                {resource.title}
-              </h3>
-              <p className="text-sm text-text-secondary leading-relaxed flex-1">
-                {resource.description}
-              </p>
-              <p className="text-xs text-text-muted mt-4">{resource.domain}</p>
-            </a>
+              title={resource.title}
+              description={resource.description}
+              meta={resourceDomain(resource.href)}
+              external
+            />
           ))}
         </div>
       </section>

--- a/ExplorerFrontend/app/learn/what-is-qrl-2/page.tsx
+++ b/ExplorerFrontend/app/learn/what-is-qrl-2/page.tsx
@@ -151,6 +151,13 @@ export default function Page(): JSX.Element {
             </p>
           </Step>
         </StepList>
+        <p>
+          For a wider map of what exists around the chain, the community-maintained{' '}
+          <a href="https://www.qrlecosystem.com/" target="_blank" rel="noopener noreferrer">
+            QRL Ecosystem Index
+          </a>{' '}
+          catalogs projects, tools, services, and resources across QRL 1.x and QRL 2.0.
+        </p>
       </LearnSection>
 
       <LearnSection id="where-zondscan-fits" title="Where ZondScan fits">

--- a/ExplorerFrontend/app/learn/why-post-quantum/page.tsx
+++ b/ExplorerFrontend/app/learn/why-post-quantum/page.tsx
@@ -172,7 +172,7 @@ export default function Page(): JSX.Element {
             Blockchain Quantum Readiness Index
           </a>{' '}
           scores over a hundred chains on quantum readiness using a published methodology, and
-          places QRL among the handful of projects in its top quantum-ready tier.
+          shows where QRL and the major chains land.
         </p>
         <Callout type="warning" title="Testnet status">
           <p>

--- a/ExplorerFrontend/app/learn/why-post-quantum/page.tsx
+++ b/ExplorerFrontend/app/learn/why-post-quantum/page.tsx
@@ -166,6 +166,14 @@ export default function Page(): JSX.Element {
           Consensus is proof of stake on a beacon chain, covered in{' '}
           <a href="/learn/validators-and-epochs">validators and epochs</a>.
         </p>
+        <p>
+          For an outside view of where the wider industry stands, the independent{' '}
+          <a href="https://qrindex.org/" target="_blank" rel="noopener noreferrer">
+            Blockchain Quantum Readiness Index
+          </a>{' '}
+          scores over a hundred chains on quantum readiness using a published methodology, and
+          places QRL among the handful of projects in its top quantum-ready tier.
+        </p>
         <Callout type="warning" title="Testnet status">
           <p>
             QRL 2.0 currently runs as a public testnet, with mainnet planned after the migration


### PR DESCRIPTION
## Summary
- Adds a **Further reading** section to the `/learn` index page with external cards for two independent sites:
  - [qrlecosystem.com](https://www.qrlecosystem.com/): community-maintained directory of projects, tools, services, and resources across QRL 1.x and 2.0.
  - [qrindex.org](https://qrindex.org/): independent Blockchain Quantum Readiness Index scoring 100+ chains with a published methodology; QRL sits in its top quantum-ready tier.
- Inline references where they fit naturally:
  - `what-is-qrl-2`: Ecosystem Index linked after the product-stack tour.
  - `why-post-quantum`: Quantum Readiness Index linked in the "How QRL answers" section as an outside view of industry readiness.
- Bumps `updated` dates for the two edited articles in `articles.ts`.

## Validation
- `npm run lint`: 0 errors (16 pre-existing warnings, none in learn files)
- `npm test`: 187 passed
- `npm run build`: green, all `/learn` routes prerendered

https://claude.ai/code/session_013DTfZj6whJh28h4UvjfH8d